### PR TITLE
fix: doctype field to fetch

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -363,11 +363,11 @@ class DocType(Document):
 
 					if frappe.db.db_type == "postgres":
 						update_query = """
-							UPDATE `tab{doctype}`
+							UPDATE `tab{doctype}` AS target
 							SET `{fieldname}` = source.`{source_fieldname}`
-							FROM `tab{link_doctype}` as source
-							WHERE `{link_fieldname}` = source.name
-							AND ifnull(`{fieldname}`, '')=''
+							FROM `tab{link_doctype}` AS source
+							WHERE `target`.`{link_fieldname}` = `source`.`name`
+							AND ifnull(`target`.`{fieldname}`, '')=''
 						"""
 					else:
 						update_query = """

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -367,7 +367,7 @@ class DocType(Document):
 							SET `{fieldname}` = source.`{source_fieldname}`
 							FROM `tab{link_doctype}` AS source
 							WHERE `target`.`{link_fieldname}` = `source`.`name`
-							AND ifnull(`target`.`{fieldname}`, '')=''
+							AND (`target`.`{fieldname}` IS NULL OR `target`.`{fieldname}` = 0)
 						"""
 					else:
 						update_query = """


### PR DESCRIPTION
while fetch from is given in doctype field 
issue:- 
-> psycopg2.errors.AmbiguousColumn: column reference "item_code" is ambiguous
LINE 4:        WHERE "item_code" = source.name
-> psycopg2.errors.InvalidTextRepresentation: invalid input syntax for type smallint: ""
LINE 5:        AND coalesce("target"."has_serial_no", '')=''


Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 114, in application
    response = frappe.api.handle(request)
  File "apps/frappe/frappe/api/__init__.py", line 49, in handle
    data = endpoint(**arguments)
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 49, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1775, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
  File "apps/frappe/frappe/desk/form/save.py", line 39, in savedocs
    doc.save()
  File "apps/frappe/frappe/model/document.py", line 337, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 390, in _save
    self.run_post_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1128, in run_post_save_methods
    self.run_method("on_update")
  File "apps/frappe/frappe/model/document.py", line 962, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1322, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1304, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 959, in fn
    return method_object(*args, **kwargs)
  File "apps/frappe/frappe/core/doctype/doctype/doctype.py", line 524, in on_update
    self.update_fields_to_fetch()
  File "apps/frappe/frappe/core/doctype/doctype/doctype.py", line 403, in update_fields_to_fetch
    frappe.db.sql(query)
  File "apps/frappe/frappe/database/postgres/database.py", line 310, in sql
    return super().sql(modify_query(query), modify_values(values), *args, **kwargs)
  File "apps/frappe/frappe/database/database.py", line 227, in sql
    self._cursor.execute(query, values)
psycopg2.errors.AmbiguousColumn: column reference "item_code" is ambiguous
LINE 4:        WHERE "item_code" = source.name