### PR TITLE
fix: Restrict Link field with filter

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -654,11 +654,14 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 
 		// to avoid unnecessary request
 		if (value) {
+			let args = {}
+			this.set_custom_query(args)
 			return frappe
 				.xcall("frappe.client.validate_link", {
 					doctype: options,
 					docname: value,
 					fields: columns_to_fetch,
+					args: args
 				})
 				.then((response) => {
 					if (!this.docname || !columns_to_fetch.length) {


### PR DESCRIPTION
- Restrict the Link field with filters
- Anywhere were link field is use
- If any value is paste which bypass link filter in that case it will unset the Link field value.

* Issue in 3.12 instance sample

https://github.com/user-attachments/assets/2a90f769-98d7-484f-9a45-c12ebd8c34b2




* Fixes Sample

https://github.com/user-attachments/assets/d1fd3b71-a465-4b39-a022-e0820f5d824c




