### PR TITLE
fix: updated frappe v15 from jan 7 to jan 14

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -51,7 +51,7 @@ from .utils.jinja import (
 )
 from .utils.lazy_loader import lazy_import
 
-__version__ = "15.51.2"
+__version__ = "15.52.0"
 __title__ = "Frappe Framework"
 
 # This if block is never executed when running the code. It is only used for

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -87,6 +87,12 @@ def new_site(
 
 	frappe.init(site=site, new_site=True)
 
+	if site in frappe.get_all_apps():
+		click.secho(
+			f"Your bench has an app called {site}, please choose another name for the site.", fg="red"
+		)
+		sys.exit(1)
+		
 	if no_mariadb_socket:
 		click.secho(
 			"--no-mariadb-socket is DEPRECATED; "

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -1029,6 +1029,14 @@ def request(context, args=None, path=None):
 @click.option("--no-git", is_flag=True, default=False, help="Do not initialize git repository for the app")
 def make_app(destination, app_name, no_git=False):
 	"Creates a boilerplate app"
+	from frappe.utils import get_sites
+	
+	if app_name in get_sites():
+		click.secho(
+			f"Your bench has a site called {app_name}, please choose another name for the app.", fg="red"
+		)
+		sys.exit(1)
+
 	from frappe.utils.boilerplate import make_boilerplate
 
 	make_boilerplate(destination, app_name, no_git=no_git)

--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
@@ -14,6 +14,7 @@
   "stopped",
   "method",
   "server_script",
+  "scheduler_event",
   "frequency",
   "cron_format",
   "create_log",
@@ -92,6 +93,13 @@
   {
    "fieldname": "column_break_9",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "scheduler_event",
+   "fieldtype": "Link",
+   "label": "Scheduler Event",
+   "options": "Scheduler Event",
+   "read_only": 1
   }
  ],
  "in_create": 1,
@@ -101,7 +109,7 @@
    "link_fieldname": "scheduled_job_type"
   }
  ],
- "modified": "2023-10-14 11:26:05.005930",
+ "modified": "2025-01-13 10:39:39.975031",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Scheduled Job Type",

--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -43,6 +43,7 @@ class ScheduledJobType(Document):
 		last_execution: DF.Datetime | None
 		method: DF.Data
 		next_execution: DF.Datetime | None
+		scheduler_event: DF.Link | None
 		server_script: DF.Link | None
 		stopped: DF.Check
 
