### PR TITLE
fix: removed filter to select mandatory table only for data improt select mandatory fields

### DIFF
--- a/frappe/public/js/frappe/data_import/data_exporter.js
+++ b/frappe/public/js/frappe/data_import/data_exporter.js
@@ -175,7 +175,6 @@ frappe.data_import.DataExporter = class DataExporter {
 	select_mandatory() {
 		let mandatory_table_fields = frappe.meta
 			.get_table_fields(this.doctype)
-			.filter((df) => df.reqd)
 			.map((df) => df.fieldname);
 		mandatory_table_fields.push(this.doctype);
 


### PR DESCRIPTION
This PR has been raised for https://github.com/8848digital/erpnext/issues/345
Issue -  In Data Import download template functionality, if child table is mandatory then only it's mandatory fields were selected on click of 'Select Mandatory' button.
fix - Removed the filter to select mandatory child tables only.