### PR TITLE
fix: 150 Sales Order Connection tab getting error

### DIFF
--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -285,6 +285,7 @@ def get_open_count(doctype: str, name: str, items=None):
 					out["external_links_found"].append(external_links_data_for_d)
 				except Exception:
 					out["external_links_found"].append({"doctype": d, "open_count": 0, "count": 0})
+					frappe.db.rollback()
 		else:
 			external_links_data_for_d = get_external_links(d, name, links)
 			out["external_links_found"].append(external_links_data_for_d)


### PR DESCRIPTION
After adding frappe.db.rollback() the error is not showing.

Reference doc :
1. https://stackoverflow.com/questions/10399727/psqlexception-current-transaction-is-aborted-commands-ignored-until-end-of-tra
2. https://dba.stackexchange.com/questions/303935/error-current-transaction-is-aborted-commands-ignored-until-end-of-transaction

![Screenshot 2024-10-08 at 1 29 34 PM](https://github.com/user-attachments/assets/57b1de56-5617-4204-b207-e0c17103cb25)

Covers :
https://github.com/8848digital/erpnext/issues/150
https://github.com/8848digital/erpnext/issues/192
https://github.com/8848digital/erpnext/issues/92
