### PR TITLE
feat: Added functionality to add filters from custom app on standard …

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -808,3 +808,17 @@ def validate_filters_permissions(report_name, filters=None, user=None):
 						linked_doctype, filters[field.fieldname]
 					)
 				)
+
+@frappe.whitelist()
+def get_custom_script(report_name):
+	all_filtetrs = "["
+	for app_name in frappe.get_installed_apps():
+		files = frappe.get_hooks("report_filters", default={}, app_name=app_name).get(report_name)
+		if files:
+			path = frappe.get_app_path(app_name, *files[0].strip("/").split("/"))
+			with open(path, 'r') as file:
+				js_content = file.read()
+				js_content = js_content.strip()[1:-1].strip().rstrip(",")
+				all_filtetrs += js_content + ','
+	return all_filtetrs + ']'
+

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -398,6 +398,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		this.prepared_report_name = null; // this should be set only if prepared report is EXPLICITLY requested
 		this.toggle_message(true);
 		this.toggle_report(false);
+		this.add_dyamic_filters();
 
 		return frappe.run_serially([
 			() => this.setup_filters(),
@@ -406,6 +407,37 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			() => this.report_settings.onload && this.report_settings.onload(this),
 			() => this.refresh(),
 		]);
+	}
+	
+	add_dyamic_filters(){
+		frappe.call({
+			method:"frappe.desk.query_report.get_custom_script",
+			args:{
+				report_name: this.report_name,
+			},
+			async:false,
+			callback:((r) => {
+				if (r.message) {
+					var custom_filter = eval(r.message)
+						custom_filter.forEach(fld=>{
+							if (this.check_duplicacy(fld.fieldname) != true){
+								frappe.query_reports[this.report_name].filters.push(fld)
+							}
+						})
+				}
+			})
+		})	
+	}
+
+	check_duplicacy(field_name){
+		var flag = false
+		for (const fld of frappe.query_reports[this.report_name].filters){
+			if (fld.fieldname == field_name){
+				flag=true
+				break;
+			}
+		}
+		return flag
 	}
 
 	get_report_doc() {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -418,12 +418,16 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			async:false,
 			callback:((r) => {
 				if (r.message) {
-					var custom_filter = eval(r.message)
+					try {
+						var custom_filter = frappe.utils.eval(r.message);
 						custom_filter.forEach(fld=>{
 							if (this.check_duplicacy(fld.fieldname) != true){
 								frappe.query_reports[this.report_name].filters.push(fld)
 							}
 						})
+					} catch (error) {
+						console.error(error)
+					}
 				}
 			})
 		})	

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -479,7 +479,7 @@ app_license = "{app_license}"
 # }}
 
 
-# Added Custom Filter in standared report
+# Custom Filter in Standard Report
 # ---------------
 
 # report_filters  = {

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -478,6 +478,26 @@ app_license = "{app_license}"
 # 	}}
 # }}
 
+
+# Added Custom Filter in standared report
+# ---------------
+
+# report_filters  = {
+#     "General Ledger": "/{app_name}/report_filters/general_ledger.js",
+#	  "Gross Profit": "/{app_name}/report_filters/gross_profit.js"
+# }
+
+# Add the list of filters in 'general_ledger.js'
+# [
+# 	{
+# 		fieldname: "field_name1",
+# 		label: __("Field Name"),
+# 		fieldtype: "Field Type",
+# 	},
+# 	...
+# ]
+
+
 # Scheduled Tasks
 # ---------------
 


### PR DESCRIPTION
Now we can add custom report filters on Standard report like General Ledger, Stock Balance etc
Step 1. Create an js file with list of filters
e.i
![image](https://github.com/user-attachments/assets/2620ee6a-e883-41b8-912c-890519db8d29)

Step 2. Add the name of the Report with path of above file in hooks.py
e.i
![image](https://github.com/user-attachments/assets/c0471de0-05d4-4843-8564-f69cba7b3956)

That's it! It will render your filter on the report.

Note:- 
Please stick to the instructions, js file should contain only array of filter object.
If other app trying to add same filter name then it will ignore, mean did not add multiple filter with same name.