@@ -260,9 +261,14 @@ def insert_single_event(frequency: str, event: str, cron_format: str | None = No
 
 
 def clear_events(all_events: list):
-	for event in frappe.get_all("Scheduled Job Type", fields=["name", "method", "server_script"]):
+	for event in frappe.get_all(
+		"Scheduled Job Type", fields=["name", "method", "server_script", "scheduler_event"]
+	):
 		is_server_script = event.server_script
 		is_defined_in_hooks = event.method in all_events
+
+		if event.scheduler_event:
+			continue
 
 		if not (is_defined_in_hooks or is_server_script):
 			frappe.delete_doc("Scheduled Job Type", event.name)

--- a/frappe/core/doctype/scheduler_event/scheduler_event.js
+++ b/frappe/core/doctype/scheduler_event/scheduler_event.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Scheduler Event", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/frappe/core/doctype/scheduler_event/scheduler_event.json
+++ b/frappe/core/doctype/scheduler_event/scheduler_event.json
@@ -1,0 +1,51 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-01-13 10:20:09.095079",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "scheduled_against",
+  "method"
+ ],
+ "fields": [
+  {
+   "fieldname": "scheduled_against",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Scheduled Against",
+   "options": "DocType",
+   "reqd": 1
+  },
+  {
+   "fieldname": "method",
+   "fieldtype": "Data",
+   "label": "Method"
+  }
+ ],
+ "in_create": 1,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-01-14 10:49:21.304114",
+ "modified_by": "Administrator",
+ "module": "Core",
+ "name": "Scheduler Event",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe/core/doctype/scheduler_event/scheduler_event.py
+++ b/frappe/core/doctype/scheduler_event/scheduler_event.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2025, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class SchedulerEvent(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+	
+	from typing import TYPE_CHECKING
+	
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		method: DF.Data | None
+		scheduled_against: DF.Link | None
+	# end: auto-generated types
+
+	pass

--- a/frappe/core/doctype/scheduler_event/test_scheduler_event.py
+++ b/frappe/core/doctype/scheduler_event/test_scheduler_event.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, Frappe Technologies and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestSchedulerEvent(FrappeTestCase):
+	pass

--- a/frappe/email/inbox.py
+++ b/frappe/email/inbox.py
@@ -55,8 +55,12 @@ def create_email_flag_queue(names, action):
 
 	for name in json.loads(names or []):
 		uid, seen_status, email_account = frappe.db.get_value(
-			"Communication", name, ["ifnull(uid, -1)", "ifnull(seen, 0)", "email_account"]
+			"Communication", name, ["uid", "seen", "email_account"]
 		)
+		if not uid:
+			uid = -1
+		if not seen_status:
+			seen_status = 0
 
 		# can not mark email SEEN or UNSEEN without uid
 		if not uid or uid == -1:

--- a/frappe/locale/fa.po
+++ b/frappe/locale/fa.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: developers@frappe.io\n"
 "POT-Creation-Date: 2024-12-29 17:34+0000\n"
-"PO-Revision-Date: 2024-12-30 21:53\n"
+"PO-Revision-Date: 2025-01-06 22:25\n"
 "Last-Translator: developers@frappe.io\n"
 "Language-Team: Persian\n"
 "MIME-Version: 1.0\n"
@@ -527,7 +527,7 @@ msgstr "<span class=\"h2\">سلام،</span>"
 #. Header text in the Tools Workspace
 #: frappe/automation/workspace/tools/tools.json
 msgid "<span class=\"h4\"><b>Documents</b></span>"
-msgstr ""
+msgstr "<span class=\"h4\"><b>اسناد</b></span>"
 
 #. Header text in the Website Workspace
 #: frappe/website/workspace/website/website.json
@@ -558,7 +558,7 @@ msgstr "<span style=\"font-size: 18px; letter-spacing: 0.18px;\"><b>اجزای �
 #. Header text in the Build Workspace
 #: frappe/core/workspace/build/build.json
 msgid "<span style=\"font-size: 18px; letter-spacing: 0.18px;\"><b>Get started</b><br></span>"
-msgstr ""
+msgstr "<span style=\"font-size: 18px; letter-spacing: 0.18px;\"><b>شروع کنید</b><br></span>"
 
 #: frappe/custom/doctype/custom_field/custom_field.js:39
 msgid "<strong>Warning:</strong> This field is system generated and may be overwritten by a future update. Modify it using {0} instead."
@@ -783,7 +783,7 @@ msgstr "حدود {0} ثانیه باقی مانده است"
 #. Label of a Section Break field in DocType 'Web Form'
 #: frappe/website/doctype/web_form/web_form.json
 msgid "Access Control"
-msgstr ""
+msgstr "کنترل دسترسی"
 
 #. Label of a Data field in DocType 'S3 Backup Settings'
 #: frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.json
@@ -1089,7 +1089,7 @@ msgstr "اضافه کردن گروه"
 
 #: frappe/core/doctype/recorder/recorder.js:30
 msgid "Add Indexes"
-msgstr ""
+msgstr "افزودن شاخص ها"
 
 #: frappe/public/js/frappe/form/grid.js:63
 msgid "Add Multiple"
@@ -1157,7 +1157,7 @@ msgstr "اضافه کردن الگو"
 #. Label of a Check field in DocType 'Report'
 #: frappe/core/doctype/report/report.json
 msgid "Add Total Row"
-msgstr "کل ردیف را اضافه کنید"
+msgstr "افزودن ردیف کل"
 
 #. Label of a Check field in DocType 'Email Queue'
 #: frappe/email/doctype/email_queue/email_queue.json
@@ -1960,7 +1960,7 @@ msgstr "اصلاح نامگذاری لغو"
 
 #: frappe/model/document.py:408
 msgid "Amendment Not Allowed"
-msgstr ""
+msgstr "اصلاحیه مجاز نیست"
 
 #: frappe/core/doctype/document_naming_settings/document_naming_settings.py:207
 msgid "Amendment naming rules updated."
@@ -2505,7 +2505,7 @@ msgstr "حداقل یک فیلد در جدول فیلدهای فرم وب اجب
 
 #: frappe/core/doctype/data_export/data_export.js:44
 msgid "Atleast one field of Parent Document Type is mandatory"
-msgstr ""
+msgstr "حداقل یک فیلد از نوع سند والد اجباری است"
 
 #. Option for the 'Type' (Select) field in DocType 'DocField'
 #. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
@@ -3128,7 +3128,7 @@ msgstr "پشتیبان گیری"
 #. Label of a Float field in DocType 'System Health Report'
 #: frappe/desk/doctype/system_health_report/system_health_report.json
 msgid "Backups (MB)"
-msgstr ""
+msgstr "پشتیبان‌ها (MB)"
 
 #: frappe/core/doctype/scheduled_job_type/scheduled_job_type.py:66
 msgid "Bad Cron Expression"
@@ -3169,7 +3169,7 @@ msgstr "بنر در بالای نوار منوی بالا قرار دارد."
 #. Option for the 'Type' (Select) field in DocType 'Dashboard Chart'
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
 msgid "Bar"
-msgstr "بار"
+msgstr "میله"
 
 #. Option for the 'Type' (Select) field in DocType 'DocField'
 #. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
@@ -3406,7 +3406,7 @@ msgstr "وبلاگ نویس"
 #. Subtitle of the Module Onboarding 'Website'
 #: frappe/website/module_onboarding/website/website.json
 msgid "Blogs, Website View Tracking, and more."
-msgstr ""
+msgstr "وبلاگ ها، ردیابی مشاهده وب سایت و موارد دیگر."
 
 #. Option for the 'Color' (Select) field in DocType 'DocType State'
 #. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
@@ -5478,7 +5478,7 @@ msgstr "ستون {0} به فیلد {1} نگاشت نشد"
 
 #: frappe/desk/page/setup_wizard/setup_wizard.js:222
 msgid "Could not start up: "
-msgstr ""
+msgstr "راه اندازی نشد: "
 
 #: frappe/public/js/frappe/web_form/web_form.js:359
 msgid "Couldn't save, please check the data you have entered"
@@ -6066,7 +6066,7 @@ msgstr "سفارشی‌سازی‌ها حذف شدند"
 
 #: frappe/custom/doctype/customize_form/customize_form.js:465
 msgid "Customizations Reset"
-msgstr "تنظیم مجدد"
+msgstr "بازنشانی سفارشی‌سازی‌ها"
 
 #: frappe/modules/utils.py:96
 msgid "Customizations for <b>{0}</b> exported to:<br>{1}"
@@ -6608,12 +6608,12 @@ msgstr "ارسال پیش فرض و صندوق ورودی"
 #. Label of a Data field in DocType 'DocType'
 #: frappe/core/doctype/doctype/doctype.json
 msgid "Default Sort Field"
-msgstr "فیلد مرتب سازی پیش فرض"
+msgstr "فیلد مرتب‌سازی پیش فرض"
 
 #. Label of a Select field in DocType 'DocType'
 #: frappe/core/doctype/doctype/doctype.json
 msgid "Default Sort Order"
-msgstr "ترتیب مرتب سازی پیش فرض"
+msgstr "ترتیب مرتب‌سازی پیش فرض"
 
 #. Label of a Data field in DocType 'Print Format Field Template'
 #: frappe/printing/doctype/print_format_field_template/print_format_field_template.json
@@ -7364,12 +7364,12 @@ msgstr "رویداد DocType"
 #. Name of a DocType
 #: frappe/custom/doctype/doctype_layout/doctype_layout.json
 msgid "DocType Layout"
-msgstr "طرح بندی DocType"
+msgstr "چیدمان DocType"
 
 #. Name of a DocType
 #: frappe/custom/doctype/doctype_layout_field/doctype_layout_field.json
 msgid "DocType Layout Field"
-msgstr "فیلد طرح بندی DocType"
+msgstr "فیلد چیدمان DocType"
 
 #. Name of a DocType
 #. Option for the 'Applied On' (Select) field in DocType 'Property Setter'
@@ -8166,7 +8166,7 @@ msgstr "ویرایش فیلترها"
 
 #: frappe/public/js/print_format_builder/PrintFormat.vue:29
 msgid "Edit Footer"
-msgstr ""
+msgstr "ویرایش پاورقی"
 
 #: frappe/printing/doctype/print_format/print_format.js:28
 msgid "Edit Format"
@@ -8692,7 +8692,7 @@ msgstr "کارهای برنامه ریزی شده را فعال کنید"
 
 #: frappe/core/doctype/rq_job/rq_job_list.js:23
 msgid "Enable Scheduler"
-msgstr "زمانبندی را فعال کنید"
+msgstr "زمان‌بندی را فعال کنید"
 
 #. Label of a Check field in DocType 'Webhook'
 #: frappe/integrations/doctype/webhook/webhook.json
@@ -8782,7 +8782,7 @@ msgstr "فعال"
 
 #: frappe/core/doctype/rq_job/rq_job_list.js:29
 msgid "Enabled Scheduler"
-msgstr "زمانبندی فعال شد"
+msgstr "زمان‌بندی فعال شد"
 
 #: frappe/email/doctype/email_account/email_account.py:935
 msgid "Enabled email inbox for user {0}"
@@ -9512,7 +9512,7 @@ msgstr ""
 
 #: frappe/core/doctype/rq_job/rq_job_list.js:33
 msgid "Failed to enable scheduler: {0}"
-msgstr "زمانبندی فعال نشد: {0}"
+msgstr "زمان‌بندی فعال نشد: {0}"
 
 #: frappe/integrations/doctype/webhook/webhook.py:139
 msgid "Failed to evaluate conditions: {}"
@@ -9544,7 +9544,7 @@ msgstr "روش {0} با {1} دریافت نشد"
 
 #: frappe/integrations/frappe_providers/frappecloud_billing.py:68
 msgid "Failed to get site info"
-msgstr ""
+msgstr "اطلاعات سایت دریافت نشد"
 
 #: frappe/model/virtual_doctype.py:63
 msgid "Failed to import virtual doctype {}, is controller file present?"
@@ -10485,7 +10485,7 @@ msgstr "کار توقف اجباری"
 #. Label of a Int field in DocType 'System Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
 msgid "Force User to Reset Password"
-msgstr "کاربر را مجبور به تنظیم مجدد رمز عبور کنید"
+msgstr "کاربر را مجبور به بازنشانی رمز عبور کنید"
 
 #. Label of a Check field in DocType 'System Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
@@ -12923,7 +12923,7 @@ msgstr "نام کاربری یا رمز عبور پشتیبانی نامعتبر
 
 #: frappe/public/js/frappe/ui/field_group.js:131
 msgid "Invalid Values"
-msgstr ""
+msgstr "مقادیر نامعتبر"
 
 #: frappe/integrations/doctype/webhook/webhook.py:119
 msgid "Invalid Webhook Secret"
@@ -13847,11 +13847,11 @@ msgstr "آخرین همگام سازی {0}"
 
 #: frappe/custom/doctype/customize_form/customize_form.js:194
 msgid "Layout Reset"
-msgstr "تنظیم مجدد طرح"
+msgstr "بازنشانی چیدمان"
 
 #: frappe/custom/doctype/customize_form/customize_form.js:186
 msgid "Layout will be reset to standard layout, are you sure you want to do this?"
-msgstr "طرح‌بندی به طرح‌بندی استاندارد بازنشانی می‌شود، آیا مطمئن هستید که می‌خواهید این کار را انجام دهید؟"
+msgstr "چیدمان به چیدمان استاندارد بازنشانی می‌شود، آیا مطمئن هستید که می‌خواهید این کار را انجام دهید؟"
 
 #: frappe/desk/page/leaderboard/leaderboard.js:15
 #: frappe/desk/page/user_profile/user_profile_sidebar.html:55
@@ -14884,7 +14884,7 @@ msgstr "حاشیه بالا"
 #. Label of a Section Break field in DocType 'System Health Report'
 #: frappe/desk/doctype/system_health_report/system_health_report.json
 msgid "MariaDB Variables"
-msgstr ""
+msgstr "متغیرهای MariaDB"
 
 #: frappe/public/js/frappe/ui/notifications/notifications.js:45
 msgid "Mark all as read"
@@ -14976,7 +14976,7 @@ msgstr "حداکثر ارزش"
 #. Label of a Int field in DocType 'Web Form'
 #: frappe/website/doctype/web_form/web_form.json
 msgid "Max attachment size"
-msgstr ""
+msgstr "حداکثر اندازه پیوست"
 
 #. Label of a Int field in DocType 'System Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
@@ -18042,7 +18042,7 @@ msgstr "رمز عبور ایمیل ارسال شد"
 
 #: frappe/core/doctype/user/user.py:393
 msgid "Password Reset"
-msgstr "تنظیم مجدد رمز عبور"
+msgstr "بازنشانی رمز عبور"
 
 #. Label of a Int field in DocType 'System Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
@@ -18100,7 +18100,7 @@ msgstr "رمزهای ورود مطابقت ندارند!"
 
 #: frappe/email/doctype/newsletter/newsletter.py:159
 msgid "Past dates are not allowed for Scheduling."
-msgstr "تاریخ های گذشته برای زمان بندی مجاز نیستند."
+msgstr "تاریخ های گذشته برای زمان‌بندی مجاز نیستند."
 
 #: frappe/public/js/frappe/views/file/file_view.js:151
 msgid "Paste"
@@ -18161,7 +18161,7 @@ msgstr "تعداد بار"
 #. Label of a Int field in DocType 'Prepared Report'
 #: frappe/core/doctype/prepared_report/prepared_report.json
 msgid "Peak Memory Usage"
-msgstr ""
+msgstr "حداکثر استفاده از حافظه"
 
 #. Option for the 'Status' (Select) field in DocType 'Data Import'
 #. Option for the 'Contribution Status' (Select) field in DocType 'Translation'
@@ -18399,7 +18399,7 @@ msgstr "ستون ها را انتخاب کنید"
 #. Option for the 'Type' (Select) field in DocType 'Dashboard Chart'
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
 msgid "Pie"
-msgstr "پای"
+msgstr "دایره"
 
 #. Label of a Data field in DocType 'Contact Us Settings'
 #: frappe/website/doctype/contact_us_settings/contact_us_settings.json
@@ -20511,7 +20511,7 @@ msgstr "حذف شکست صفحه"
 #: frappe/public/js/form_builder/components/Section.vue:266
 #: frappe/public/js/print_format_builder/PrintFormatSection.vue:135
 msgid "Remove section"
-msgstr ""
+msgstr "حذف بخش"
 
 #: frappe/public/js/form_builder/components/Tabs.vue:140
 msgid "Remove tab"
@@ -20948,7 +20948,7 @@ msgstr "رمز عبور LDAP را بازنشانی کنید"
 
 #: frappe/custom/doctype/customize_form/customize_form.js:128
 msgid "Reset Layout"
-msgstr "تنظیم مجدد طرح"
+msgstr "بازنشانی چیدمان"
 
 #: frappe/core/doctype/user/user.js:228
 msgid "Reset OTP Secret"
@@ -20985,7 +20985,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/utils/datatable.js:8
 msgid "Reset sorting"
-msgstr "مرتب سازی را بازنشانی کنید"
+msgstr "بازنشانی مرتب‌سازی"
 
 #: frappe/www/me.html:36
 msgid "Reset the password for your account"
@@ -20993,11 +20993,11 @@ msgstr "رمز عبور حساب خود را بازنشانی کنید"
 
 #: frappe/public/js/frappe/form/grid_row.js:410
 msgid "Reset to default"
-msgstr "تنظیم مجدد به حالت پیش فرض"
+msgstr "بازنشانی به حالت پیش فرض"
 
 #: frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js:19
 msgid "Reset to defaults"
-msgstr "به حالت پیش فرض بازنشانی کنید"
+msgstr "بازنشانی به حالت پیش فرض"
 
 #: frappe/templates/emails/password_reset.html:3
 msgid "Reset your password"
@@ -21793,11 +21793,11 @@ msgstr "برنامه"
 
 #: frappe/email/doctype/newsletter/newsletter.js:106
 msgid "Schedule Newsletter"
-msgstr "زمانبندی خبرنامه"
+msgstr "زمان‌بندی خبرنامه"
 
 #: frappe/public/js/frappe/views/communication.js:85
 msgid "Schedule Send At"
-msgstr "زمانبندی ارسال در"
+msgstr "زمان‌بندی ارسال در"
 
 #: frappe/email/doctype/newsletter/newsletter.js:70
 msgid "Schedule sending"
@@ -21870,7 +21870,7 @@ msgstr ""
 #. Option for the 'Script Type' (Select) field in DocType 'Server Script'
 #: frappe/core/doctype/server_script/server_script.json
 msgid "Scheduler Event"
-msgstr "رویداد زمانبندی"
+msgstr "رویداد زمان‌بندی"
 
 #: frappe/core/doctype/data_import/data_import.py:97
 msgid "Scheduler Inactive"
@@ -21891,11 +21891,11 @@ msgstr "زمانبند غیرفعال است. نمی توان داده ها را
 
 #: frappe/core/doctype/rq_job/rq_job_list.js:19
 msgid "Scheduler: Active"
-msgstr "زمانبندی: فعال"
+msgstr "زمان‌بندی: فعال"
 
 #: frappe/core/doctype/rq_job/rq_job_list.js:21
 msgid "Scheduler: Inactive"
-msgstr "زمانبندی: غیر فعال"
+msgstr "زمان‌بندی: غیر فعال"
 
 #. Label of a Data field in DocType 'OAuth Scope'
 #: frappe/integrations/doctype/oauth_scope/oauth_scope.json
@@ -22002,7 +22002,7 @@ msgstr "اولویت های جستجو"
 
 #: frappe/public/js/frappe/file_uploader/FileBrowser.vue:132
 msgid "Search Results"
-msgstr ""
+msgstr "نتایج جستجو"
 
 #: frappe/www/search.py:14
 msgid "Search Results for"
@@ -22986,7 +22986,7 @@ msgstr "فقط یکبار تنظیم کنید"
 #. Description of the 'Max attachment size' (Int) field in DocType 'Web Form'
 #: frappe/website/doctype/web_form/web_form.json
 msgid "Set size in MB"
-msgstr ""
+msgstr "تنظیم اندازه به مگابایت"
 
 #. Description of the 'Filters Configuration' (Code) field in DocType 'Number
 #. Card'
@@ -23124,7 +23124,7 @@ msgstr "راه‌اندازی سری برای تراکنش ها"
 
 #: frappe/desk/page/setup_wizard/setup_wizard.js:224
 msgid "Setup failed"
-msgstr ""
+msgstr "راه اندازی انجام نشد"
 
 #. Label of a Check field in DocType 'Custom DocPerm'
 #. Label of a Check field in DocType 'DocPerm'
@@ -23732,7 +23732,7 @@ msgstr "ورود به سیستم اجتماعی"
 #. Label of a Select field in DocType 'System Health Report'
 #: frappe/desk/doctype/system_health_report/system_health_report.json
 msgid "SocketIO Ping Check"
-msgstr ""
+msgstr "بررسی پینگ SocketIO"
 
 #. Label of a Select field in DocType 'System Health Report'
 #: frappe/desk/doctype/system_health_report/system_health_report.json
@@ -23779,16 +23779,16 @@ msgstr "متاسف! شما مجاز به مشاهده این صفحه نیستی
 
 #: frappe/public/js/frappe/utils/datatable.js:6
 msgid "Sort Ascending"
-msgstr "مرتب سازی صعودی"
+msgstr "مرتب‌سازی صعودی"
 
 #: frappe/public/js/frappe/utils/datatable.js:7
 msgid "Sort Descending"
-msgstr "مرتب سازی نزولی"
+msgstr "مرتب‌سازی نزولی"
 
 #. Label of a Select field in DocType 'Customize Form'
 #: frappe/custom/doctype/customize_form/customize_form.json
 msgid "Sort Field"
-msgstr "فیلد مرتب سازی"
+msgstr "فیلد مرتب‌سازی"
 
 #. Label of a Check field in DocType 'DocField'
 #. Label of a Check field in DocType 'Custom Field'
@@ -23797,16 +23797,16 @@ msgstr "فیلد مرتب سازی"
 #: frappe/custom/doctype/custom_field/custom_field.json
 #: frappe/custom/doctype/customize_form_field/customize_form_field.json
 msgid "Sort Options"
-msgstr "گزینه های مرتب سازی"
+msgstr "گزینه های مرتب‌سازی"
 
 #. Label of a Select field in DocType 'Customize Form'
 #: frappe/custom/doctype/customize_form/customize_form.json
 msgid "Sort Order"
-msgstr "ترتیب مرتب سازی"
+msgstr "ترتیب مرتب‌سازی"
 
 #: frappe/core/doctype/doctype/doctype.py:1512
 msgid "Sort field {0} must be a valid fieldname"
-msgstr "فیلد مرتب سازی {0} باید یک نام فیلد معتبر باشد"
+msgstr "فیلد مرتب‌سازی {0} باید یک نام فیلد معتبر باشد"
 
 #. Label of a Data field in DocType 'Web Page View'
 #. Label of a Small Text field in DocType 'Website Route Redirect'
@@ -25074,7 +25074,7 @@ msgstr "موقتا غیر فعال می باشد"
 #: frappe/core/doctype/translation/test_translation.py:47
 #: frappe/core/doctype/translation/test_translation.py:54
 msgid "Test Data"
-msgstr ""
+msgstr "داده های تست"
 
 #. Label of a Data field in DocType 'System Health Report'
 #: frappe/desk/doctype/system_health_report/system_health_report.json
@@ -25084,7 +25084,7 @@ msgstr ""
 #: frappe/core/doctype/translation/test_translation.py:49
 #: frappe/core/doctype/translation/test_translation.py:57
 msgid "Test Spanish"
-msgstr ""
+msgstr "تست اسپانیایی"
 
 #: frappe/email/doctype/newsletter/newsletter.py:94
 msgid "Test email sent to {0}"
@@ -27301,7 +27301,7 @@ msgstr "کاربر نمی تواند جستجو کند"
 
 #: frappe/public/js/frappe/desk.js:531
 msgid "User Changed"
-msgstr ""
+msgstr "کاربر تغییر کرد"
 
 #. Label of a Table field in DocType 'User'
 #: frappe/core/doctype/user/user.json
@@ -28955,7 +28955,7 @@ msgstr "شما فقط می توانید 3 نوع Doctype سفارشی را در 
 
 #: frappe/handler.py:230
 msgid "You can only upload JPG, PNG, PDF, TXT, CSV or Microsoft documents."
-msgstr ""
+msgstr "شما فقط می توانید اسناد JPG، PNG، PDF، TXT، CSV یا Microsoft را آپلود کنید."
 
 #: frappe/core/doctype/data_export/exporter.py:199
 msgid "You can only upload upto 5000 records in one go. (may be less in some cases)"
@@ -29567,27 +29567,27 @@ msgstr "شورون راست"
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "chevron-up"
-msgstr "شورون آپ"
+msgstr "chevron-up"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "circle-arrow-down"
-msgstr "دایره-پیکان-پایین"
+msgstr "circle-arrow-down"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "circle-arrow-left"
-msgstr "دایره-پیکان-چپ"
+msgstr "circle-arrow-left"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "circle-arrow-right"
-msgstr "دایره-پیکان-راست"
+msgstr "circle-arrow-right"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "circle-arrow-up"
-msgstr "دایره-پیکان-بالا"
+msgstr "circle-arrow-up"
 
 #: frappe/templates/includes/list/filters.html:19
 msgid "clear"
@@ -29596,12 +29596,12 @@ msgstr "روشن"
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "cog"
-msgstr "چرخ دنده"
+msgstr "cog"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "comment"
-msgstr "اظهار نظر"
+msgstr "comment"
 
 #: frappe/public/js/frappe/form/templates/timeline_message_box.html:33
 msgid "commented"
@@ -29677,12 +29677,12 @@ msgstr "نوع سند...، به عنوان مثال مشتری"
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "download"
-msgstr "دانلود"
+msgstr "download"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "download-alt"
-msgstr "دانلود - alt"
+msgstr "download-alt"
 
 #. Description of the 'Email Account Name' (Data) field in DocType 'Email
 #. Account'
@@ -29721,12 +29721,12 @@ msgstr "به عنوان مثال:"
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "edit"
-msgstr "ویرایش"
+msgstr "edit"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "eject"
-msgstr "بیرون انداختن"
+msgstr "eject"
 
 #. Option for the 'Permission Type' (Select) field in DocType 'Permission
 #. Inspector'
@@ -29749,12 +29749,12 @@ msgstr "خالی"
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "envelope"
-msgstr "پاکت نامه"
+msgstr "envelope"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "exclamation-sign"
-msgstr "علامت تعجب"
+msgstr "exclamation-sign"
 
 #. Option for the 'Permission Type' (Select) field in DocType 'Permission
 #. Inspector'
@@ -29765,12 +29765,12 @@ msgstr "برون‌بُرد"
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "eye-close"
-msgstr "چشم بسته"
+msgstr "eye-close"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "eye-open"
-msgstr "چشم باز"
+msgstr "fast-backward"
 
 #. Option for the 'Social Link Type' (Select) field in DocType 'Social Link
 #. Settings'
@@ -29797,27 +29797,27 @@ msgstr "fairlogin"
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "fast-backward"
-msgstr "سریع به عقب"
+msgstr "fast-backward"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "fast-forward"
-msgstr "سریع به جلو"
+msgstr "fast-forward"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "file"
-msgstr "فایل"
+msgstr "file"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "film"
-msgstr "فیلم"
+msgstr "film"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "filter"
-msgstr "فیلتر"
+msgstr "filter"
 
 #. Option for the 'Status' (Select) field in DocType 'RQ Job'
 #: frappe/core/doctype/rq_job/rq_job.json
@@ -29827,12 +29827,12 @@ msgstr "تمام شده"
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "fire"
-msgstr "آتش"
+msgstr "fire"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "flag"
-msgstr "پرچم"
+msgstr "flag"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json

--- a/frappe/locale/fr.po
+++ b/frappe/locale/fr.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: developers@frappe.io\n"
 "POT-Creation-Date: 2024-12-29 17:34+0000\n"
-"PO-Revision-Date: 2024-12-29 21:29\n"
+"PO-Revision-Date: 2025-01-13 00:35\n"
 "Last-Translator: developers@frappe.io\n"
 "Language-Team: French\n"
 "MIME-Version: 1.0\n"
@@ -23370,7 +23370,7 @@ msgstr "Afficher le tableau de bord"
 #. Label of a Button field in DocType 'Access Log'
 #: frappe/core/doctype/access_log/access_log.json
 msgid "Show Document"
-msgstr "Afficher le document"
+msgstr ""
 
 #: frappe/www/error.html:41 frappe/www/error.html:59
 msgid "Show Error"

--- a/frappe/locale/sv.po
+++ b/frappe/locale/sv.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: developers@frappe.io\n"
 "POT-Creation-Date: 2024-12-29 17:34+0000\n"
-"PO-Revision-Date: 2024-12-29 21:29\n"
+"PO-Revision-Date: 2025-01-06 22:25\n"
 "Last-Translator: developers@frappe.io\n"
 "Language-Team: Swedish\n"
 "MIME-Version: 1.0\n"
@@ -1519,7 +1519,7 @@ msgstr "Adress Titel"
 
 #: frappe/contacts/doctype/address/address.py:72
 msgid "Address Title is mandatory."
-msgstr "Adress Titel erfodras."
+msgstr "Adress Benämning erfodras."
 
 #. Label of a Select field in DocType 'Address'
 #: frappe/contacts/doctype/address/address.json
@@ -3831,7 +3831,7 @@ msgstr "Efter \"Nummer Serie\"."
 #: frappe/website/doctype/web_page/web_page.js:111
 #: frappe/website/doctype/web_page/web_page.js:118
 msgid "By default the title is used as meta title, adding a value here will override it."
-msgstr "Som standard används titel som meta titel. Att lägga till värde här kommer att åsidosätta standard värde."
+msgstr "Som standard används benämning som metabenämning. Att lägga till värde här kommer att åsidosätta standard värde."
 
 #. Description of the 'Send Email for Successful Backup' (Check) field in
 #. DocType 'S3 Backup Settings'
@@ -5684,7 +5684,7 @@ msgstr "Antal"
 
 #: frappe/public/js/frappe/widgets/widget_dialog.js:504
 msgid "Count Customizations"
-msgstr "Antal & Färgkod Status"
+msgstr "Antal Anpassningar"
 
 #. Label of a Section Break field in DocType 'Workspace Shortcut'
 #. Label of a Code field in DocType 'Workspace Shortcut'
@@ -8169,7 +8169,7 @@ msgstr "Rullgardin Meny"
 #. Label of a Date field in DocType 'ToDo'
 #: frappe/desk/doctype/todo/todo.json
 msgid "Due Date"
-msgstr "Förfallodatum"
+msgstr "Förfallo Datum"
 
 #. Label of a Select field in DocType 'Assignment Rule'
 #: frappe/automation/doctype/assignment_rule/assignment_rule.json
@@ -9871,7 +9871,7 @@ msgstr "Fält \"\"sökväg\"\" erfodras för Webb Vyer"
 
 #: frappe/core/doctype/doctype/doctype.py:1488
 msgid "Field \"title\" is mandatory if \"Website Search Field\" is set."
-msgstr "Fält \"titel\" erfodras om \"Webbplats Sökfält\" är angiven."
+msgstr "Fält \"benämning\" erfodras om \"Webbplats Sökfält\" är angiven."
 
 #: frappe/desk/doctype/bulk_update/bulk_update.js:17
 msgid "Field \"value\" is mandatory. Please specify value to be updated"
@@ -15402,7 +15402,7 @@ msgstr "Meta Taggar"
 #: frappe/website/doctype/blog_post/blog_post.json
 #: frappe/website/doctype/web_page/web_page.js:117
 msgid "Meta Title"
-msgstr "Meta Titel"
+msgstr "Meta Benämning"
 
 #. Label of a Small Text field in DocType 'Web Form'
 #: frappe/website/doctype/web_form/web_form.json
@@ -15417,11 +15417,11 @@ msgstr "Meta Bild"
 #. Label of a Data field in DocType 'Web Form'
 #: frappe/website/doctype/web_form/web_form.json
 msgid "Meta title"
-msgstr "Meta Titel"
+msgstr "Meta Benämning"
 
 #: frappe/website/doctype/web_page/web_page.js:110
 msgid "Meta title for SEO"
-msgstr "Meta Titel för SEO"
+msgstr "Meta Benämning för SEO"
 
 #. Label of a Data field in DocType 'Access Log'
 #. Label of a Select field in DocType 'Recorder'
@@ -20743,7 +20743,7 @@ msgstr "Rendera etikett till vänster och värde till höger i detta sektion"
 #: frappe/core/doctype/communication/communication.js:43
 #: frappe/desk/doctype/todo/todo.js:36
 msgid "Reopen"
-msgstr "Öppna Igen"
+msgstr "Återöppna"
 
 #: frappe/public/js/frappe/form/toolbar.js:480
 msgid "Repeat"
@@ -22284,7 +22284,7 @@ msgstr "Sektion"
 #: frappe/public/js/form_builder/components/Section.vue:28
 #: frappe/public/js/print_format_builder/PrintFormatSection.vue:8
 msgid "Section Title"
-msgstr "Sektion Namn"
+msgstr "Sektion Benämning"
 
 #: frappe/public/js/form_builder/components/Section.vue:217
 #: frappe/public/js/form_builder/components/Section.vue:240
@@ -23728,7 +23728,7 @@ msgstr "Registrering är inaktiverad"
 #: frappe/templates/signup.html:16 frappe/www/login.html:120
 #: frappe/www/login.html:136 frappe/www/update-password.html:35
 msgid "Sign up"
-msgstr "Registrera dig"
+msgstr "Registrera"
 
 #. Label of a Select field in DocType 'Social Login Key'
 #: frappe/integrations/doctype/social_login_key/social_login_key.json
@@ -24033,7 +24033,7 @@ msgstr "Sortering Fält {0} måste vara giltig fält namn"
 #: frappe/website/doctype/website_route_redirect/website_route_redirect.json
 #: frappe/website/report/website_analytics/website_analytics.js:38
 msgid "Source"
-msgstr "Källa"
+msgstr "Från"
 
 #. Label of a Data field in DocType 'Dashboard Chart Source'
 #: frappe/desk/doctype/dashboard_chart_source/dashboard_chart_source.json
@@ -24687,7 +24687,7 @@ msgstr "Klart Meddelande"
 #. Label of a Data field in DocType 'Web Form'
 #: frappe/website/doctype/web_form/web_form.json
 msgid "Success title"
-msgstr "Klart Titel"
+msgstr "Klart Benämning"
 
 #: frappe/www/update-password.html:79
 msgid "Success! You are good to go 👍"
@@ -25948,7 +25948,7 @@ msgstr "Denna webbplats körs i utvecklarläge. Alla ändringar som görs här k
 
 #: frappe/website/doctype/web_page/web_page.js:71
 msgid "This title will be used as the title of the webpage as well as in meta tags"
-msgstr "Denna titel kommer att användas som titel på hemsida såväl som i meta taggar"
+msgstr "Denna benämning kommer att användas som benämning på hemsida såväl som i meta taggar"
 
 #: frappe/public/js/frappe/form/controls/base_input.js:120
 msgid "This value is fetched from {0}'s {1} field"
@@ -26219,7 +26219,7 @@ msgstr "Tid Stämpel"
 #: frappe/website/doctype/website_sidebar/website_sidebar.json
 #: frappe/website/doctype/website_sidebar_item/website_sidebar_item.json
 msgid "Title"
-msgstr "Titel"
+msgstr "Benämning"
 
 #. Label of a Data field in DocType 'DocType'
 #. Label of a Data field in DocType 'Customize Form'
@@ -26235,11 +26235,11 @@ msgstr "Titel Prefix"
 
 #: frappe/core/doctype/doctype/doctype.py:1437
 msgid "Title field must be a valid fieldname"
-msgstr "Titel Fält måste vara giltig fält namn"
+msgstr "Benämning Fält måste vara giltig fält namn"
 
 #: frappe/website/doctype/web_page/web_page.js:70
 msgid "Title of the page"
-msgstr "Sida Titel"
+msgstr "Sida Benämning"
 
 #. Label of a Code field in DocType 'Communication'
 #. Label of a Section Break field in DocType 'Newsletter'
@@ -26879,7 +26879,7 @@ msgstr "Skriv något i sökruta för att söka"
 #: frappe/templates/discussions/reply_section.html:53
 #: frappe/templates/discussions/topic_modal.html:11
 msgid "Type title"
-msgstr "Skriv rubrik"
+msgstr "Benämning"
 
 #: frappe/templates/discussions/discussions.js:341
 msgid "Type your reply here..."
@@ -31762,7 +31762,7 @@ msgstr "{0}/{1} komplett | Lämna denna flik öppen tills den är klar."
 
 #: frappe/model/base_document.py:1025
 msgid "{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}"
-msgstr "{0}: {1} ({3}) kommer att förminskas då maximum tillåtna antal tecken är {2}"
+msgstr "{0}: '{1}' ({3}) kommer att avkortas, eftersom max tillåtna tecken är {2}"
 
 #: frappe/core/doctype/doctype/doctype.py:1762
 msgid "{0}: Cannot set Amend without Cancel"

--- a/frappe/modules/export_file.py
+++ b/frappe/modules/export_file.py
@@ -3,6 +3,7 @@
 
 import os
 import shutil
+from pathlib import Path
 
 import frappe
 import frappe.model
@@ -37,18 +38,21 @@ def write_document_file(doc, record_module=None, create_init=True, folder_name=N
 
 	doc_export = strip_default_fields(doc, doc_export)
 	module = record_module or get_module_name(doc)
+	is_custom_module = frappe.db.get_value("Module Def", module, "custom")
 
 	# create folder
 	if folder_name:
-		folder = create_folder(module, folder_name, doc.name, create_init)
+		folder = create_folder(module, folder_name, doc.name, create_init, is_custom_module)
 	else:
-		folder = create_folder(module, doc.doctype, doc.name, create_init)
+		folder = create_folder(module, doc.doctype, doc.name, create_init, is_custom_module)
 
 	fname = scrub(doc.name)
 	write_code_files(folder, fname, doc, doc_export)
 
 	# write the data file
 	path = os.path.join(folder, f"{fname}.json")
+	if is_custom_module and not Path(path).resolve().is_relative_to(Path(frappe.get_site_path()).resolve()):
+		frappe.throw("Invalid export path: " + Path(path).as_posix())
 	with open(path, "w+") as txtfile:
 		txtfile.write(frappe.as_json(doc_export))
 	print(f"Wrote document file for {doc.doctype} {doc.name} at {path}")
@@ -73,7 +77,10 @@ def write_code_files(folder, fname, doc, doc_export):
 	if hasattr(doc, "get_code_fields"):
 		for key, extn in doc.get_code_fields().items():
 			if doc.get(key):
-				with open(os.path.join(folder, fname + "." + extn), "w+") as txtfile:
+				path = os.path.join(folder, fname + "." + extn)
+				if not Path(path).resolve().is_relative_to(Path(frappe.get_site_path()).resolve()):
+					frappe.throw("Invalid export path: " + Path(path).as_posix())
+				with open(path, "w+") as txtfile:
 					txtfile.write(doc.get(key))
 
 				# remove from exporting
@@ -108,8 +115,8 @@ def delete_folder(module, dt, dn):
 		shutil.rmtree(folder)
 
 
-def create_folder(module, dt, dn, create_init):
-	if frappe.db.get_value("Module Def", module, "custom"):
+def create_folder(module, dt, dn, create_init, is_custom_module):
+	if is_custom_module:
 		module_path = get_custom_module_path(module)
 	else:
 		module_path = get_module_path(module)
@@ -134,6 +141,9 @@ def get_custom_module_path(module):
 		frappe.throw(f"Package must be set for custom Module <b>{module}</b>")
 
 	path = os.path.join(get_package_path(package), scrub(module))
+	if not Path(path).resolve().is_relative_to(Path(frappe.get_site_path()).resolve()):
+		frappe.throw("Invalid module path: " + Path(path).as_posix())
+		
 	if not os.path.exists(path):
 		os.makedirs(path)
 

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -882,18 +882,15 @@ frappe.ui.form.Form = class FrappeForm {
 				args: {
 					doctype: me.doc.doctype,
 					name: me.doc.name,
+					ignore_doctypes_on_cancel_all: me.ignore_doctypes_on_cancel_all,
 				},
 				freeze: true,
 			})
 			.then((r) => {
 				if (!r.exc) {
-					let doctypes_to_cancel = (r.message.docs || [])
-						.map((value) => {
-							return value.doctype;
-						})
-						.filter((value) => {
-							return !me.ignore_doctypes_on_cancel_all.includes(value);
-						});
+					let doctypes_to_cancel = (r.message.docs || []).map((value) => {
+						return value.doctype;
+					})
 
 					if (doctypes_to_cancel.length) {
 						return me._cancel_all(r, btn, callback, on_error);

--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -60,11 +60,7 @@ $.extend(frappe.model, {
 		if (frappe.route_options && !doc.parent) {
 			$.each(frappe.route_options, function (fieldname, value) {
 				var df = frappe.meta.has_field(doctype, fieldname);
-				if (
-					df &&
-					["Link", "Data", "Select", "Dynamic Link"].includes(df.fieldtype) &&
-					!df.no_copy
-				) {
+				if (df && !df.no_copy) {
 					doc[fieldname] = value;
 				}
 			});

--- a/frappe/public/scss/desk/image_view.scss
+++ b/frappe/public/scss/desk/image_view.scss
@@ -160,6 +160,13 @@
 
 			.ellipsis {
 				vertical-align: bottom;
+
+				// Display two lines instead of one
+				white-space: normal;
+				display: -webkit-box;
+				line-clamp: 2;
+				-webkit-line-clamp: 2;
+				-webkit-box-orient: vertical;
 			}
 
 			display: flex;

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -1,13 +1,15 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-# imports - standard imports
 import gzip
 import importlib
 import json
 import os
 import shlex
+import signal
 import subprocess
+import sys
+import time
 import types
 import unittest
 from contextlib import contextmanager
@@ -17,13 +19,12 @@ from pathlib import Path
 from unittest.case import skipIf
 from unittest.mock import patch
 
-# imports - third party imports
 import click
+import requests
 from click import Command
 from click.testing import CliRunner, Result
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
 
-# imports - module imports
 import frappe
 import frappe.commands.scheduler
 import frappe.commands.site
@@ -918,3 +919,41 @@ class TestSchedulerCLI(BaseTestCommands):
 		self.execute("bench --site {site} scheduler resume")
 		self.assertEqual(self.returncode, 0)
 		self.assertRegex(self.stdout, r"Scheduler is resumed for site .*")
+
+
+class TestGunicornWorker(FrappeTestCase):
+	port = 8005
+
+	def spawn_gunicorn(self, args):
+		self.handle = subprocess.Popen(
+			[
+				sys.executable,
+				"-m",
+				"gunicorn",
+				"-b",
+				f"127.0.0.1:{self.port}",
+				"-w1",
+				"frappe.app:application",
+				"--preload",
+				*args,
+			],
+		)
+		time.sleep(1)  # let worker startup finish
+		self.addCleanup(self.kill_gunicorn)
+		
+	def kill_gunicorn(self):
+		self.handle.send_signal(signal.SIGINT)
+		try:
+			self.handle.communicate(timeout=1)
+		except subprocess.TimeoutExpired:
+			self.handle.kill()
+
+	def test_gunicorn_ping_sync(self):
+		self.spawn_gunicorn([])
+		path = f"http://{self.TEST_SITE}:{self.port}/api/method/ping"
+		self.assertEqual(requests.get(path).status_code, 200)
+		
+	def test_gunicorn_ping_gthread(self):
+		self.spawn_gunicorn(["--threads=2"])
+		path = f"http://{self.TEST_SITE}:{self.port}/api/method/ping"
+		self.assertEqual(requests.get(path).status_code, 200)

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -278,7 +278,13 @@ def add_years(date, years):
 	return add_to_date(date, years=years)
 
 
-def date_diff(string_ed_date, string_st_date):
+def date_diff(string_ed_date: DateTimeLikeObject, string_st_date: DateTimeLikeObject) -> int:
+	"""Returns the difference between given two dates in days."""
+	return days_diff(string_ed_date, string_st_date)
+
+
+def days_diff(string_ed_date: DateTimeLikeObject, string_st_date: DateTimeLikeObject) -> int:
+	"""Returns the difference between given two dates in days."""
 	return (getdate(string_ed_date) - getdate(string_st_date)).days
 
 

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -98,7 +98,7 @@ class RedisWrapper(redis.Redis):
 			if not expires:
 				if val is None and generator:
 					val = generator()
-					self.set_value(original_key, val, user=user)
+					self.set_value(original_key, val, user=user, shared=shared)
 
 				else:
 					frappe.local.cache[key] = val

--- a/frappe/website/doctype/web_form/web_form.json
+++ b/frappe/website/doctype/web_form/web_form.json
@@ -387,7 +387,7 @@
      },
      {
       "fieldname": "condition_json",
-      "fieldtype": "JSON",
+      "fieldtype": "Text",
       "label": "Condition JSON"
      },
      {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "cryptography~=43.0.1",
     "cssutils~=2.9.0",
     "email-reply-parser~=0.5.12",
-    "gunicorn~=22.0.0",
+    "gunicorn @ git+https://github.com/frappe/gunicorn@2f5b4923399d18c28e4221f6514792b5cc7d2c21",
     "html5lib~=1.1",
     "ipython~=8.15.0",
     "ldap3~=2.9",


### PR DESCRIPTION
Added new changes from the Frappe version 15 branch from Jan 7 to Jan 14.
### Bug Fixes

* add missing type hints 
* **export_file:** check paths before writing 
* Forward `shared` flag to cache generator 
* Ignoring linked doctypes on cancel
* in case of owner, always include owner in count data 
* **make-app:** don't allow creating an app with the same name as a site 
* move ifnull logic to applicaiton for better orm support 
* **new-site:** don't allow creating a site with the same name as an app 
* sync translations from crowdin 

### Features

* **create_new:** drop fieldtype check for filling from route 
* display two lines in image view
* Scheduler Event 