### PR TITLE
fix: Fixed trasaction aborted issue in bulk operation

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -226,6 +226,9 @@ class Database:
 		try:
 			self._cursor.execute(query, values)
 		except Exception as e:
+			if self.db_type == "postgres":
+				frappe.db.rollback()
+
 			if self.is_syntax_error(e):
 				frappe.log(f"Syntax error in query:\n{query} {values or ''}")
 


### PR DESCRIPTION
Solved transaction aborted issue 

**issue**=> https://github.com/8848digital/erpnext/issues/481

**Desc**
The error `psycopg2.errors.InFailedSqlTransaction` with the message `current transaction is aborted, commands ignored until end of transaction block` usually indicates that an earlier SQL operation in the current transaction failed, which causes subsequent queries to be ignored because the transaction is already in a failed state.

In PostgreSQL, when a transaction encounters an error, it is marked as "failed." Any further SQL operations within this transaction will be ignored until the transaction is rolled back. In the Frappe framework, if an exception occurs during a database operation and you do not explicitly handle it, the current transaction may remain in a failed state.