### PR TITLE
Frappe v15 commits mar 12 to mar 18

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -61,7 +61,7 @@ from .utils.jinja import (
 )
 from .utils.lazy_loader import lazy_import
 
-__version__ = "15.59.0"
+__version__ = "15.60.0""
 __title__ = "Frappe Framework"
 
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -61,7 +61,7 @@ from .utils.jinja import (
 )
 from .utils.lazy_loader import lazy_import
 
-__version__ = "15.58.1"
+__version__ = "15.59.0"
 __title__ = "Frappe Framework"
 
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -61,7 +61,7 @@ from .utils.jinja import (
 )
 from .utils.lazy_loader import lazy_import
 
-__version__ = "15.60.0""
+__version__ = "15.60.0"
 __title__ = "Frappe Framework"
 
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -61,7 +61,7 @@ from .utils.jinja import (
 )
 from .utils.lazy_loader import lazy_import
 
-__version__ = "15.58.0"
+__version__ = "15.58.1"
 __title__ = "Frappe Framework"
 
 

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -550,23 +550,12 @@ def list_apps(context, format):
 @pass_context
 def add_db_index(context, doctype, column):
 	"Adds a new DB index and creates a property setter to persist it."
-	from frappe.custom.doctype.property_setter.property_setter import make_property_setter
-
 	columns = column  # correct naming
 	for site in context.sites:
 		frappe.init(site=site)
 		frappe.connect()
 		try:
 			frappe.db.add_index(doctype, columns)
-			if len(columns) == 1:
-				make_property_setter(
-					doctype,
-					columns[0],
-					property="search_index",
-					value="1",
-					property_type="Check",
-					for_doctype=False,  # Applied on docfield
-				)
 			frappe.db.commit()
 		finally:
 			frappe.destroy()

--- a/frappe/core/doctype/recorder/recorder.py
+++ b/frappe/core/doctype/recorder/recorder.py
@@ -130,14 +130,6 @@ def add_indexes(indexes):
 def _add_index(table, column):
 	doctype = get_doctype_name(table)
 	frappe.db.add_index(doctype, [column])
-	make_property_setter(
-		doctype,
-		column,
-		property="search_index",
-		value="1",
-		property_type="Check",
-		for_doctype=False,  # Applied on docfield
-	)
 	frappe.msgprint(
 		_("Index created successfully on column {0} of doctype {1}").format(column, doctype),
 		alert=True,

--- a/frappe/core/doctype/report/report.json
+++ b/frappe/core/doctype/report/report.json
@@ -71,6 +71,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval: doc.report_type !== \"Report Builder\"",
    "fieldname": "add_total_row",
    "fieldtype": "Check",
    "label": "Add Total Row"
@@ -201,7 +202,7 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-11 10:42:45.591937",
+ "modified": "2025-03-12 17:08:09.629411",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Report",

--- a/frappe/core/doctype/sms_parameter/sms_parameter.json
+++ b/frappe/core/doctype/sms_parameter/sms_parameter.json
@@ -25,6 +25,7 @@
    "in_list_view": 1,
    "label": "Value",
    "print_width": "150px",
+   "length": 255,
    "reqd": 1,
    "width": "150px"
   },
@@ -39,7 +40,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-08-03 12:20:53.129765",
+ "modified": "2025-03-12 19:40:34.519601",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "SMS Parameter",

--- a/frappe/core/doctype/user/user.json
+++ b/frappe/core/doctype/user/user.json
@@ -873,7 +873,8 @@
    "link_fieldname": "user"
   }
  ],
- "modified": "2025-02-21 20:11:36.150167",
+ "make_attachments_public": 1,
+ "modified": "2025-03-17 11:29:39.254304",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User",

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -33,6 +33,7 @@ from frappe.utils import (
 )
 from frappe.utils.data import sha256_hash
 from frappe.utils.deprecations import deprecated
+from frappe.utils.html_utils import sanitize_html
 from frappe.utils.password import check_password, get_password_reset_limit
 from frappe.utils.password import update_password as _update_password
 from frappe.utils.user import get_system_managers
@@ -178,6 +179,7 @@ class User(Document):
 		self.populate_role_profile_roles()
 		self.check_roles_added()
 		self.set_system_user()
+		self.clean_name()
 		self.set_full_name()
 		self.check_enable_disable()
 		self.ensure_unique_roles()
@@ -253,6 +255,11 @@ class User(Document):
 	def has_website_permission(self, ptype, user, verbose=False):
 		"""Returns true if current user is the session user"""
 		return self.name == frappe.session.user
+
+	def clean_name(self):
+		for field in ("first_name", "middle_name", "last_name"):
+			if field_value := self.get(field):
+				self.set(field, sanitize_html(field_value, always_sanitize=True))
 
 	def set_full_name(self):
 		self.full_name = " ".join(filter(None, [self.first_name, self.last_name]))

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -123,6 +123,7 @@ class MariaDBConnectionUtil:
 			"user": self.user,
 			"conv": self.CONVERSION_MAP,
 			"charset": "utf8mb4",
+			"collation": "utf8mb4_unicode_ci",
 			"use_unicode": True,
 		}
 
@@ -321,7 +322,7 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 			`doctype` VARCHAR(180) NOT NULL,
 			`data` TEXT,
 			UNIQUE(user, doctype)
-			) ENGINE=InnoDB DEFAULT CHARSET=utf8"""
+			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"""
 		)
 
 	@staticmethod

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -404,14 +404,26 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 	def add_index(self, doctype: str, fields: list, index_name: str | None = None):
 		"""Creates an index with given fields if not already created.
 		Index name will be `fieldname1_fieldname2_index`"""
+		from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 		index_name = index_name or self.get_index_name(fields)
 		table_name = get_table_name(doctype)
 		if not self.has_index(table_name, index_name):
 			self.commit()
 			self.sql(
 				"""ALTER TABLE `{}`
-				ADD INDEX `{}`({})""".format(table_name, index_name, ", ".join(fields))
+				ADD INDEX IF NOT EXISTS `{}`({})""".format(table_name, index_name, ", ".join(fields))
 			)
+			# Ensure that DB migration doesn't clear this index, assuming this is manually added
+			# via code or console.
+			if len(fields) == 1 and not (frappe.flags.in_install or frappe.flags.in_migrate):
+				make_property_setter(
+					doctype,
+					fields[0],
+					property="search_index",
+					value="1",
+					property_type="Check",
+					for_doctype=False,  # Applied on docfield
+				)
 
 	def add_unique(self, doctype, fields, constraint_name=None):
 		if isinstance(fields, str):

--- a/frappe/desk/doctype/list_view_settings/list_view_settings.json
+++ b/frappe/desk/doctype/list_view_settings/list_view_settings.json
@@ -11,6 +11,7 @@
  "disable_sidebar_stats",
  "disable_auto_refresh",
  "allow_edit",
+ "disable_automatic_recency_filters",
  "total_fields",
  "fields_html",
  "fields"
@@ -64,10 +65,17 @@
  "fieldname": "allow_edit",
  "fieldtype": "Check",
  "label": "Allow Bulk Editing"
- }
+},
+{
+ "default": "0",
+ "fieldname": "disable_automatic_recency_filters",
+ "fieldtype": "Check",
+ "label": "Disable Automatic Recency Filters"
+}
  ],
+ "grid_page_length": 50,
  "links": [],
- "modified": "2024-08-21 18:17:24.889783",
+ "modified": "2025-03-12 16:28:46.073808",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "List View Settings",

--- a/frappe/desk/doctype/list_view_settings/list_view_settings.py
+++ b/frappe/desk/doctype/list_view_settings/list_view_settings.py
@@ -16,6 +16,7 @@ class ListViewSettings(Document):
 
 		allow_edit: DF.Check
 		disable_auto_refresh: DF.Check
+		disable_automatic_recency_filters: DF.Check
 		disable_comment_count: DF.Check
 		disable_count: DF.Check
 		disable_sidebar_stats: DF.Check

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -19,6 +19,7 @@ from frappe.model.utils import is_virtual_doctype
 from frappe.utils import add_user_info, cint, format_duration
 from frappe.utils.data import sbool
 
+DISALLOWED_PARAMS = ("cmd", "data", "ignore_permissions", "view", "user", "csrf_token", "join")
 
 @frappe.whitelist()
 @frappe.read_only()
@@ -226,8 +227,9 @@ def update_wildcard_field_param(data):
 
 
 def clean_params(data):
-	for param in ("cmd", "data", "ignore_permissions", "view", "user", "csrf_token", "join"):
-		data.pop(param, None)
+	for param in DISALLOWED_PARAMS:
+		if param in data:
+			del data[param]
 
 
 def parse_json(data):

--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -7,6 +7,10 @@ from datetime import timedelta
 from email.utils import formataddr
 
 import frappe
+import frappe.email
+import frappe.email.doctype
+import frappe.email.doctype.auto_email_report
+import frappe.email.doctype.auto_email_report.auto_email_report
 from frappe import _
 from frappe.desk.query_report import build_xlsx_data
 from frappe.model.document import Document
@@ -305,25 +309,35 @@ def send_now(name):
 def send_daily():
 	"""Check reports to be sent daily"""
 
-	current_day = calendar.day_name[now_datetime().weekday()]
 	enabled_reports = frappe.get_all(
 		"Auto Email Report", filters={"enabled": 1, "frequency": ("in", ("Daily", "Weekdays", "Weekly"))}
 	)
 
 	for report in enabled_reports:
-		auto_email_report = frappe.get_doc("Auto Email Report", report.name)
+		frappe.enqueue(
+			"frappe.email.doctype.auto_email_report.auto_email_report.process_auto_email_report",
+			report=report,
+		)
 
-		# if not correct weekday, skip
-		if auto_email_report.frequency == "Weekdays":
-			if current_day in ("Saturday", "Sunday"):
-				continue
-		elif auto_email_report.frequency == "Weekly":
-			if auto_email_report.day_of_week != current_day:
-				continue
-		try:
-			auto_email_report.send()
-		except Exception:
-			auto_email_report.log_error(f"Failed to send {auto_email_report.name} Auto Email Report")
+
+def process_auto_email_report(report):
+	"""Process and send the Auto Email Report based on frequency"""
+
+	current_day = calendar.day_name[now_datetime().weekday()]
+
+	auto_email_report = frappe.get_doc("Auto Email Report", report.name)
+
+	# if not correct weekday, skip
+	if auto_email_report.frequency == "Weekdays":
+		if current_day in ("Saturday", "Sunday"):
+			return
+	elif auto_email_report.frequency == "Weekly":
+		if auto_email_report.day_of_week != current_day:
+			return
+	try:
+		auto_email_report.send()
+	except Exception:
+		auto_email_report.log_error(f"Failed to send {auto_email_report.name} Auto Email Report")
 
 
 def send_monthly():

--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -7,10 +7,6 @@ from datetime import timedelta
 from email.utils import formataddr
 
 import frappe
-import frappe.email
-import frappe.email.doctype
-import frappe.email.doctype.auto_email_report
-import frappe.email.doctype.auto_email_report.auto_email_report
 from frappe import _
 from frappe.desk.query_report import build_xlsx_data
 from frappe.model.document import Document

--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -313,6 +313,7 @@ def send_daily():
 		frappe.enqueue(
 			"frappe.email.doctype.auto_email_report.auto_email_report.process_auto_email_report",
 			report=report,
+			queue="long",
 		)
 
 

--- a/frappe/locale/fa.po
+++ b/frappe/locale/fa.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: developers@frappe.io\n"
 "POT-Creation-Date: 2025-02-24 14:51+0000\n"
-"PO-Revision-Date: 2025-03-09 18:48\n"
+"PO-Revision-Date: 2025-03-15 20:53\n"
 "Last-Translator: developers@frappe.io\n"
 "Language-Team: Persian\n"
 "MIME-Version: 1.0\n"
@@ -2028,7 +2028,7 @@ msgstr "{0} دیگری با نام {1} وجود دارد، نام دیگری ر�
 #. Description of the 'Raw Commands' (Code) field in DocType 'Print Format'
 #: frappe/printing/doctype/print_format/print_format.json
 msgid "Any string-based printer languages can be used. Writing raw commands requires knowledge of the printer's native language provided by the printer manufacturer. Please refer to the developer manual provided by the printer manufacturer on how to write their native commands. These commands are rendered on the server side using the Jinja Templating Language."
-msgstr "می‌توان از هر زبان چاپگر مبتنی بر رشته استفاده کرد. نوشتن دستورات خام مستلزم دانش زبان مادری چاپگر است که توسط سازنده چاپگر ارائه شده است. لطفاً به کتابچه راهنمای توسعه دهنده ارائه شده توسط سازنده چاپگر در مورد نحوه نوشتن دستورات اصلی آنها مراجعه کنید. این دستورات در سمت سرور با استفاده از زبان قالب گیری Jinja ارائه می شوند."
+msgstr "می‌توان از هر زبان چاپگر مبتنی بر رشته استفاده کرد. نوشتن دستورات خام مستلزم دانش زبان مادری چاپگر است که توسط سازنده چاپگر ارائه شده است. لطفاً به کتابچه راهنمای توسعه دهنده ارائه شده توسط سازنده چاپگر در مورد نحوه نوشتن دستورات اصلی آنها مراجعه کنید. این دستورات در سمت سرور با استفاده از زبان قالب گیری Jinja ارائه می‌شوند."
 
 #: frappe/core/page/permission_manager/permission_manager_help.html:36
 msgid "Apart from System Manager, roles with Set User Permissions right can set permissions for other users for that Document Type."
@@ -2278,7 +2278,7 @@ msgstr "آیا مطمئن هستید که می‌خواهید ستون را حذ
 #: frappe/public/js/form_builder/components/Section.vue:126
 msgctxt "Confirmation dialog message"
 msgid "Are you sure you want to delete the section? All the columns along with fields in the section will be moved to the previous section."
-msgstr "آیا مطمئن هستید که می‌خواهید بخش را حذف کنید؟ تمام ستون ها به همراه فیلدهای موجود در بخش به بخش قبلی منتقل می شوند."
+msgstr "آیا مطمئن هستید که می‌خواهید بخش را حذف کنید؟ تمام ستون ها به همراه فیلدهای موجود در بخش به بخش قبلی منتقل می‌شوند."
 
 #: frappe/public/js/form_builder/components/Tabs.vue:65
 msgctxt "Confirmation dialog message"
@@ -3668,7 +3668,7 @@ msgstr "به طور پیش‌فرض عنوان به عنوان عنوان متا
 #. DocType 'S3 Backup Settings'
 #: frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.json
 msgid "By default, emails are only sent for failed backups."
-msgstr "به طور پیش‌فرض، ایمیل ها فقط برای پشتیبان گیری ناموفق ارسال می شوند."
+msgstr "به طور پیش‌فرض، ایمیل ها فقط برای پشتیبان گیری ناموفق ارسال می‌شوند."
 
 #. Option for the 'Naming Rule' (Select) field in DocType 'DocType'
 #. Option for the 'Naming Rule' (Select) field in DocType 'Customize Form'
@@ -3692,7 +3692,7 @@ msgstr "دور زدن آدرس IP محدود بررسی کنید که آیا ت�
 #. Label of a Check field in DocType 'System Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
 msgid "Bypass Two Factor Auth for users who login from restricted IP Address"
-msgstr "دور زدن تأیید اعتبار دو عاملی برای کاربرانی که از آدرس IP محدود وارد می شوند"
+msgstr "دور زدن تأیید اعتبار دو عاملی برای کاربرانی که از آدرس IP محدود وارد می‌شوند"
 
 #. Label of a Check field in DocType 'System Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
@@ -4455,7 +4455,7 @@ msgstr "جدول فرزند {0} برای فیلد {1}"
 #: frappe/core/doctype/doctype/doctype.json
 #: frappe/core/doctype/doctype/doctype_list.js:37
 msgid "Child Tables are shown as a Grid in other DocTypes"
-msgstr "جداول Child به صورت Grid در سایر DocType ها نشان داده می شوند"
+msgstr "جداول Child به صورت Grid در سایر DocType ها نشان داده می‌شوند"
 
 #: frappe/public/js/frappe/widgets/widget_dialog.js:619
 msgid "Choose Existing Card or create New Card"
@@ -9884,7 +9884,7 @@ msgstr "فیلدهای \"file_name\" یا \"file_url\" باید برای File ت
 #. Description of the 'Search Fields' (Data) field in DocType 'Customize Form'
 #: frappe/custom/doctype/customize_form/customize_form.json
 msgid "Fields separated by comma (,) will be included in the \"Search By\" list of Search dialog box"
-msgstr "فیلدهایی که با کاما (،) از هم جدا شده اند در لیست \"جستجو بر اساس\" کادر گفتگوی جستجو گنجانده می شوند."
+msgstr "فیلدهایی که با کاما (،) از هم جدا شده اند در لیست \"جستجو بر اساس\" کادر گفتگوی جستجو گنجانده می‌شوند."
 
 #. Label of a Select field in DocType 'Report Column'
 #. Label of a Select field in DocType 'Report Filter'
@@ -11964,7 +11964,7 @@ msgstr "اگر فعال باشد، تغییرات سند ردیابی شده و 
 #. Description of the 'Track Views' (Check) field in DocType 'DocType'
 #: frappe/core/doctype/doctype/doctype.json
 msgid "If enabled, document views are tracked, this can happen multiple times"
-msgstr "اگر فعال باشد، نماهای سند ردیابی می شوند، این می‌تواند چندین بار اتفاق بیفتد"
+msgstr "اگر فعال باشد، نماهای سند ردیابی می‌شوند، این می‌تواند چندین بار اتفاق بیفتد"
 
 #. Description of the 'Track Seen' (Check) field in DocType 'DocType'
 #: frappe/core/doctype/doctype/doctype.json
@@ -11993,7 +11993,7 @@ msgstr "اگر فعال باشد، از کاربرانی که از آدرس IP �
 #. 'Note'
 #: frappe/desk/doctype/note/note.json
 msgid "If enabled, users will be notified every time they login. If not enabled, users will only be notified once."
-msgstr "در صورت فعال بودن، هر بار که کاربران وارد سیستم می شوند، از آن مطلع می شوند. در صورت فعال نشدن، فقط یک بار به کاربران اطلاع داده می‌شود."
+msgstr "در صورت فعال بودن، هر بار که کاربران وارد سیستم می‌شوند، از آن مطلع می‌شوند. در صورت فعال نشدن، فقط یک بار به کاربران اطلاع داده می‌شود."
 
 #. Description of the 'Default Workspace' (Link) field in DocType 'User'
 #: frappe/core/doctype/user/user.json
@@ -13948,7 +13948,7 @@ msgstr "این گفتگو را ترک کنید"
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: frappe/printing/doctype/print_settings/print_settings.json
 msgid "Ledger"
-msgstr "دفتر کل"
+msgstr "دفتر"
 
 #. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #. Option for the 'Align' (Select) field in DocType 'Letter Head'
@@ -17237,7 +17237,7 @@ msgstr "نام فیلدهای قدیمی و جدید یکسان است."
 #. Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
 msgid "Older backups will be automatically deleted"
-msgstr "نسخه های پشتیبان قدیمی به طور خودکار حذف می شوند"
+msgstr "نسخه های پشتیبان قدیمی به طور خودکار حذف می‌شوند"
 
 #. Label of a Link field in DocType 'System Health Report'
 #: frappe/desk/doctype/system_health_report/system_health_report.json
@@ -18025,7 +18025,7 @@ msgstr "نوع سند والد برای ایجاد نمودار داشبورد �
 
 #: frappe/core/doctype/data_export/exporter.py:253
 msgid "Parent is the name of the document to which the data will get added to."
-msgstr "والدین نام سندی است که داده ها به آن اضافه می شوند."
+msgstr "والدین نام سندی است که داده ها به آن اضافه می‌شوند."
 
 #: frappe/permissions.py:798
 msgid "Parentfield not specified in {0}: {1}"
@@ -19871,7 +19871,7 @@ msgstr "محدودیت های نرخ"
 #. Label of a Int field in DocType 'System Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
 msgid "Rate limit for email link login"
-msgstr ""
+msgstr "محدودیت تعداد درخواست برای ورود با لینک ایمیل"
 
 #. Label of a Int field in DocType 'Communication'
 #. Option for the 'Type' (Select) field in DocType 'DocField'
@@ -23534,7 +23534,7 @@ msgstr ""
 #. Card'
 #: frappe/desk/doctype/number_card/number_card.json
 msgid "Show percentage difference according to this time interval"
-msgstr "با توجه به این فاصله زمانی، درصد اختلاف را نشان دهید"
+msgstr "نمایش درصد اختلاف با توجه به این بازه زمانی"
 
 #. Description of the 'Title Prefix' (Data) field in DocType 'Website Settings'
 #: frappe/website/doctype/website_settings/website_settings.json
@@ -23645,7 +23645,7 @@ msgstr "Single DocType ها را نمی‌توان سفارشی کرد."
 #: frappe/core/doctype/doctype/doctype.json
 #: frappe/core/doctype/doctype/doctype_list.js:51
 msgid "Single Types have only one record no tables associated. Values are stored in tabSingles"
-msgstr "Single Type ها فقط یک رکورد دارند و هیچ جدولی مرتبط نیست. مقادیر در tabSingles ذخیره می شوند"
+msgstr "Single Type ها فقط یک رکورد دارند و هیچ جدولی مرتبط نیست. مقادیر در tabSingles ذخیره می‌شوند"
 
 #: frappe/database/database.py:243
 msgid "Site is running in read only mode for maintenance or site update, this action can not be performed right now. Please try again later."
@@ -25582,7 +25582,7 @@ msgstr "اگر از فهرست LDAP 'Custom' استفاده شود، این تن
 #. Description of the 'Defaults' (Section Break) field in DocType 'User'
 #: frappe/core/doctype/user/user.json
 msgid "These values will be automatically updated in transactions and also will be useful to restrict permissions for this user on transactions containing these values."
-msgstr "این مقادیر به طور خودکار در تراکنش ها به روز می شوند و همچنین برای محدود کردن مجوزهای این کاربر در تراکنش های حاوی این مقادیر مفید خواهند بود."
+msgstr "این مقادیر به طور خودکار در تراکنش ها به روز می‌شوند و همچنین برای محدود کردن مجوزهای این کاربر در تراکنش های حاوی این مقادیر مفید خواهند بود."
 
 #: frappe/www/third_party_apps.html:3 frappe/www/third_party_apps.html:13
 msgid "Third Party Apps"
@@ -25736,7 +25736,7 @@ msgstr "این یک رمز عبور بسیار رایج است."
 
 #: frappe/core/doctype/rq_job/rq_job.js:9
 msgid "This is a virtual doctype and data is cleared periodically."
-msgstr "این یک Doctype مجازی است و داده ها به صورت دوره ای پاک می شوند."
+msgstr "این یک Doctype مجازی است و داده ها به صورت دوره ای پاک می‌شوند."
 
 #: frappe/templates/emails/auto_reply.html:5
 msgid "This is an automatically generated reply"
@@ -25895,7 +25895,7 @@ msgstr "فرمت زمان"
 #. Label of a Select field in DocType 'Dashboard Chart'
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
 msgid "Time Interval"
-msgstr "فاصله زمانی"
+msgstr "بازه زمانی"
 
 #. Label of a Check field in DocType 'Dashboard Chart'
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -26489,7 +26489,7 @@ msgstr "فیلد پیست"
 #. Label of a Check field in DocType 'DocType'
 #: frappe/core/doctype/doctype/doctype.json
 msgid "Track Seen"
-msgstr "آهنگ دیده شده"
+msgstr "ردیابی دیده شده"
 
 #. Label of a Check field in DocType 'Form Tour'
 #: frappe/desk/doctype/form_tour/form_tour.json
@@ -26501,7 +26501,7 @@ msgstr "ردیابی مراحل"
 #: frappe/core/doctype/doctype/doctype.json
 #: frappe/custom/doctype/customize_form/customize_form.json
 msgid "Track Views"
-msgstr "نماهای آهنگ"
+msgstr "ردیابی بازدیدها"
 
 #. Description of the 'Track Email Status' (Check) field in DocType 'Email
 #. Account'
@@ -26612,7 +26612,7 @@ msgstr "نمای درخت"
 #. Description of the 'Is Tree' (Check) field in DocType 'DocType'
 #: frappe/core/doctype/doctype/doctype.json
 msgid "Tree structures are implemented using Nested Set"
-msgstr "ساختارهای درختی با استفاده از مجموعه تودرتو پیاده سازی می شوند"
+msgstr "ساختارهای درختی با استفاده از مجموعه تودرتو پیاده سازی می‌شوند"
 
 #: frappe/public/js/frappe/views/treeview.js:20
 msgid "Tree view is not available for {0}"
@@ -31465,11 +31465,11 @@ msgstr "رکورد {0} حذف شد"
 
 #: frappe/public/js/frappe/logtypes.js:22
 msgid "{0} records are not automatically deleted."
-msgstr "رکوردهای {0} به طور خودکار حذف نمی شوند."
+msgstr "رکوردهای {0} به طور خودکار حذف نمی‌شوند."
 
 #: frappe/public/js/frappe/logtypes.js:29
 msgid "{0} records are retained for {1} days."
-msgstr "رکوردهای {0} برای {1} روز حفظ می شوند."
+msgstr "رکوردهای {0} برای {1} روز حفظ می‌شوند."
 
 #: frappe/core/doctype/user_permission/user_permission_list.js:179
 msgid "{0} records deleted"

--- a/frappe/locale/hr.po
+++ b/frappe/locale/hr.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: developers@frappe.io\n"
 "POT-Creation-Date: 2025-02-24 14:51+0000\n"
-"PO-Revision-Date: 2025-03-10 18:54\n"
+"PO-Revision-Date: 2025-03-17 21:13\n"
 "Last-Translator: developers@frappe.io\n"
 "Language-Team: Croatian\n"
 "MIME-Version: 1.0\n"
@@ -26,13 +26,13 @@ msgstr " u vaš preglednik"
 #. Condition'
 #: frappe/core/doctype/document_naming_rule_condition/document_naming_rule_condition.json
 msgid "!="
-msgstr ""
+msgstr "!="
 
 #. Description of the 'Org History Heading' (Data) field in DocType 'About Us
 #. Settings'
 #: frappe/website/doctype/about_us_settings/about_us_settings.json
 msgid "\"Company History\""
-msgstr ""
+msgstr "\"Povijest Tvrtke\""
 
 #: frappe/core/doctype/data_export/exporter.py:202
 msgid "\"Parent\" signifies the parent table in which this row must be added"
@@ -76,19 +76,19 @@ msgstr "'U Globalnoj Pretrazi' nije dozvoljeno za polje {0} tipa {1}"
 
 #: frappe/core/doctype/doctype/doctype.py:1316
 msgid "'In Global Search' not allowed for type {0} in row {1}"
-msgstr ""
+msgstr "'U Globalnom Pretraživanju' nije dopušteno za tip {0} u retku {1}"
 
 #: frappe/public/js/form_builder/store.js:198
 msgid "'In List View' is not allowed for field {0} of type {1}"
-msgstr ""
+msgstr "'U Prikazu Liste' nije dopušteno za polje {0} tipa {1}"
 
 #: frappe/custom/doctype/customize_form/customize_form.py:359
 msgid "'In List View' not allowed for type {0} in row {1}"
-msgstr ""
+msgstr "'U Prikazu Liste' nije dopušteno za tip {0} u redu {1}"
 
 #: frappe/automation/doctype/auto_repeat/auto_repeat.py:156
 msgid "'Recipients' not specified"
-msgstr ""
+msgstr "'Primatelji' nisu navedeni"
 
 #: frappe/utils/__init__.py:242
 msgid "'{0}' is not a valid URL"
@@ -120,7 +120,7 @@ msgstr ""
 #. Description of the 'Priority' (Int) field in DocType 'Web Page'
 #: frappe/website/doctype/web_page/web_page.json
 msgid "0 is highest"
-msgstr ""
+msgstr "0 je najviše"
 
 #: frappe/public/js/frappe/form/grid_row.js:820
 msgid "1 = True & 0 = False"
@@ -130,7 +130,8 @@ msgstr "1 = Točno & 0 = Netočno"
 #: frappe/geo/doctype/currency/currency.json
 msgid "1 Currency = [?] Fraction\n"
 "For e.g. 1 USD = 100 Cent"
-msgstr ""
+msgstr "1 Valuta = [?] Dio\n"
+"Za npr. 1 USD = 100 Cent"
 
 #: frappe/public/js/frappe/form/reminders.js:19
 msgid "1 Day"
@@ -138,7 +139,7 @@ msgstr "1 Dan"
 
 #: frappe/integrations/doctype/google_calendar/google_calendar.py:361
 msgid "1 Google Calendar Event synced."
-msgstr "Sinkroniziran je 1 događaj Google Kalendara."
+msgstr "Sinhroniziran je 1 događaj iz Google Kalendara."
 
 #: frappe/public/js/frappe/views/reports/query_report.js:886
 msgid "1 Report"
@@ -177,7 +178,7 @@ msgstr "1 od 2"
 
 #: frappe/public/js/frappe/data_import/data_exporter.js:227
 msgid "1 record will be exported"
-msgstr "Izvest će se 1 zapis"
+msgstr "1 zapis će biti izvezen"
 
 #: frappe/tests/test_utils.py:641
 msgid "1 second ago"
@@ -186,7 +187,7 @@ msgstr "prije 1 sekundu"
 #: frappe/public/js/frappe/utils/pretty_date.js:62
 #: frappe/tests/test_utils.py:648
 msgid "1 week ago"
-msgstr "prije 1 tjedan"
+msgstr "prije 1 sedmicu"
 
 #: frappe/public/js/frappe/utils/pretty_date.js:70
 #: frappe/tests/test_utils.py:652
@@ -237,13 +238,13 @@ msgstr "; nije dopušteno u stanju"
 #. Condition'
 #: frappe/core/doctype/document_naming_rule_condition/document_naming_rule_condition.json
 msgid "<"
-msgstr ""
+msgstr "<"
 
 #. Option for the 'Condition' (Select) field in DocType 'Document Naming Rule
 #. Condition'
 #: frappe/core/doctype/document_naming_rule_condition/document_naming_rule_condition.json
 msgid "<="
-msgstr ""
+msgstr "<="
 
 #: frappe/public/js/frappe/widgets/widget_dialog.js:569
 msgid "<b>{0}</b> is not a valid URL"
@@ -567,19 +568,19 @@ msgstr ""
 #. Condition'
 #: frappe/core/doctype/document_naming_rule_condition/document_naming_rule_condition.json
 msgid "="
-msgstr ""
+msgstr "="
 
 #. Option for the 'Condition' (Select) field in DocType 'Document Naming Rule
 #. Condition'
 #: frappe/core/doctype/document_naming_rule_condition/document_naming_rule_condition.json
 msgid ">"
-msgstr ""
+msgstr ">"
 
 #. Option for the 'Condition' (Select) field in DocType 'Document Naming Rule
 #. Condition'
 #: frappe/core/doctype/document_naming_rule_condition/document_naming_rule_condition.json
 msgid ">="
-msgstr ""
+msgstr ">="
 
 #. Description of the Onboarding Step 'Custom Document Types'
 #: frappe/custom/onboarding_step/custom_doctype/custom_doctype.json
@@ -609,101 +610,101 @@ msgstr ""
 
 #: frappe/templates/emails/new_user.html:5
 msgid "A new account has been created for you at {0}"
-msgstr ""
+msgstr "Za vas je stvoren novi račun {0}"
 
 #: frappe/automation/doctype/auto_repeat/auto_repeat.py:395
 msgid "A recurring {0} {1} has been created for you via Auto Repeat {2}."
-msgstr ""
+msgstr "Ponavljajuće {0} {1} stvoreno je za vas putem Automatskog Ponavljanja {2}."
 
 #. Description of the 'Symbol' (Data) field in DocType 'Currency'
 #: frappe/geo/doctype/currency/currency.json
 msgid "A symbol for this currency. For e.g. $"
-msgstr ""
+msgstr "Simbol za ovu valutu. Za npr. $"
 
 #: frappe/printing/doctype/print_format_field_template/print_format_field_template.py:49
 msgid "A template already exists for field {0} of {1}"
-msgstr ""
+msgstr "Predložak već postoji za polje {0} od {1}"
 
 #: frappe/utils/password_strength.py:165
 msgid "A word by itself is easy to guess."
-msgstr ""
+msgstr "Riječ samu po sebi lako je pogoditi."
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: frappe/printing/doctype/print_settings/print_settings.json
 msgid "A0"
-msgstr ""
+msgstr "A0"
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: frappe/printing/doctype/print_settings/print_settings.json
 msgid "A1"
-msgstr ""
+msgstr "A1"
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: frappe/printing/doctype/print_settings/print_settings.json
 msgid "A2"
-msgstr ""
+msgstr "A2"
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: frappe/printing/doctype/print_settings/print_settings.json
 msgid "A3"
-msgstr ""
+msgstr "A3"
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: frappe/printing/doctype/print_settings/print_settings.json
 msgid "A4"
-msgstr ""
+msgstr "A4"
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: frappe/printing/doctype/print_settings/print_settings.json
 msgid "A5"
-msgstr ""
+msgstr "A5"
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: frappe/printing/doctype/print_settings/print_settings.json
 msgid "A6"
-msgstr ""
+msgstr "A6"
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: frappe/printing/doctype/print_settings/print_settings.json
 msgid "A7"
-msgstr ""
+msgstr "A7"
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: frappe/printing/doctype/print_settings/print_settings.json
 msgid "A8"
-msgstr ""
+msgstr "A8"
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: frappe/printing/doctype/print_settings/print_settings.json
 msgid "A9"
-msgstr ""
+msgstr "A9"
 
 #. Option for the 'Email Sync Option' (Select) field in DocType 'Email Account'
 #: frappe/email/doctype/email_account/email_account.json
 msgid "ALL"
-msgstr ""
+msgstr "SVE"
 
 #. Option for the 'Script Type' (Select) field in DocType 'Server Script'
 #: frappe/core/doctype/server_script/server_script.json
 msgid "API"
-msgstr ""
+msgstr "API"
 
 #. Label of a Section Break field in DocType 'User'
 #. Label of a Section Break field in DocType 'S3 Backup Settings'
 #: frappe/core/doctype/user/user.json
 #: frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.json
 msgid "API Access"
-msgstr ""
+msgstr "API Pristup"
 
 #. Label of a Data field in DocType 'Social Login Key'
 #: frappe/integrations/doctype/social_login_key/social_login_key.json
 msgid "API Endpoint"
-msgstr ""
+msgstr "API Krajnja Točka"
 
 #. Label of a Code field in DocType 'Social Login Key'
 #: frappe/integrations/doctype/social_login_key/social_login_key.json
 msgid "API Endpoint Args"
-msgstr ""
+msgstr "API Argumenti Krajnje Točke"
 
 #. Label of a Data field in DocType 'User'
 #. Label of a Data field in DocType 'Google Settings'
@@ -713,37 +714,37 @@ msgstr ""
 #: frappe/integrations/doctype/google_settings/google_settings.json
 #: frappe/integrations/doctype/push_notification_settings/push_notification_settings.json
 msgid "API Key"
-msgstr ""
+msgstr "API Ključ"
 
 #. Description of the 'Authentication' (Section Break) field in DocType 'Push
 #. Notification Settings'
 #: frappe/integrations/doctype/push_notification_settings/push_notification_settings.json
 msgid "API Key and Secret to interact with the relay server. These will be auto-generated when the first push notification is sent from any of the apps installed on this site."
-msgstr ""
+msgstr "API Ključ i Tajna za interakciju s relejnim poslužiteljem. Oni će se automatski generirati kada se prva push obavijest pošalje iz bilo koje aplikacije instalirane na ovoj stranici."
 
 #. Description of the 'API Key' (Data) field in DocType 'User'
 #: frappe/core/doctype/user/user.json
 msgid "API Key cannot be regenerated"
-msgstr ""
+msgstr "API Ključ se ne može regenerirati"
 
 #. Label of a Data field in DocType 'Server Script'
 #: frappe/core/doctype/server_script/server_script.json
 msgid "API Method"
-msgstr ""
+msgstr "API Metoda"
 
 #. Label of a Password field in DocType 'User'
 #. Label of a Password field in DocType 'Push Notification Settings'
 #: frappe/core/doctype/user/user.json
 #: frappe/integrations/doctype/push_notification_settings/push_notification_settings.json
 msgid "API Secret"
-msgstr ""
+msgstr "API Tajna"
 
 #. Option for the 'Default Sort Order' (Select) field in DocType 'DocType'
 #. Option for the 'Sort Order' (Select) field in DocType 'Customize Form'
 #: frappe/core/doctype/doctype/doctype.json
 #: frappe/custom/doctype/customize_form/customize_form.json
 msgid "ASC"
-msgstr ""
+msgstr "UZL"
 
 #. Label of a standard help item
 #. Type: Action
@@ -760,7 +761,7 @@ msgstr "O Nama"
 #: frappe/website/doctype/about_us_settings/about_us_settings.json
 #: frappe/website/workspace/website/website.json
 msgid "About Us Settings"
-msgstr ""
+msgstr "Postavke O Nama"
 
 #. Name of a DocType
 #: frappe/website/doctype/about_us_team_member/about_us_team_member.json
@@ -807,33 +808,33 @@ msgstr "Zapisnik Pristupa"
 #: frappe/integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
 #: frappe/integrations/doctype/token_cache/token_cache.json
 msgid "Access Token"
-msgstr ""
+msgstr "Pristupni Token"
 
 #. Label of a Data field in DocType 'Social Login Key'
 #: frappe/integrations/doctype/social_login_key/social_login_key.json
 msgid "Access Token URL"
-msgstr ""
+msgstr "URL Pristupnog Tokena"
 
 #: frappe/auth.py:483
 msgid "Access not allowed from this IP Address"
-msgstr "Pristup nije dozvoljen s ove IP adrese"
+msgstr "Pristup nije dopušten s ove IP adrese"
 
 #. Label of a Section Break field in DocType 'Email Account'
 #: frappe/email/doctype/email_account/email_account.json
 msgid "Account"
-msgstr ""
+msgstr "Račun"
 
 #. Label of a Section Break field in DocType 'Website Settings'
 #: frappe/website/doctype/website_settings/website_settings.json
 msgid "Account Deletion Settings"
-msgstr ""
+msgstr "Postavke Brisanja Računa"
 
 #. Name of a role
 #: frappe/automation/doctype/auto_repeat/auto_repeat.json
 #: frappe/contacts/doctype/contact/contact.json
 #: frappe/geo/doctype/currency/currency.json
 msgid "Accounts Manager"
-msgstr ""
+msgstr "Upravitelj Knjigovodstva"
 
 #. Name of a role
 #: frappe/automation/doctype/auto_repeat/auto_repeat.json
@@ -841,7 +842,7 @@ msgstr ""
 #: frappe/contacts/doctype/contact/contact.json
 #: frappe/geo/doctype/currency/currency.json
 msgid "Accounts User"
-msgstr ""
+msgstr "Korisnik Knjigovodstva"
 
 #. Label of a Select field in DocType 'Amended Document Naming Settings'
 #. Option for the 'Item Type' (Select) field in DocType 'Navbar Item'
@@ -861,17 +862,17 @@ msgstr ""
 #: frappe/workflow/doctype/workflow_transition/workflow_transition.json
 #: frappe/workflow/page/workflow_builder/workflow_builder.js:37
 msgid "Action"
-msgstr ""
+msgstr "Radnja"
 
 #. Label of a Small Text field in DocType 'DocType Action'
 #: frappe/core/doctype/doctype_action/doctype_action.json
 msgid "Action / Route"
-msgstr ""
+msgstr "Radnja / Ruta"
 
 #: frappe/public/js/frappe/widgets/onboarding_widget.js:310
 #: frappe/public/js/frappe/widgets/onboarding_widget.js:381
 msgid "Action Complete"
-msgstr "Radnja Završena"
+msgstr "Radnja Dovršena"
 
 #: frappe/model/document.py:1711
 msgid "Action Failed"
@@ -880,17 +881,17 @@ msgstr "Radnja Neuspješna"
 #. Label of a Data field in DocType 'Onboarding Step'
 #: frappe/desk/doctype/onboarding_step/onboarding_step.json
 msgid "Action Label"
-msgstr ""
+msgstr "Oznaka Radnje"
 
 #. Label of a Int field in DocType 'Success Action'
 #: frappe/core/doctype/success_action/success_action.json
 msgid "Action Timeout (Seconds)"
-msgstr ""
+msgstr "Istek Radnje (Sekunde)"
 
 #. Label of a Select field in DocType 'DocType Action'
 #: frappe/core/doctype/doctype_action/doctype_action.json
 msgid "Action Type"
-msgstr ""
+msgstr "Tip Radnje"
 
 #: frappe/core/doctype/submission_queue/submission_queue.py:120
 msgid "Action {0} completed successfully on {1} {2}. View it {3}"
@@ -928,12 +929,12 @@ msgstr "Radnja {0} nije uspjela {1} {2}. Pogledaj {3}"
 #: frappe/public/js/frappe/views/reports/query_report.js:214
 #: frappe/public/js/frappe/views/reports/query_report.js:780
 msgid "Actions"
-msgstr ""
+msgstr "Radnje"
 
 #. Label of a Check field in DocType 'Package Import'
 #: frappe/core/doctype/package_import/package_import.json
 msgid "Activate"
-msgstr ""
+msgstr "Aktiviraj"
 
 #. Option for the 'Status' (Select) field in DocType 'Auto Repeat'
 #. Option for the 'Status' (Select) field in DocType 'Kanban Board Column'
@@ -945,18 +946,18 @@ msgstr ""
 #: frappe/integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
 #: frappe/workflow/doctype/workflow/workflow_list.js:5
 msgid "Active"
-msgstr ""
+msgstr "Aktivan"
 
 #. Option for the 'Directory Server' (Select) field in DocType 'LDAP Settings'
 #: frappe/integrations/doctype/ldap_settings/ldap_settings.json
 msgid "Active Directory"
-msgstr ""
+msgstr "Aktivni Direktorij"
 
 #. Label of a Section Break field in DocType 'Domain Settings'
 #. Label of a Table field in DocType 'Domain Settings'
 #: frappe/core/doctype/domain_settings/domain_settings.json
 msgid "Active Domains"
-msgstr ""
+msgstr "Aktivne Domene"
 
 #. Label of a Int field in DocType 'System Health Report'
 #: frappe/desk/doctype/system_health_report/system_health_report.json
@@ -969,7 +970,7 @@ msgstr "Aktivne Sesije"
 #: frappe/public/js/frappe/form/dashboard.js:22
 #: frappe/public/js/frappe/form/footer/form_timeline.js:60
 msgid "Activity"
-msgstr ""
+msgstr "Aktivnost"
 
 #. Name of a DocType
 #. Linked DocType in User's connections
@@ -1005,7 +1006,7 @@ msgstr "Dodaj/Ukloni Stupce"
 
 #: frappe/core/doctype/user_permission/user_permission_list.js:4
 msgid "Add / Update"
-msgstr "Dodaj / Ažuriraj"
+msgstr "Dodaj/Ažuriraj"
 
 #: frappe/core/page/permission_manager/permission_manager.js:435
 msgid "Add A New Rule"
@@ -1014,39 +1015,39 @@ msgstr "Dodaj Novo Pravilo"
 #: frappe/public/js/frappe/views/communication.js:586
 #: frappe/public/js/frappe/views/interaction.js:159
 msgid "Add Attachment"
-msgstr "Dodaj Prilog"
+msgstr "Dodaj Privitak"
 
 #. Label of a Check field in DocType 'Web Page Block'
 #: frappe/website/doctype/web_page_block/web_page_block.json
 msgid "Add Background Image"
-msgstr ""
+msgstr "Dodaj Pozadinsku Sliku"
 
 #. Title of an Onboarding Step
 #: frappe/website/onboarding_step/add_blog_category/add_blog_category.json
 msgid "Add Blog Category"
-msgstr ""
+msgstr "Dodaj Kategoriju Bloga"
 
 #. Label of a Check field in DocType 'Web Page Block'
 #: frappe/website/doctype/web_page_block/web_page_block.json
 msgid "Add Border at Bottom"
-msgstr ""
+msgstr "Dodaj Obrub na Dno"
 
 #. Label of a Check field in DocType 'Web Page Block'
 #: frappe/website/doctype/web_page_block/web_page_block.json
 msgid "Add Border at Top"
-msgstr ""
+msgstr "Dodaj Obrub na Vrh"
 
 #: frappe/desk/doctype/number_card/number_card.js:36
 msgid "Add Card to Dashboard"
-msgstr ""
+msgstr "Dodaj Karticu na Nadzornu Ploču"
 
 #: frappe/public/js/frappe/views/reports/query_report.js:210
 msgid "Add Chart to Dashboard"
-msgstr ""
+msgstr "Dodaj Grafikon na Nadzornu Ploču"
 
 #: frappe/public/js/frappe/views/treeview.js:267
 msgid "Add Child"
-msgstr ""
+msgstr "Dodaj Podređeni"
 
 #: frappe/public/js/frappe/views/kanban/kanban_board.html:4
 #: frappe/public/js/frappe/views/reports/query_report.js:1694
@@ -1055,112 +1056,112 @@ msgstr ""
 #: frappe/public/js/frappe/views/reports/report_view.js:350
 #: frappe/public/js/print_format_builder/Field.vue:112
 msgid "Add Column"
-msgstr ""
+msgstr "Dodaj Stupac"
 
 #: frappe/core/doctype/communication/communication.js:127
 msgid "Add Contact"
-msgstr ""
+msgstr "Dodaj Kontakt"
 
 #: frappe/desk/doctype/event/event.js:38
 msgid "Add Contacts"
-msgstr ""
+msgstr "Dodaj Kontakte"
 
 #. Label of a Check field in DocType 'Web Page Block'
 #: frappe/website/doctype/web_page_block/web_page_block.json
 msgid "Add Container"
-msgstr ""
+msgstr "Dodaj Spremnik"
 
 #. Label of a Button field in DocType 'Web Page'
 #: frappe/website/doctype/web_page/web_page.json
 msgid "Add Custom Tags"
-msgstr ""
+msgstr "Dodaj Prilagođene Oznake"
 
 #: frappe/public/js/frappe/widgets/widget_dialog.js:159
 #: frappe/public/js/frappe/widgets/widget_dialog.js:688
 msgid "Add Filters"
-msgstr ""
+msgstr "Dodaj Filtere"
 
 #. Label of a Check field in DocType 'Web Page Block'
 #: frappe/website/doctype/web_page_block/web_page_block.json
 msgid "Add Gray Background"
-msgstr ""
+msgstr "Dodaj Sivu Pozadinu"
 
 #: frappe/public/js/frappe/ui/group_by/group_by.js:230
 #: frappe/public/js/frappe/ui/group_by/group_by.js:418
 msgid "Add Group"
-msgstr ""
+msgstr "Dodaj Grupu"
 
 #: frappe/core/doctype/recorder/recorder.js:30
 msgid "Add Indexes"
-msgstr ""
+msgstr "Dodaj Indekse"
 
 #: frappe/public/js/frappe/form/grid.js:63
 msgid "Add Multiple"
-msgstr ""
+msgstr "Dodaj Više"
 
 #: frappe/core/page/permission_manager/permission_manager.js:438
 msgid "Add New Permission Rule"
-msgstr ""
+msgstr "Dodaj Novo Pravilo Dopuštenja"
 
 #: frappe/desk/doctype/event/event.js:35 frappe/desk/doctype/event/event.js:42
 msgid "Add Participants"
-msgstr ""
+msgstr "Dodajte Sudionike"
 
 #. Label of a Check field in DocType 'Email Group'
 #: frappe/email/doctype/email_group/email_group.json
 msgid "Add Query Parameters"
-msgstr ""
+msgstr "Dodaj Parametre Upita"
 
 #: frappe/public/js/frappe/form/sidebar/review.js:45
 msgid "Add Review"
-msgstr ""
+msgstr "Dodaj Recenziju"
 
 #: frappe/core/doctype/user/user.py:760
 msgid "Add Roles"
-msgstr ""
+msgstr "Dodaj Uloge"
 
 #: frappe/public/js/frappe/form/grid.js:63
 msgid "Add Row"
-msgstr ""
+msgstr "Dodaj Red"
 
 #. Label of a Check field in DocType 'Email Account'
 #: frappe/email/doctype/email_account/email_account.json
 #: frappe/public/js/frappe/views/communication.js:121
 msgid "Add Signature"
-msgstr ""
+msgstr "Dodaj Potpis"
 
 #. Label of a Check field in DocType 'Web Page Block'
 #: frappe/website/doctype/web_page_block/web_page_block.json
 msgid "Add Space at Bottom"
-msgstr ""
+msgstr "Dodaj Razmak na Dnu"
 
 #. Label of a Check field in DocType 'Web Page Block'
 #: frappe/website/doctype/web_page_block/web_page_block.json
 msgid "Add Space at Top"
-msgstr ""
+msgstr "Dodaj Razmak na Vrh"
 
 #: frappe/email/doctype/email_group/email_group.js:38
 #: frappe/email/doctype/email_group/email_group.js:59
 msgid "Add Subscribers"
-msgstr ""
+msgstr "Dodaj Pretplatnike"
 
 #: frappe/public/js/frappe/list/bulk_operations.js:425
 msgid "Add Tags"
-msgstr ""
+msgstr "Dodaj Oznake"
 
 #: frappe/public/js/frappe/list/list_view.js:1925
 msgctxt "Button in list view actions menu"
 msgid "Add Tags"
-msgstr ""
+msgstr "Dodaj Oznake"
 
 #: frappe/public/js/frappe/views/communication.js:418
 msgid "Add Template"
-msgstr ""
+msgstr "Dodaj Predložak"
 
 #. Label of a Check field in DocType 'Report'
 #: frappe/core/doctype/report/report.json
 msgid "Add Total Row"
-msgstr ""
+msgstr "Dodaj Ukupan Broj Redova"
 
 #. Label of a Check field in DocType 'Email Queue'
 #: frappe/email/doctype/email_queue/email_queue.json
@@ -1169,7 +1170,7 @@ msgstr ""
 
 #: frappe/core/doctype/user_permission/user_permission_list.js:6
 msgid "Add User Permissions"
-msgstr ""
+msgstr "Dodaj Korisnička Dopuštenja"
 
 #. Label of a Check field in DocType 'Event'
 #: frappe/desk/doctype/event/event.json
@@ -1178,90 +1179,90 @@ msgstr ""
 
 #: frappe/public/js/frappe/ui/filters/filter_list.js:298
 msgid "Add a Filter"
-msgstr ""
+msgstr "Dodaj Filter"
 
 #: frappe/core/page/permission_manager/permission_manager_help.html:9
 msgid "Add a New Role"
-msgstr ""
+msgstr "Dodaj Novu Ulogu"
 
 #: frappe/public/js/frappe/form/form_tour.js:211
 msgid "Add a Row"
-msgstr ""
+msgstr "Dodaj Red"
 
 #: frappe/templates/includes/comments/comments.html:30
 #: frappe/templates/includes/comments/comments.html:47
 msgid "Add a comment"
-msgstr ""
+msgstr "Dodaj Komentar"
 
 #: frappe/printing/page/print_format_builder/print_format_builder_layout.html:28
 #: frappe/public/js/form_builder/components/Tabs.vue:192
 msgid "Add a new section"
-msgstr ""
+msgstr "Dodaj Novi Odjeljak"
 
 #: frappe/public/js/frappe/form/form.js:192
 msgid "Add a row above the current row"
-msgstr ""
+msgstr "Dodaj Red Iznad Trenutnog Reda"
 
 #: frappe/public/js/frappe/form/form.js:204
 msgid "Add a row at the bottom"
-msgstr ""
+msgstr "Dodaj Red na Dnu"
 
 #: frappe/public/js/frappe/form/form.js:200
 msgid "Add a row at the top"
-msgstr ""
+msgstr "Dodaj Red na Vrhu"
 
 #: frappe/public/js/frappe/form/form.js:196
 msgid "Add a row below the current row"
-msgstr ""
+msgstr "Dodaj Red Ispod Trenutnog Reda"
 
 #: frappe/public/js/frappe/views/dashboard/dashboard_view.js:285
 msgid "Add a {0} Chart"
-msgstr ""
+msgstr "+ {0} Grafikon"
 
 #: frappe/public/js/form_builder/components/Section.vue:271
 #: frappe/public/js/print_format_builder/PrintFormatSection.vue:115
 msgid "Add column"
-msgstr ""
+msgstr "Dodaj Stupac"
 
 #: frappe/public/js/form_builder/components/AddFieldButton.vue:9
 #: frappe/public/js/form_builder/components/AddFieldButton.vue:48
 msgid "Add field"
-msgstr ""
+msgstr "Dodaj polje"
 
 #: frappe/public/js/form_builder/components/Sidebar.vue:49
 #: frappe/public/js/form_builder/components/Tabs.vue:153
 msgid "Add new tab"
-msgstr ""
+msgstr "Dodaj novu karticu"
 
 #: frappe/public/js/print_format_builder/PrintFormatSection.vue:125
 msgid "Add page break"
-msgstr ""
+msgstr "Dodaj prijelom stranice"
 
 #: frappe/custom/doctype/client_script/client_script.js:16
 msgid "Add script for Child Table"
-msgstr ""
+msgstr "Dodajte skriptu za Podređenu Tabelu"
 
 #: frappe/public/js/print_format_builder/PrintFormatSection.vue:111
 msgid "Add section above"
-msgstr ""
+msgstr "Dodajte odjeljak iznad"
 
 #: frappe/public/js/form_builder/components/Section.vue:265
 msgid "Add section below"
-msgstr ""
+msgstr "Dodajte odjeljak ispod"
 
 #: frappe/public/js/form_builder/components/Sidebar.vue:52
 #: frappe/public/js/form_builder/components/Tabs.vue:157
 msgid "Add tab"
-msgstr ""
+msgstr "Dodaj karticu"
 
 #: frappe/public/js/frappe/utils/dashboard_utils.js:263
 #: frappe/public/js/frappe/views/reports/query_report.js:252
 msgid "Add to Dashboard"
-msgstr ""
+msgstr "Dodaj na Nadzornu Ploču"
 
 #: frappe/public/js/frappe/form/sidebar/assign_to.js:98
 msgid "Add to ToDo"
-msgstr ""
+msgstr "Dodaj u Za Uraditi"
 
 #: frappe/website/doctype/website_slideshow/website_slideshow.js:32
 msgid "Add to table"
@@ -1312,7 +1313,7 @@ msgstr ""
 #: frappe/website/doctype/contact_us_settings/contact_us_settings.json
 #: frappe/website/doctype/website_settings/website_settings.json
 msgid "Address"
-msgstr ""
+msgstr "Adresa"
 
 #. Label of a Data field in DocType 'Address'
 #. Label of a Data field in DocType 'Contact Us Settings'
@@ -1331,7 +1332,7 @@ msgstr ""
 #. Name of a DocType
 #: frappe/contacts/doctype/address_template/address_template.json
 msgid "Address Template"
-msgstr ""
+msgstr "Predložak Adrese"
 
 #. Label of a Data field in DocType 'Address'
 #. Label of a Data field in DocType 'Contact Us Settings'
@@ -1342,7 +1343,7 @@ msgstr ""
 
 #: frappe/contacts/doctype/address/address.py:72
 msgid "Address Title is mandatory."
-msgstr ""
+msgstr "Naziv Adrese je obavezan."
 
 #. Label of a Select field in DocType 'Address'
 #: frappe/contacts/doctype/address/address.json
@@ -1357,26 +1358,26 @@ msgstr ""
 
 #: frappe/contacts/doctype/address/address.py:206
 msgid "Addresses"
-msgstr ""
+msgstr "Adrese"
 
 #. Name of a report
 #: frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.json
 msgid "Addresses And Contacts"
-msgstr ""
+msgstr "Adrese i Kontakti"
 
 #. Description of a DocType
 #: frappe/custom/doctype/client_script/client_script.json
 msgid "Adds a custom client script to a DocType"
-msgstr ""
+msgstr "Dodaje prilagođenu klijentsku skriptu u DocType"
 
 #. Description of a DocType
 #: frappe/custom/doctype/custom_field/custom_field.json
 msgid "Adds a custom field to a DocType"
-msgstr ""
+msgstr "Dodaje prilagođeno polje u DocType"
 
 #: frappe/public/js/frappe/ui/toolbar/search_utils.js:552
 msgid "Administration"
-msgstr ""
+msgstr "Administracija"
 
 #. Name of a role
 #: frappe/contacts/doctype/salutation/salutation.json
@@ -1398,7 +1399,7 @@ msgstr ""
 #: frappe/desk/doctype/onboarding_step/onboarding_step.json
 #: frappe/website/doctype/website_theme/website_theme.json
 msgid "Administrator"
-msgstr ""
+msgstr "Administrator"
 
 #: frappe/core/doctype/user/user.py:1158
 msgid "Administrator Logged In"
@@ -1433,7 +1434,7 @@ msgstr ""
 #: frappe/public/js/frappe/ui/filters/filter.js:61
 #: frappe/public/js/frappe/ui/filters/filter.js:67
 msgid "After"
-msgstr ""
+msgstr "Nakon"
 
 #. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: frappe/core/doctype/server_script/server_script.json
@@ -1543,7 +1544,7 @@ msgstr ""
 #: frappe/website/doctype/personal_data_download_request/personal_data_download_request.json
 #: frappe/website/doctype/website_settings/website_settings.json
 msgid "All"
-msgstr ""
+msgstr "Sve"
 
 #. Label of a Check field in DocType 'Calendar View'
 #. Label of a Check field in DocType 'Event'
@@ -1559,11 +1560,11 @@ msgstr ""
 
 #: frappe/public/js/frappe/data_import/data_exporter.js:29
 msgid "All Records"
-msgstr ""
+msgstr "Svi Zapisi"
 
 #: frappe/public/js/frappe/form/form.js:2120
 msgid "All Submissions"
-msgstr ""
+msgstr "Svi Podnesci"
 
 #: frappe/custom/doctype/customize_form/customize_form.js:452
 msgid "All customizations will be removed. Please confirm."
@@ -1598,11 +1599,11 @@ msgstr ""
 #: frappe/integrations/doctype/social_login_key/social_login_key.json
 #: frappe/templates/includes/oauth_confirmation.html:15
 msgid "Allow"
-msgstr ""
+msgstr "Dopusti"
 
 #: frappe/website/doctype/website_settings/website_settings.py:160
 msgid "Allow API Indexing Access"
-msgstr ""
+msgstr "Dopusti API Pristup Indeksiranju"
 
 #. Label of a Check field in DocType 'DocType'
 #. Label of a Check field in DocType 'Customize Form'
@@ -2156,7 +2157,7 @@ msgstr ""
 
 #: frappe/public/js/form_builder/components/Field.vue:103
 msgid "Apply"
-msgstr ""
+msgstr "Primjeni"
 
 #: frappe/public/js/frappe/list/list_view.js:1910
 msgctxt "Button in list view actions menu"
@@ -3829,7 +3830,7 @@ msgstr ""
 #: frappe/public/js/frappe/file_uploader/FileUploader.vue:150
 #: frappe/public/js/frappe/ui/capture.js:326
 msgid "Camera"
-msgstr ""
+msgstr "Kamera"
 
 #. Label of a Link field in DocType 'Newsletter'
 #. Label of a Data field in DocType 'Web Page View'
@@ -3897,17 +3898,17 @@ msgstr ""
 #: frappe/public/js/frappe/form/reminders.js:54
 #: frappe/social/doctype/energy_point_rule/energy_point_rule.json
 msgid "Cancel"
-msgstr ""
+msgstr "Otkaži"
 
 #: frappe/public/js/frappe/list/list_view.js:1980
 msgctxt "Button in list view actions menu"
 msgid "Cancel"
-msgstr ""
+msgstr "Otkaži"
 
 #: frappe/public/js/frappe/ui/messages.js:68
 msgctxt "Secondary button in warning dialog"
 msgid "Cancel"
-msgstr ""
+msgstr "Otkaži"
 
 #: frappe/public/js/frappe/form/form.js:953
 msgid "Cancel All"
@@ -4181,7 +4182,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/ui/capture.js:286
 msgid "Capture"
-msgstr ""
+msgstr "Uhvati"
 
 #. Label of a Link field in DocType 'Number Card Link'
 #: frappe/desk/doctype/number_card_link/number_card_link.json
@@ -4492,7 +4493,7 @@ msgstr ""
 #: frappe/core/doctype/recorder/recorder_list.js:12
 #: frappe/public/js/frappe/form/controls/attach.js:16
 msgid "Clear"
-msgstr ""
+msgstr "Očisti"
 
 #: frappe/public/js/frappe/views/communication.js:423
 msgid "Clear & Add Template"
@@ -4698,7 +4699,7 @@ msgstr ""
 #: frappe/public/js/frappe/ui/messages.js:246
 #: frappe/website/js/bootstrap-4.js:24
 msgid "Close"
-msgstr ""
+msgstr "Zatvori"
 
 #. Label of a Code field in DocType 'Assignment Rule'
 #: frappe/automation/doctype/assignment_rule/assignment_rule.json
@@ -4751,12 +4752,12 @@ msgstr ""
 #: frappe/public/js/frappe/form/form_tour.js:276
 #: frappe/public/js/frappe/widgets/base_widget.js:159
 msgid "Collapse"
-msgstr ""
+msgstr "Sklopi"
 
 #: frappe/public/js/frappe/form/controls/code.js:179
 msgctxt "Shrink code field."
 msgid "Collapse"
-msgstr ""
+msgstr "Sklopi"
 
 #: frappe/public/js/frappe/views/reports/query_report.js:1979
 #: frappe/public/js/frappe/views/treeview.js:110
@@ -4770,7 +4771,7 @@ msgstr ""
 #: frappe/custom/doctype/custom_field/custom_field.json
 #: frappe/custom/doctype/customize_form_field/customize_form_field.json
 msgid "Collapsible"
-msgstr ""
+msgstr "Sklopivo"
 
 #. Label of a Code field in DocType 'Custom Field'
 #. Label of a Code field in DocType 'Customize Form Field'
@@ -8219,7 +8220,7 @@ msgstr ""
 #: frappe/printing/page/print_format_builder/print_format_builder.js:602
 #: frappe/printing/page/print_format_builder/print_format_builder_layout.html:8
 msgid "Edit Heading"
-msgstr ""
+msgstr "Uredi Naslov"
 
 #: frappe/public/js/print_format_builder/LetterHeadEditor.vue:52
 msgid "Edit Letter Head"
@@ -11453,7 +11454,7 @@ msgstr ""
 #: frappe/website/doctype/contact_us_settings/contact_us_settings.json
 #: frappe/website/doctype/website_slideshow_item/website_slideshow_item.json
 msgid "Heading"
-msgstr ""
+msgstr "Naslov"
 
 #. Option for the 'Type' (Select) field in DocType 'Dashboard Chart'
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -18585,7 +18586,7 @@ msgstr ""
 
 #: frappe/core/doctype/data_export/exporter.py:184
 msgid "Please do not change the template headings."
-msgstr ""
+msgstr "Ne mijenjaj Naslove Predložaka."
 
 #: frappe/printing/doctype/print_format/print_format.js:18
 msgid "Please duplicate this to make changes"
@@ -22140,7 +22141,7 @@ msgstr ""
 
 #: frappe/printing/page/print_format_builder/print_format_builder.js:421
 msgid "Section Heading"
-msgstr ""
+msgstr "Naslov Odjeljka"
 
 #. Label of a Data field in DocType 'Web Page Block'
 #: frappe/website/doctype/web_page_block/web_page_block.json

--- a/frappe/locale/pl.po
+++ b/frappe/locale/pl.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: developers@frappe.io\n"
 "POT-Creation-Date: 2025-02-24 14:51+0000\n"
-"PO-Revision-Date: 2025-03-10 18:54\n"
+"PO-Revision-Date: 2025-03-11 19:35\n"
 "Last-Translator: developers@frappe.io\n"
 "Language-Team: Polish\n"
 "MIME-Version: 1.0\n"
@@ -76,7 +76,7 @@ msgstr ""
 
 #: frappe/core/doctype/doctype/doctype.py:1316
 msgid "'In Global Search' not allowed for type {0} in row {1}"
-msgstr ""
+msgstr "'In Global Search' niedozwolone dla typu {0} w wierszu {1}"
 
 #: frappe/public/js/form_builder/store.js:198
 msgid "'In List View' is not allowed for field {0} of type {1}"
@@ -84,7 +84,7 @@ msgstr ""
 
 #: frappe/custom/doctype/customize_form/customize_form.py:359
 msgid "'In List View' not allowed for type {0} in row {1}"
-msgstr ""
+msgstr "Pole 'W widoku listy' nie jest dozwolone dla typu {0} w lini {1}"
 
 #: frappe/automation/doctype/auto_repeat/auto_repeat.py:156
 msgid "'Recipients' not specified"
@@ -605,7 +605,7 @@ msgstr ""
 #. Description of the 'Scopes' (Text) field in DocType 'OAuth Client'
 #: frappe/integrations/doctype/oauth_client/oauth_client.json
 msgid "A list of resources which the Client App will have access to after the user allows it.<br> e.g. project"
-msgstr ""
+msgstr "Wykaz środków, które App klient będzie miał dostęp do gdy użytkownik na to pozwala. <br> np projekt"
 
 #: frappe/templates/emails/new_user.html:5
 msgid "A new account has been created for you at {0}"
@@ -613,7 +613,7 @@ msgstr "Nowe konto zostało stworzone dla Ciebie na {0}"
 
 #: frappe/automation/doctype/auto_repeat/auto_repeat.py:395
 msgid "A recurring {0} {1} has been created for you via Auto Repeat {2}."
-msgstr ""
+msgstr "Cykliczne {0} {1} zostało dla Ciebie stworzone przez Auto Repeat {2}."
 
 #. Description of the 'Symbol' (Data) field in DocType 'Currency'
 #: frappe/geo/doctype/currency/currency.json
@@ -760,7 +760,7 @@ msgstr ""
 #: frappe/website/doctype/about_us_settings/about_us_settings.json
 #: frappe/website/workspace/website/website.json
 msgid "About Us Settings"
-msgstr ""
+msgstr "O Nas - Ustawienia"
 
 #. Name of a DocType
 #: frappe/website/doctype/about_us_team_member/about_us_team_member.json
@@ -807,12 +807,12 @@ msgstr "Dziennik dostępu"
 #: frappe/integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
 #: frappe/integrations/doctype/token_cache/token_cache.json
 msgid "Access Token"
-msgstr ""
+msgstr "Dostęp za pomocą Tokenu"
 
 #. Label of a Data field in DocType 'Social Login Key'
 #: frappe/integrations/doctype/social_login_key/social_login_key.json
 msgid "Access Token URL"
-msgstr ""
+msgstr "Uzyskaj dostęp do adresu URL tokenu"
 
 #: frappe/auth.py:483
 msgid "Access not allowed from this IP Address"
@@ -1046,7 +1046,7 @@ msgstr "Dodaj wykres do pulpitu nawigacyjnego"
 
 #: frappe/public/js/frappe/views/treeview.js:267
 msgid "Add Child"
-msgstr ""
+msgstr "Dodaj pod-element"
 
 #: frappe/public/js/frappe/views/kanban/kanban_board.html:4
 #: frappe/public/js/frappe/views/reports/query_report.js:1694
@@ -1580,7 +1580,7 @@ msgstr ""
 
 #: frappe/utils/password_strength.py:179
 msgid "All-uppercase is almost as easy to guess as all-lowercase."
-msgstr ""
+msgstr "All-wielka jest prawie tak samo łatwe do odgadnięcia, jak wszystko-małe."
 
 #. Label of a Link field in DocType 'ToDo'
 #: frappe/desk/doctype/todo/todo.json
@@ -1659,7 +1659,7 @@ msgstr "Zezwól na dostęp do kontaktów Google"
 
 #: frappe/integrations/doctype/google_drive/google_drive.py:52
 msgid "Allow Google Drive Access"
-msgstr ""
+msgstr "Pozwól na dostęp do Google Drive"
 
 #. Label of a Check field in DocType 'Server Script'
 #: frappe/core/doctype/server_script/server_script.json
@@ -1755,7 +1755,7 @@ msgstr "Zezwól na zmianę nazwy"
 #: frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.json
 #: frappe/desk/doctype/module_onboarding/module_onboarding.json
 msgid "Allow Roles"
-msgstr ""
+msgstr "Pozostawić Roles"
 
 #. Label of a Check field in DocType 'Workflow Transition'
 #: frappe/workflow/doctype/workflow_transition/workflow_transition.json
@@ -1976,7 +1976,7 @@ msgstr "Wystąpił błąd podczas ustawiania domyślnych ustawień sesji"
 #. Description of the 'FavIcon' (Attach) field in DocType 'Website Settings'
 #: frappe/website/doctype/website_settings/website_settings.json
 msgid "An icon file with .ico extension. Should be 16 x 16 px. Generated using a favicon generator. [favicon-generator.org]"
-msgstr ""
+msgstr "Plik ikona z .ico rozszerzenia. Powinno być 16 x 16 px. Generowane przy użyciu generator favicon. [favicon-generator.org]"
 
 #: frappe/templates/includes/oauth_confirmation.html:35
 msgid "An unexpected error occurred while authorizing {}."
@@ -2027,7 +2027,7 @@ msgstr "Inny {0} z nazwą {1} istnieje, wybierz inną nazwę"
 #. Description of the 'Raw Commands' (Code) field in DocType 'Print Format'
 #: frappe/printing/doctype/print_format/print_format.json
 msgid "Any string-based printer languages can be used. Writing raw commands requires knowledge of the printer's native language provided by the printer manufacturer. Please refer to the developer manual provided by the printer manufacturer on how to write their native commands. These commands are rendered on the server side using the Jinja Templating Language."
-msgstr ""
+msgstr "Można używać dowolnych języków drukarki opartych na łańcuchach. Pisanie surowych poleceń wymaga znajomości języka ojczystego drukarki dostarczonego przez producenta drukarki. Zapoznaj się z podręcznikiem programisty dostarczonym przez producenta drukarki na temat pisania własnych poleceń. Te polecenia są renderowane po stronie serwera przy użyciu języka Jinja Templating."
 
 #: frappe/core/page/permission_manager/permission_manager_help.html:36
 msgid "Apart from System Manager, roles with Set User Permissions right can set permissions for other users for that Document Type."
@@ -2056,12 +2056,12 @@ msgstr ""
 #. Label of a Data field in DocType 'OAuth Client'
 #: frappe/integrations/doctype/oauth_client/oauth_client.json
 msgid "App Client ID"
-msgstr ""
+msgstr "App ID klienta"
 
 #. Label of a Data field in DocType 'OAuth Client'
 #: frappe/integrations/doctype/oauth_client/oauth_client.json
 msgid "App Client Secret"
-msgstr ""
+msgstr "Tajny Klient App"
 
 #. Label of a Data field in DocType 'Google Settings'
 #: frappe/integrations/doctype/google_settings/google_settings.json
@@ -2084,12 +2084,12 @@ msgstr ""
 #: frappe/integrations/doctype/oauth_client/oauth_client.json
 #: frappe/website/doctype/website_settings/website_settings.json
 msgid "App Name"
-msgstr ""
+msgstr "Nazwa App"
 
 #. Label of a Password field in DocType 'Dropbox Settings'
 #: frappe/integrations/doctype/dropbox_settings/dropbox_settings.json
 msgid "App Secret Key"
-msgstr ""
+msgstr "App klucz tajny"
 
 #: frappe/modules/utils.py:280
 msgid "App not found for module: {0}"
@@ -2097,7 +2097,7 @@ msgstr ""
 
 #: frappe/__init__.py:1720
 msgid "App {0} is not installed"
-msgstr ""
+msgstr "App {0} nie jest zainstalowany"
 
 #. Label of a Check field in DocType 'Email Account'
 #. Label of a Check field in DocType 'Email Domain'
@@ -2294,7 +2294,7 @@ msgstr "Czy na pewno chcesz wygenerować nowy raport?"
 
 #: frappe/public/js/billing.bundle.js:37
 msgid "Are you sure you want to login to Frappe Cloud dashboard?"
-msgstr ""
+msgstr "Czy na pewno chcesz zalogować się do panelu Frappe Cloud?"
 
 #: frappe/public/js/frappe/form/toolbar.js:111
 msgid "Are you sure you want to merge {0} with {1}?"
@@ -2617,7 +2617,7 @@ msgstr "Link do załącznika"
 #: frappe/core/doctype/comment/comment.json
 #: frappe/core/doctype/communication/communication.json
 msgid "Attachment Removed"
-msgstr ""
+msgstr "Usunięto Attachment"
 
 #. Label of a Code field in DocType 'Email Queue'
 #. Label of a Table field in DocType 'Newsletter'
@@ -2636,7 +2636,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/form/print_utils.js:107
 msgid "Attempting to launch QZ Tray..."
-msgstr ""
+msgstr "Próba uruchomienia QZ Tray ..."
 
 #. Label of a Table field in DocType 'Newsletter'
 #: frappe/email/doctype/newsletter/newsletter.json
@@ -2674,7 +2674,7 @@ msgstr "Poświadczenie"
 
 #: frappe/www/qrcode.html:19
 msgid "Authentication Apps you can use are: "
-msgstr ""
+msgstr "Aplikacja uwierzytelniania, którą możesz użyć to:"
 
 #: frappe/email/doctype/email_account/email_account.py:307
 msgid "Authentication failed while receiving emails from Email Account: {0}."
@@ -2811,7 +2811,7 @@ msgstr "Wiadomość automatycznej odpowiedzi"
 
 #: frappe/automation/doctype/assignment_rule/assignment_rule.py:177
 msgid "Auto assignment failed: {0}"
-msgstr ""
+msgstr "Automatyczne przypisanie nie powiodło się: {0}"
 
 #. Label of a Check field in DocType 'User'
 #: frappe/core/doctype/user/user.json
@@ -2917,7 +2917,7 @@ msgstr "Średnia z {0}"
 
 #: frappe/utils/password_strength.py:124
 msgid "Avoid dates and years that are associated with you."
-msgstr ""
+msgstr "Unikać dat i lat, które są powiązane ze tobą"
 
 #: frappe/utils/password_strength.py:118
 msgid "Avoid recent years."
@@ -3442,12 +3442,12 @@ msgstr ""
 
 #: frappe/printing/page/print_format_builder/print_format_builder.js:126
 msgid "Both DocType and Name required"
-msgstr ""
+msgstr "Zarówno DocType i Imię wymagane"
 
 #: frappe/templates/includes/login/login.js:25
 #: frappe/templates/includes/login/login.js:97
 msgid "Both login and password required"
-msgstr ""
+msgstr "Zarówno login i hasło wymagane"
 
 #. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #: frappe/desk/doctype/form_tour_step/form_tour_step.json
@@ -3685,12 +3685,12 @@ msgstr ""
 #. Label of a Check field in DocType 'User'
 #: frappe/core/doctype/user/user.json
 msgid "Bypass Restricted IP Address Check If Two Factor Auth Enabled"
-msgstr ""
+msgstr "Pomiń ograniczony adres IP Sprawdź, czy uwierzytelnianie dwuskładnikowe jest włączone"
 
 #. Label of a Check field in DocType 'System Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
 msgid "Bypass Two Factor Auth for users who login from restricted IP Address"
-msgstr ""
+msgstr "Ominięcie dwóch czynników Auth dla użytkowników logujących się z ograniczonego adresu IP"
 
 #. Label of a Check field in DocType 'System Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
@@ -4116,7 +4116,7 @@ msgstr ""
 
 #: frappe/printing/page/print/print.js:844
 msgid "Cannot have multiple printers mapped to a single print format."
-msgstr ""
+msgstr "Nie można zmapować wielu drukarek do jednego formatu wydruku."
 
 #: frappe/model/document.py:979
 msgid "Cannot link cancelled document: {0}"
@@ -4165,7 +4165,7 @@ msgstr "Nie można zaktualizować {0}"
 
 #: frappe/model/db_query.py:1115
 msgid "Cannot use sub-query in order by"
-msgstr ""
+msgstr "Nie można używać sub-zapytanie w kolejności"
 
 #: frappe/model/db_query.py:1133
 msgid "Cannot use {0} in order/group by"
@@ -4237,7 +4237,7 @@ msgstr "Środek"
 
 #: frappe/core/page/permission_manager/permission_manager_help.html:16
 msgid "Certain documents, like an Invoice, should not be changed once final. The final state for such documents is called Submitted. You can restrict which roles can Submit."
-msgstr ""
+msgstr "Niektóre dokumenty, takie jak faktury, powinny umożliwiać zmiany ich treści. Ostateczną wersję takich dokumentów otrzymamy po Zatwierdzeniu. Możesz decydować, kto posiada uprawnienia do Zatwierdzania."
 
 #: frappe/core/report/transaction_log_report/transaction_log_report.py:82
 msgid "Chain Integrity"
@@ -4265,7 +4265,7 @@ msgstr ""
 #. Label of a Data field in DocType 'Customize Form'
 #: frappe/custom/doctype/customize_form/customize_form.json
 msgid "Change Label (via Custom Translation)"
-msgstr ""
+msgstr "Zmień etykietę (poprzez niestandardowe Translation)"
 
 #: frappe/public/js/print_format_builder/LetterHeadEditor.vue:45
 #: frappe/public/js/print_format_builder/LetterHeadEditor.vue:141
@@ -4429,7 +4429,7 @@ msgstr "Zaznaczenie tego spowoduje opublikowanie strony w Twojej witrynie i będ
 
 #: frappe/website/doctype/web_page/web_page.js:104
 msgid "Checking this will show a text area where you can write custom javascript that will run on this page."
-msgstr ""
+msgstr "Zaznaczenie tego spowoduje wyświetlenie obszaru tekstowego, w którym możesz napisać niestandardowy skrypt javascript, który będzie działał na tej stronie."
 
 #. Label of a Data field in DocType 'Transaction Log'
 #: frappe/core/doctype/transaction_log/transaction_log.json
@@ -4538,7 +4538,7 @@ msgstr "Usunięcie daty zakończenia, ponieważ nie może być w przeszłości d
 
 #: frappe/public/js/frappe/views/dashboard/dashboard_view.js:193
 msgid "Click On Customize to add your first widget"
-msgstr ""
+msgstr "Kliknij opcję Dostosuj, aby dodać pierwszy widżet"
 
 #: frappe/website/doctype/web_form/templates/web_form.html:144
 msgid "Click here"
@@ -4574,7 +4574,7 @@ msgstr "Kliknij poniższy link, aby zatwierdzić wniosek"
 
 #: frappe/templates/emails/new_user.html:7
 msgid "Click on the link below to complete your registration and set a new password"
-msgstr ""
+msgstr "Kliknij na link poniżej, aby dokończyć rejestrację i ustawić nowe hasło"
 
 #: frappe/templates/emails/download_data.html:3
 msgid "Click on the link below to download your data"
@@ -4593,7 +4593,7 @@ msgstr "Kliknij ikonę kłódki, aby przełączyć tryb publiczny / prywatny"
 #: frappe/integrations/doctype/google_drive/google_drive.py:53
 #: frappe/website/doctype/website_settings/website_settings.py:161
 msgid "Click on {0} to generate Refresh Token."
-msgstr ""
+msgstr "Kliknij {0}, aby wygenerować Refresh Token."
 
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.js:315
 #: frappe/desk/doctype/number_card/number_card.js:215
@@ -4897,7 +4897,7 @@ msgstr "Kolumny na podstawie"
 
 #: frappe/integrations/doctype/oauth_client/oauth_client.py:48
 msgid "Combination of Grant Type (<code>{0}</code>) and Response Type (<code>{1}</code>) not allowed"
-msgstr ""
+msgstr "Kombinacja typu grantu ( <code>{0}</code> ) i typu odpowiedzi ( <code>{1}</code> ) jest niedozwolona"
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: frappe/printing/doctype/print_settings/print_settings.json
@@ -5381,7 +5381,7 @@ msgstr "Treść (Markdown)"
 #. Label of a Data field in DocType 'File'
 #: frappe/core/doctype/file/file.json
 msgid "Content Hash"
-msgstr ""
+msgstr "Hash zawartości"
 
 #. Label of a Select field in DocType 'Newsletter'
 #. Label of a Select field in DocType 'Blog Post'
@@ -5490,7 +5490,7 @@ msgstr "Nie znaleziono: {0}"
 
 #: frappe/core/doctype/data_import/importer.py:895
 msgid "Could not map column {0} to field {1}"
-msgstr ""
+msgstr "Nie można zmapować kolumny {0} do pola {1}"
 
 #: frappe/desk/page/setup_wizard/setup_wizard.js:222
 msgid "Could not start up: "
@@ -5762,7 +5762,7 @@ msgstr ""
 #: frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
 #: frappe/core/doctype/server_script/server_script.json
 msgid "Cron Format"
-msgstr ""
+msgstr "Format Cron"
 
 #: frappe/core/doctype/scheduled_job_type/scheduled_job_type.py:61
 msgid "Cron format is required for job types with Cron frequency."
@@ -6043,7 +6043,7 @@ msgstr "Niestandardowy SCSS"
 #. Label of a Section Break field in DocType 'Portal Settings'
 #: frappe/website/doctype/portal_settings/portal_settings.json
 msgid "Custom Sidebar Menu"
-msgstr ""
+msgstr "Niestandardowe Sidebar Menu"
 
 #. Label of a Link in the Build Workspace
 #: frappe/core/workspace/build/build.json
@@ -7145,7 +7145,7 @@ msgstr "Wyłącz rejestrację w swojej witrynie"
 #. Label of a Check field in DocType 'System Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
 msgid "Disable Standard Email Footer"
-msgstr ""
+msgstr "Wyłącz Standardowy Email stopka"
 
 #. Label of a Check field in DocType 'System Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
@@ -7295,7 +7295,7 @@ msgstr ""
 #. Label of a Section Break field in DocType 'Webhook'
 #: frappe/integrations/doctype/webhook/webhook.json
 msgid "Doc Events"
-msgstr ""
+msgstr "Doc Wydarzenia"
 
 #. Label of a Select field in DocType 'Workflow Document State'
 #: frappe/workflow/doctype/workflow_document_state/workflow_document_state.json
@@ -7479,7 +7479,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/list/bulk_operations.js:3
 msgid "Doctype required"
-msgstr ""
+msgstr "Wymagany Doctype"
 
 #: frappe/public/js/frappe/views/workspace/workspace.js:1348
 msgid "Doctype with same route already exist. Please choose different title."
@@ -7944,7 +7944,7 @@ msgstr ""
 
 #: frappe/desk/page/setup_wizard/install_fixtures.py:47
 msgid "Dr"
-msgstr ""
+msgstr "Wn"
 
 #: frappe/public/js/frappe/model/indicator.js:73
 #: frappe/public/js/frappe/ui/filters/filter.js:531
@@ -7986,7 +7986,7 @@ msgstr "Upuść pliki tutaj"
 #. Label of a Password field in DocType 'Dropbox Settings'
 #: frappe/integrations/doctype/dropbox_settings/dropbox_settings.json
 msgid "Dropbox Access Token"
-msgstr ""
+msgstr "Token dostępu do Dropboxa"
 
 #. Label of a Password field in DocType 'Dropbox Settings'
 #: frappe/integrations/doctype/dropbox_settings/dropbox_settings.json
@@ -8032,11 +8032,11 @@ msgstr ""
 
 #: frappe/public/js/frappe/list/list_filter.js:137
 msgid "Duplicate Filter Name"
-msgstr ""
+msgstr "Zduplikowana nazwa filtra"
 
 #: frappe/model/base_document.py:600 frappe/model/rename_doc.py:111
 msgid "Duplicate Name"
-msgstr ""
+msgstr "Zduplikowana nazwa"
 
 #: frappe/public/js/frappe/views/workspace/workspace.js:592
 #: frappe/public/js/frappe/views/workspace/workspace.js:854
@@ -8418,7 +8418,7 @@ msgstr "Domena poczty elektronicznej"
 #. Name of a DocType
 #: frappe/email/doctype/email_flag_queue/email_flag_queue.json
 msgid "Email Flag Queue"
-msgstr ""
+msgstr "Email Oznacz Queue"
 
 #. Label of a Small Text field in DocType 'System Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
@@ -8434,7 +8434,7 @@ msgstr "Stopka dla e-maila"
 #: frappe/email/doctype/email_group_member/email_group_member.json
 #: frappe/email/doctype/newsletter_email_group/newsletter_email_group.json
 msgid "Email Group"
-msgstr ""
+msgstr "Grupa email"
 
 #. Linked DocType in Email Group's connections
 #. Name of a DocType
@@ -8471,7 +8471,7 @@ msgstr "Skrzynka odbiorcza e-mail"
 #. Name of a DocType
 #: frappe/email/doctype/email_queue/email_queue.json
 msgid "Email Queue"
-msgstr ""
+msgstr "Kolejka email"
 
 #. Name of a DocType
 #: frappe/email/doctype/email_queue_recipient/email_queue_recipient.json
@@ -8485,7 +8485,7 @@ msgstr ""
 #. Description of a DocType
 #: frappe/email/doctype/email_queue/email_queue.json
 msgid "Email Queue records."
-msgstr ""
+msgstr "Zapisy email kolejce."
 
 #. Label of a HTML field in DocType 'Email Template'
 #: frappe/email/doctype/email_template/email_template.json
@@ -8500,7 +8500,7 @@ msgstr ""
 #. Name of a DocType
 #: frappe/email/doctype/email_rule/email_rule.json
 msgid "Email Rule"
-msgstr ""
+msgstr "Zasada email"
 
 #. Label of a Check field in DocType 'Newsletter'
 #. Label of a Check field in DocType 'Blog Post'
@@ -8533,7 +8533,7 @@ msgstr "Sygnatura wiadomości e-mail"
 #. Label of a Select field in DocType 'Communication'
 #: frappe/core/doctype/communication/communication.json
 msgid "Email Status"
-msgstr ""
+msgstr "Stan email"
 
 #. Label of a Select field in DocType 'Email Account'
 #: frappe/email/doctype/email_account/email_account.json
@@ -8567,15 +8567,15 @@ msgstr "E-mail Wypisz się"
 
 #: frappe/core/doctype/communication/communication.js:342
 msgid "Email has been marked as spam"
-msgstr ""
+msgstr "Email został oznaczony jako spam"
 
 #: frappe/core/doctype/communication/communication.js:355
 msgid "Email has been moved to trash"
-msgstr ""
+msgstr "Email został przeniesiony do kosza"
 
 #: frappe/public/js/frappe/views/communication.js:807
 msgid "Email not sent to {0} (unsubscribed / disabled)"
-msgstr ""
+msgstr "E-mail nie wysłany do {0} (wypisany / wyłączony)"
 
 #: frappe/utils/oauth.py:164
 msgid "Email not verified with {0}"
@@ -8592,7 +8592,7 @@ msgstr ""
 
 #: frappe/email/queue.py:137
 msgid "Emails are muted"
-msgstr ""
+msgstr "Email wyciszony"
 
 #. Description of the 'Send Email Alert' (Check) field in DocType 'Workflow'
 #: frappe/workflow/doctype/workflow/workflow.json
@@ -8667,12 +8667,12 @@ msgstr ""
 #: frappe/email/doctype/email_account/email_account.json
 #: frappe/email/doctype/email_account/email_account.py:197
 msgid "Enable Incoming"
-msgstr ""
+msgstr "Włącz Incoming"
 
 #. Label of a Check field in DocType 'System Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
 msgid "Enable Onboarding"
-msgstr ""
+msgstr "Włącz onboarding"
 
 #. Label of a Check field in DocType 'User Email'
 #. Label of a Check field in DocType 'Email Account'
@@ -9078,7 +9078,7 @@ msgstr "Komunikat o błędzie"
 
 #: frappe/public/js/frappe/form/print_utils.js:128
 msgid "Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a target=\"_blank\" href=\"https://qz.io/download/\">Click here to Download and install QZ Tray</a>.<br> <a target=\"_blank\" href=\"https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing\">Click here to learn more about Raw Printing</a>."
-msgstr ""
+msgstr "Błąd połączenia z aplikacją QZ Tray ... <br><br> Musisz mieć zainstalowaną i uruchomioną aplikację QZ Tray, aby móc korzystać z funkcji Raw Print. <br><br> <a href=\"https://qz.io/download/\" target=\"_blank\">Kliknij tutaj, aby pobrać i zainstalować tacę QZ</a> . <br> <a href=\"https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing\" target=\"_blank\">Kliknij tutaj, aby dowiedzieć się więcej o drukowaniu surowym</a> ."
 
 #: frappe/email/doctype/email_domain/email_domain.py:32
 msgid "Error connecting via IMAP/POP3: {e}"
@@ -9201,7 +9201,7 @@ msgstr "Wszyscy"
 #. Chart'
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
 msgid "Ex: \"colors\": [\"#d1d8dd\", \"#ff5858\"]"
-msgstr ""
+msgstr "Np. &quot;Kolory&quot;: [&quot;# d1d8dd&quot;, &quot;# ff5858&quot;]"
 
 #. Label of a Int field in DocType 'Recorder Query'
 #: frappe/core/doctype/recorder_query/recorder_query.json
@@ -9217,7 +9217,7 @@ msgstr "Przykład"
 #. Settings'
 #: frappe/website/doctype/portal_settings/portal_settings.json
 msgid "Example: \"/desk\""
-msgstr ""
+msgstr "Przykład: „/ desk”"
 
 #. Description of the 'Path' (Data) field in DocType 'Onboarding Step'
 #: frappe/desk/doctype/onboarding_step/onboarding_step.json
@@ -9338,7 +9338,7 @@ msgstr ""
 #. Label of a Int field in DocType 'System Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
 msgid "Expiry time of QR Code Image Page"
-msgstr ""
+msgstr "Czas wygaśnięcia strony z obrazem QR Code"
 
 #. Label of a Check field in DocType 'Custom DocPerm'
 #. Label of a Check field in DocType 'DocPerm'
@@ -9412,7 +9412,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/utils/tools.js:11
 msgid "Export not allowed. You need {0} role to export."
-msgstr ""
+msgstr "eksport nie jest dozwolony. Potrzebujesz {0} modeli żeby eksportować"
 
 #. Description of the 'Export without main header' (Check) field in DocType
 #. 'Data Export'
@@ -9436,7 +9436,7 @@ msgstr ""
 #. Label of a Data field in DocType 'Email Queue'
 #: frappe/email/doctype/email_queue/email_queue.json
 msgid "Expose Recipients"
-msgstr ""
+msgstr "Expose Odbiorcy"
 
 #. Option for the 'Naming Rule' (Select) field in DocType 'DocType'
 #. Option for the 'Naming Rule' (Select) field in DocType 'Customize Form'
@@ -9534,7 +9534,7 @@ msgstr ""
 
 #: frappe/auth.py:686
 msgid "Failed to decode token, please provide a valid base64-encoded token."
-msgstr ""
+msgstr "Nie udało się zdekodować tokena. Podaj prawidłowy token zakodowany w base64."
 
 #: frappe/utils/password.py:198
 msgid "Failed to decrypt key {0}"
@@ -9582,7 +9582,7 @@ msgstr ""
 
 #: frappe/public/js/billing.bundle.js:60
 msgid "Failed to login to Frappe Cloud. Please try again"
-msgstr ""
+msgstr "Nie udało się zalogować do Frappe Cloud. Spróbuj ponownie"
 
 #: frappe/utils/image.py:76
 msgid "Failed to optimize image: {0}"
@@ -9590,7 +9590,7 @@ msgstr ""
 
 #: frappe/integrations/frappe_providers/frappecloud_billing.py:78
 msgid "Failed to request login to Frappe Cloud"
-msgstr ""
+msgstr "Nie udało się poprosić o zalogowanie do Frappe Cloud"
 
 #: frappe/email/doctype/email_queue/email_queue.py:280
 msgid "Failed to send email with subject:"
@@ -9625,7 +9625,7 @@ msgstr ""
 #. Label of a Attach field in DocType 'Website Settings'
 #: frappe/website/doctype/website_settings/website_settings.json
 msgid "FavIcon"
-msgstr ""
+msgstr "Favicon"
 
 #. Label of a Data field in DocType 'Address'
 #: frappe/contacts/doctype/address/address.json
@@ -9711,7 +9711,7 @@ msgstr "Pole"
 
 #: frappe/core/doctype/doctype/doctype.py:411
 msgid "Field \"route\" is mandatory for Web Views"
-msgstr ""
+msgstr "Pole &quot;route&quot; jest obowiązkowe w przypadku widoków sieciowych"
 
 #: frappe/core/doctype/doctype/doctype.py:1488
 msgid "Field \"title\" is mandatory if \"Website Search Field\" is set."
@@ -9873,7 +9873,7 @@ msgstr "Pola"
 #. Label of a HTML field in DocType 'Data Export'
 #: frappe/core/doctype/data_export/data_export.json
 msgid "Fields Multicheck"
-msgstr ""
+msgstr "Pola Multicheck"
 
 #: frappe/core/doctype/file/file.py:403
 msgid "Fields `file_name` or `file_url` must be set for File"
@@ -9882,7 +9882,7 @@ msgstr ""
 #. Description of the 'Search Fields' (Data) field in DocType 'Customize Form'
 #: frappe/custom/doctype/customize_form/customize_form.json
 msgid "Fields separated by comma (,) will be included in the \"Search By\" list of Search dialog box"
-msgstr ""
+msgstr "Pola oddzielone przecinkami (,) zostaną uwzględnione w &quot;Szukaj według&quot; listy w oknie dialogowym Szukaj"
 
 #. Label of a Select field in DocType 'Report Column'
 #. Label of a Select field in DocType 'Report Filter'
@@ -10054,7 +10054,7 @@ msgstr "Filtr musi być krotką lub listą (na liście)"
 
 #: frappe/utils/data.py:1832
 msgid "Filter must have 4 values (doctype, fieldname, operator, value): {0}"
-msgstr ""
+msgstr "Filtr musi mieć 4 wartości (doctype, fieldname, operator, value): {0}"
 
 #: frappe/printing/page/print_format_builder/print_format_builder_sidebar.html:3
 msgid "Filter..."
@@ -10128,7 +10128,7 @@ msgstr ""
 #. Description of the 'Script' (Code) field in DocType 'Report'
 #: frappe/core/doctype/report/report.json
 msgid "Filters will be accessible via <code>filters</code>. <br><br>Send output as <code>result = [result]</code>, or for old style <code>data = [columns], [result]</code>"
-msgstr ""
+msgstr "Filtry będą dostępne za pośrednictwem <code>filters</code> .<br><br> Wyślij dane wyjściowe jako <code>result = [result]</code> lub dla <code>data = [columns], [result]</code> w starym stylu <code>data = [columns], [result]</code>"
 
 #: frappe/public/js/frappe/ui/filters/filter_list.js:133
 msgid "Filters {0}"
@@ -10452,7 +10452,7 @@ msgstr ""
 
 #: frappe/core/page/permission_manager/permission_manager_help.html:19
 msgid "For example if you cancel and amend INV004 it will become a new document INV004-1. This helps you to keep track of each amendment."
-msgstr ""
+msgstr "Na przykład w przypadku anulowania i zmiany INV004 stanie się nowym INV004-1 dokument. To pozwala na śledzenie każdej poprawki."
 
 #: frappe/public/js/frappe/utils/dashboard_utils.js:162
 msgid "For example:"
@@ -10476,7 +10476,7 @@ msgstr "Aby uzyskać pomoc, zobacz <a href=\"https://frappeframework.com/docs/us
 #. DocType 'Email Account'
 #: frappe/email/doctype/email_account/email_account.json
 msgid "For more information, <a class=\"text-muted\" href=\"https://erpnext.com/docs/user/manual/en/setting-up/email/linking-emails-to-document\">click here</a>."
-msgstr ""
+msgstr "Aby uzyskać więcej informacji, <a class=\"text-muted\" href=\"https://erpnext.com/docs/user/manual/en/setting-up/email/linking-emails-to-document\">kliknij tutaj</a> ."
 
 #: frappe/integrations/doctype/google_settings/google_settings.js:7
 msgid "For more information, {0}."
@@ -10625,11 +10625,11 @@ msgstr "Jednostki ułamku"
 #: frappe/www/login.html:61 frappe/www/login.html:142 frappe/www/login.py:50
 #: frappe/www/login.py:139
 msgid "Frappe"
-msgstr ""
+msgstr "Frappe"
 
 #: frappe/public/js/billing.bundle.js:125
 msgid "Frappe Cloud Login Successful"
-msgstr ""
+msgstr "Logowanie do Frappe Cloud zakończone sukcesem"
 
 #: frappe/public/js/frappe/ui/toolbar/about.js:4
 msgid "Frappe Framework"
@@ -10651,7 +10651,7 @@ msgstr ""
 
 #: frappe/website/doctype/web_page/web_page.js:92
 msgid "Frappe page builder using components"
-msgstr ""
+msgstr "Kreator stron Frappe wykorzystujący komponenty"
 
 #: frappe/public/js/frappe/file_uploader/ImageCropper.vue:112
 msgctxt "Image Cropper"
@@ -10925,7 +10925,7 @@ msgstr ""
 
 #: frappe/website/doctype/web_page/web_page.js:92
 msgid "Github flavoured markdown syntax"
-msgstr ""
+msgstr "Składnia promocji na Github"
 
 #: frappe/social/doctype/energy_point_settings/energy_point_settings.js:7
 #: frappe/social/doctype/energy_point_settings/energy_point_settings.js:14
@@ -11053,27 +11053,27 @@ msgstr ""
 
 #: frappe/integrations/doctype/google_calendar/google_calendar.py:254
 msgid "Google Calendar - Could not create Calendar for {0}, error code {1}."
-msgstr ""
+msgstr "Kalendarz Google - nie można utworzyć kalendarza dla {0}, kod błędu {1}."
 
 #: frappe/integrations/doctype/google_calendar/google_calendar.py:574
 msgid "Google Calendar - Could not delete Event {0} from Google Calendar, error code {1}."
-msgstr ""
+msgstr "Kalendarz Google - nie można usunąć zdarzenia {0} z kalendarza Google, kod błędu {1}."
 
 #: frappe/integrations/doctype/google_calendar/google_calendar.py:291
 msgid "Google Calendar - Could not fetch event from Google Calendar, error code {0}."
-msgstr ""
+msgstr "Kalendarz Google - nie można pobrać wydarzenia z Kalendarza Google, kod błędu {0}."
 
 #: frappe/integrations/doctype/google_contacts/google_contacts.py:234
 msgid "Google Calendar - Could not insert contact in Google Contacts {0}, error code {1}."
-msgstr ""
+msgstr "Kalendarz Google - nie można wstawić kontaktu do Kontaktów Google {0}, kod błędu {1}."
 
 #: frappe/integrations/doctype/google_calendar/google_calendar.py:457
 msgid "Google Calendar - Could not insert event in Google Calendar {0}, error code {1}."
-msgstr ""
+msgstr "Kalendarz Google - Nie można wstawić wydarzenia do Kalendarza Google {0}, kod błędu {1}."
 
 #: frappe/integrations/doctype/google_calendar/google_calendar.py:541
 msgid "Google Calendar - Could not update Event {0} in Google Calendar, error code {1}."
-msgstr ""
+msgstr "Kalendarz Google - nie można zaktualizować zdarzenia {0} w kalendarzu Google, kod błędu {1}."
 
 #. Label of a Data field in DocType 'Event'
 #: frappe/desk/doctype/event/event.json
@@ -11104,11 +11104,11 @@ msgstr "Kontakty Google"
 
 #: frappe/integrations/doctype/google_contacts/google_contacts.py:139
 msgid "Google Contacts - Could not sync contacts from Google Contacts {0}, error code {1}."
-msgstr ""
+msgstr "Kontakty Google - Nie można zsynchronizować kontaktów z Kontaktów Google {0}, kod błędu {1}."
 
 #: frappe/integrations/doctype/google_contacts/google_contacts.py:296
 msgid "Google Contacts - Could not update contact in Google Contacts {0}, error code {1}."
-msgstr ""
+msgstr "Kontakty Google - Nie można zaktualizować kontaktu w Kontaktach Google {0}, kod błędu {1}."
 
 #. Label of a Data field in DocType 'Contact'
 #: frappe/contacts/doctype/contact/contact.json
@@ -11126,15 +11126,15 @@ msgstr ""
 
 #: frappe/integrations/doctype/google_drive/google_drive.py:119
 msgid "Google Drive - Could not create folder in Google Drive - Error Code {0}"
-msgstr ""
+msgstr "Dysk Google - nie można utworzyć folderu na Dysku Google - kod błędu {0}"
 
 #: frappe/integrations/doctype/google_drive/google_drive.py:134
 msgid "Google Drive - Could not find folder in Google Drive - Error Code {0}"
-msgstr ""
+msgstr "Dysk Google - nie można znaleźć folderu na Dysku Google - kod błędu {0}"
 
 #: frappe/integrations/doctype/google_drive/google_drive.py:195
 msgid "Google Drive - Could not locate - {0}"
-msgstr ""
+msgstr "Dysk Google - nie można zlokalizować - {0}"
 
 #: frappe/integrations/doctype/google_drive/google_drive.py:206
 msgid "Google Drive Backup Successful."
@@ -11288,7 +11288,7 @@ msgstr "GG: mm"
 #. Option for the 'Time Format' (Select) field in DocType 'System Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
 msgid "HH:mm:ss"
-msgstr ""
+msgstr "GG: mm: ss"
 
 #. Option for the 'Type' (Select) field in DocType 'DocField'
 #. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
@@ -11389,7 +11389,7 @@ msgstr ""
 #. Label of a Check field in DocType 'DocType'
 #: frappe/core/doctype/doctype/doctype.json
 msgid "Has Web View"
-msgstr ""
+msgstr "Ma Web View"
 
 #: frappe/templates/signup.html:19
 msgid "Have an account? Login"
@@ -11498,7 +11498,7 @@ msgstr "Kategoria pomocy"
 #: frappe/core/doctype/navbar_settings/navbar_settings.json
 #: frappe/public/js/frappe/ui/toolbar/navbar.html:84
 msgid "Help Dropdown"
-msgstr ""
+msgstr "Pomoc Dropdown"
 
 #. Label of a HTML field in DocType 'Document Naming Settings'
 #: frappe/core/doctype/document_naming_settings/document_naming_settings.json
@@ -11713,7 +11713,7 @@ msgstr "Najpierw zostanie zastosowana zasada wyższego priorytetu"
 #. Label of a Text field in DocType 'Company History'
 #: frappe/website/doctype/company_history/company_history.json
 msgid "Highlight"
-msgstr ""
+msgstr "Leflektor"
 
 #: frappe/www/update-password.html:274
 msgid "Hint: Include symbols, numbers and capital letters in the password"
@@ -11889,7 +11889,7 @@ msgstr "Szczegóły tożsamości"
 #. Label of a Int field in DocType 'Desktop Icon'
 #: frappe/desk/doctype/desktop_icon/desktop_icon.json
 msgid "Idx"
-msgstr ""
+msgstr "idx"
 
 #. Description of the 'Apply Strict User Permissions' (Check) field in DocType
 #. 'System Settings'
@@ -12001,12 +12001,12 @@ msgstr ""
 #. Description of the 'Port' (Data) field in DocType 'Email Domain'
 #: frappe/email/doctype/email_domain/email_domain.json
 msgid "If non standard port (e.g. 587)"
-msgstr ""
+msgstr "Jeśli nie standardowy port (np 587)"
 
 #. Description of the 'Port' (Data) field in DocType 'Email Account'
 #: frappe/email/doctype/email_account/email_account.json
 msgid "If non standard port (e.g. 587). If on Google Cloud, try port 2525."
-msgstr ""
+msgstr "Jeśli nietypowy port (np. 587). Jeśli używasz Google Cloud, spróbuj port 2525."
 
 #. Description of the 'Port' (Data) field in DocType 'Email Account'
 #. Description of the 'Port' (Data) field in DocType 'Email Domain'
@@ -12038,7 +12038,7 @@ msgstr ""
 
 #: frappe/core/page/permission_manager/permission_manager_help.html:38
 msgid "If these instructions where not helpful, please add in your suggestions on GitHub Issues."
-msgstr ""
+msgstr "Jeśli instrukcje te nie były pomocne, proszę dodaj swoje sugestie dotyczące zagadnień GitHub."
 
 #. Description of the 'Fetch on Save if Empty' (Check) field in DocType
 #. 'DocField'
@@ -12061,11 +12061,11 @@ msgstr "Jeśli użytkownik jest właścicielem"
 
 #: frappe/core/doctype/data_export/exporter.py:204
 msgid "If you are updating, please select \"Overwrite\" else existing rows will not be deleted."
-msgstr ""
+msgstr "W przypadku aktualizacji, należy wybrać opcję \"Zastąp\" jeszcze istniejące wiersze nie zostaną usunięte."
 
 #: frappe/core/doctype/data_export/exporter.py:188
 msgid "If you are uploading new records, \"Naming Series\" becomes mandatory, if present."
-msgstr ""
+msgstr "Jeśli wysyłasz nowe rekordy, \"Naming Series\" staje się obowiązkowe, jeśli jest obecny."
 
 #: frappe/core/doctype/data_export/exporter.py:186
 msgid "If you are uploading new records, leave the \"name\" (ID) column blank."
@@ -12200,7 +12200,7 @@ msgstr "Pole Obraz musi być poprawnym nazwa_pola"
 
 #: frappe/core/doctype/doctype/doctype.py:1470
 msgid "Image field must be of type Attach Image"
-msgstr ""
+msgstr "Obraz pola muszą być typu Zamontuj obraz"
 
 #: frappe/core/doctype/file/utils.py:137
 msgid "Image link '{0}' is not valid"
@@ -12324,7 +12324,7 @@ msgstr "Importuj z Arkuszy Google"
 
 #: frappe/core/doctype/data_import/importer.py:605
 msgid "Import template should be of type .csv, .xlsx or .xls"
-msgstr ""
+msgstr "Szablon importu powinien być typu .csv, .xlsx lub .xls"
 
 #: frappe/core/doctype/data_import/importer.py:475
 msgid "Import template should contain a Header and atleast one row."
@@ -12375,7 +12375,7 @@ msgstr "W Filtrze"
 #: frappe/custom/doctype/custom_field/custom_field.json
 #: frappe/custom/doctype/customize_form_field/customize_form_field.json
 msgid "In Global Search"
-msgstr ""
+msgstr "W Global Search"
 
 #: frappe/core/doctype/doctype/doctype.js:96
 msgid "In Grid View"
@@ -12490,7 +12490,7 @@ msgstr "Dołącz wcięcia"
 
 #: frappe/public/js/frappe/form/controls/password.js:106
 msgid "Include symbols, numbers and capital letters in the password"
-msgstr ""
+msgstr "DołĘ ... cz symbole, cyfry i wielkie litery w hasło"
 
 #. Label of a Section Break field in DocType 'Email Account'
 #: frappe/email/doctype/email_account/email_account.json
@@ -12613,7 +12613,7 @@ msgstr "Informacje:"
 #. Label of a Select field in DocType 'Email Account'
 #: frappe/email/doctype/email_account/email_account.json
 msgid "Initial Sync Count"
-msgstr ""
+msgstr "Początkowa Sync Hrabia"
 
 #. Option for the 'Database Engine' (Select) field in DocType 'DocType'
 #: frappe/core/doctype/doctype/doctype.json
@@ -12667,7 +12667,7 @@ msgstr "Wstaw Styl"
 #: frappe/public/js/frappe/ui/toolbar/search_utils.js:691
 #: frappe/public/js/frappe/ui/toolbar/search_utils.js:692
 msgid "Install {0} from Marketplace"
-msgstr ""
+msgstr "Zainstaluj {0} z Marketplace"
 
 #. Name of a DocType
 #: frappe/core/doctype/installed_application/installed_application.json
@@ -13001,7 +13001,7 @@ msgstr "Niepoprawna nazwa pola {0}"
 
 #: frappe/core/doctype/doctype/doctype.py:1061
 msgid "Invalid fieldname '{0}' in autoname"
-msgstr ""
+msgstr "Nieprawidłowa nazwa pola &#39;{0}&#39; w autoname"
 
 #: frappe/client.py:344
 msgid "Invalid file path: {0}"
@@ -13359,12 +13359,12 @@ msgstr ""
 #. Label of a Code field in DocType 'Website Theme'
 #: frappe/website/doctype/website_theme/website_theme.json
 msgid "JavaScript"
-msgstr ""
+msgstr "javascript"
 
 #. Description of the 'Javascript' (Code) field in DocType 'Report'
 #: frappe/core/doctype/report/report.json
 msgid "JavaScript Format: frappe.query_reports['REPORTNAME'] = {}"
-msgstr ""
+msgstr "Format JavaScript: raporty frappe.query [ 'ReportName'] = {}"
 
 #. Label of a Code field in DocType 'Report'
 #. Label of a Section Break field in DocType 'Custom HTML Block'
@@ -13379,7 +13379,7 @@ msgstr "JavaScript"
 
 #: frappe/www/login.html:71
 msgid "Javascript is disabled on your browser"
-msgstr ""
+msgstr "Javascript jest wyłączony w Twojej przeglądarce"
 
 #. Option for the 'Print Format Type' (Select) field in DocType 'Print Format'
 #: frappe/printing/doctype/print_format/print_format.json
@@ -13457,13 +13457,13 @@ msgstr ""
 #. Name of a DocType
 #: frappe/desk/doctype/kanban_board_column/kanban_board_column.json
 msgid "Kanban Board Column"
-msgstr ""
+msgstr "Kolumna Kanban Board"
 
 #. Label of a Data field in DocType 'Kanban Board'
 #: frappe/desk/doctype/kanban_board/kanban_board.json
 #: frappe/public/js/frappe/views/kanban/kanban_view.js:388
 msgid "Kanban Board Name"
-msgstr ""
+msgstr "Nazwa Kanban Board"
 
 #: frappe/public/js/frappe/views/kanban/kanban_view.js:265
 msgctxt "Button in kanban view menu"
@@ -13530,7 +13530,7 @@ msgstr "Baza wiedzy specjalista"
 #. Name of a role
 #: frappe/website/doctype/help_article/help_article.json
 msgid "Knowledge Base Editor"
-msgstr ""
+msgstr "Baza wiedzy Editor"
 
 #: frappe/public/js/frappe/utils/number_systems.js:27
 #: frappe/public/js/frappe/utils/number_systems.js:49
@@ -13551,7 +13551,7 @@ msgstr ""
 #. Label of a Data field in DocType 'LDAP Settings'
 #: frappe/integrations/doctype/ldap_settings/ldap_settings.json
 msgid "LDAP Email Field"
-msgstr ""
+msgstr "LDAP email Pole"
 
 #. Label of a Data field in DocType 'LDAP Settings'
 #: frappe/integrations/doctype/ldap_settings/ldap_settings.json
@@ -13936,7 +13936,7 @@ msgstr ""
 #. Description of the 'Repeat Till' (Date) field in DocType 'Event'
 #: frappe/desk/doctype/event/event.json
 msgid "Leave blank to repeat always"
-msgstr ""
+msgstr "Zostaw puste by zawsze powtarzać"
 
 #: frappe/core/doctype/communication/mixins.py:207
 #: frappe/email/doctype/email_account/email_account.py:663
@@ -14085,7 +14085,7 @@ msgstr ""
 #. Head'
 #: frappe/printing/doctype/letter_head/letter_head.json
 msgid "Letter Head in HTML"
-msgstr ""
+msgstr "Nagłówek w HTMLu"
 
 #. Label of a Int field in DocType 'Custom DocPerm'
 #. Label of a Int field in DocType 'DocPerm'
@@ -14289,7 +14289,7 @@ msgstr "Łącze Nazwa"
 #: frappe/core/doctype/communication_link/communication_link.json
 #: frappe/core/doctype/dynamic_link/dynamic_link.json
 msgid "Link Title"
-msgstr ""
+msgstr "link Title"
 
 #. Label of a Dynamic Link field in DocType 'Workspace Link'
 #. Label of a Dynamic Link field in DocType 'Workspace Shortcut'
@@ -14417,7 +14417,7 @@ msgstr "Listy typ dokumentu"
 #: frappe/website/doctype/web_form/web_form.json
 #: frappe/website/doctype/web_page/web_page.json
 msgid "List as [{\"label\": _(\"Jobs\"), \"route\":\"jobs\"}]"
-msgstr ""
+msgstr "Lista jako [{ &quot;label&quot;: _ ( &quot;Praca&quot;), &quot;drogi&quot;: &quot;Jobs&quot;}]"
 
 #. Description of a DocType
 #: frappe/core/doctype/patch_log/patch_log.json
@@ -14779,7 +14779,7 @@ msgstr ""
 #. Label of a Check field in DocType 'DocType'
 #: frappe/core/doctype/doctype/doctype.json
 msgid "Make \"name\" searchable in Global Search"
-msgstr ""
+msgstr "Make „Nazwa” można przeszukiwać w Global Search"
 
 #. Label of a Check field in DocType 'DocField'
 #: frappe/core/doctype/docfield/docfield.json
@@ -14864,7 +14864,7 @@ msgstr "Pole obowiązkowe {0}"
 
 #: frappe/public/js/frappe/form/save.js:167
 msgid "Mandatory fields required in table {0}, Row {1}"
-msgstr ""
+msgstr "Obowiązkowe pola wymagane w tabeli {0} {1} Row"
 
 #: frappe/public/js/frappe/form/save.js:172
 msgid "Mandatory fields required in {0}"
@@ -14900,7 +14900,7 @@ msgstr "Odwzoruj kolumny od {0} na pola w {1}"
 #. Description of the 'Dynamic Route' (Check) field in DocType 'Web Page'
 #: frappe/website/doctype/web_page/web_page.json
 msgid "Map route parameters into form variables. Example <code>/project/&lt;name&gt;</code>"
-msgstr ""
+msgstr "Zmapuj parametry trasy na zmienne formularza. Przykład <code>/project/&lt;name&gt;</code>"
 
 #: frappe/core/doctype/data_import/importer.py:886
 msgid "Mapping column {0} to field {1}"
@@ -14984,7 +14984,7 @@ msgstr ""
 
 #: frappe/desk/page/setup_wizard/install_fixtures.py:51
 msgid "Master"
-msgstr ""
+msgstr "Мistrz"
 
 #. Description of the 'Limit' (Int) field in DocType 'Bulk Update'
 #: frappe/desk/doctype/bulk_update/bulk_update.json
@@ -15030,7 +15030,7 @@ msgstr ""
 
 #: frappe/core/doctype/doctype/doctype.py:1304
 msgid "Max width for type Currency is 100px in row {0}"
-msgstr ""
+msgstr "Maksymalna szerokość dla typu Waluta to 100px w rzędzie {0}"
 
 #. Option for the 'Function' (Select) field in DocType 'Number Card'
 #: frappe/desk/doctype/number_card/number_card.json
@@ -15128,7 +15128,7 @@ msgstr "Połączy się z istniejącą"
 
 #: frappe/utils/nestedset.py:311
 msgid "Merging is only possible between Group-to-Group or Leaf Node-to-Leaf Node"
-msgstr ""
+msgstr "Łączenie jest możliwe tylko pomiędzy Grupa-Grupa lub Liść-Liść"
 
 #. Label of a Text field in DocType 'Auto Repeat'
 #. Label of a Text Editor field in DocType 'Activity Log'
@@ -15193,7 +15193,7 @@ msgstr "Parametr Wiadomości"
 
 #: frappe/templates/includes/contact.js:36
 msgid "Message Sent"
-msgstr ""
+msgstr "Widomość wysłana"
 
 #. Label of a Select field in DocType 'Notification'
 #: frappe/email/doctype/notification/notification.json
@@ -15366,7 +15366,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/form/save.js:178
 msgid "Missing Fields"
-msgstr ""
+msgstr "brakujące Fields"
 
 #: frappe/email/doctype/auto_email_report/auto_email_report.py:129
 msgid "Missing Filters Required"
@@ -15628,7 +15628,7 @@ msgstr "Więcej artykułów na {0}"
 #. Settings'
 #: frappe/website/doctype/about_us_settings/about_us_settings.json
 msgid "More content for the bottom of the page."
-msgstr ""
+msgstr "Więcej contentu do dolnej strony."
 
 #: frappe/public/js/frappe/ui/sort_selector.js:191
 msgid "Most Used"
@@ -15823,7 +15823,7 @@ msgstr "Nazwa nie może zawierać znaków specjalnych, takich jak {0}"
 
 #: frappe/custom/doctype/custom_field/custom_field.js:91
 msgid "Name of the Document Type (DocType) you want this field to be linked to. e.g. Customer"
-msgstr ""
+msgstr "Nazwa typu dokumentu (DocType) chcesz to pole, aby być powiązane. np klienta"
 
 #: frappe/printing/page/print_format_builder/print_format_builder.js:117
 msgid "Name of the new Print Format"
@@ -15944,7 +15944,7 @@ msgstr "Ujemna wartość"
 
 #: frappe/utils/nestedset.py:94
 msgid "Nested set error. Please contact the Administrator."
-msgstr ""
+msgstr "Błąd Nested set. Skontaktuj się z Administratorem."
 
 #. Name of a DocType
 #: frappe/printing/doctype/network_printer_settings/network_printer_settings.json
@@ -16151,7 +16151,7 @@ msgstr ""
 #. Name of a DocType
 #: frappe/email/doctype/newsletter_email_group/newsletter_email_group.json
 msgid "Newsletter Email Group"
-msgstr ""
+msgstr "Newsletter Email Grupa"
 
 #. Name of a role
 #: frappe/email/doctype/email_group/email_group.json
@@ -16529,7 +16529,7 @@ msgstr ""
 
 #: frappe/desk/form/utils.py:101
 msgid "No further records"
-msgstr ""
+msgstr "Nie ma dlaszych zaksięgowań"
 
 #: frappe/templates/includes/search_template.html:49
 msgid "No matching records. Search something new"
@@ -16558,7 +16558,7 @@ msgstr "Numer kolumn"
 #. Label of a Int field in DocType 'Auto Email Report'
 #: frappe/email/doctype/auto_email_report/auto_email_report.json
 msgid "No of Rows (Max 500)"
-msgstr ""
+msgstr "Nie rzędów (max 500)"
 
 #: frappe/__init__.py:1055 frappe/client.py:109 frappe/client.py:151
 msgid "No permission for {0}"
@@ -16587,7 +16587,7 @@ msgstr "Brak rekordów w {0}"
 
 #: frappe/public/js/frappe/list/list_sidebar_stat.html:3
 msgid "No records tagged."
-msgstr ""
+msgstr "Brak otagowanych rekordów."
 
 #: frappe/public/js/frappe/data_import/data_exporter.js:225
 msgid "No records will be exported"
@@ -16807,7 +16807,7 @@ msgstr "Nie w trybie dewelopera"
 
 #: frappe/core/doctype/doctype/doctype.py:331
 msgid "Not in Developer Mode! Set in site_config.json or make 'Custom' DocType."
-msgstr ""
+msgstr "Nie w trybie dewelopera! Położony w site_config.json lub dokonać DOCTYPE \"custom\"."
 
 #: frappe/api/v1.py:88 frappe/api/v1.py:93
 #: frappe/core/doctype/system_settings/system_settings.py:212
@@ -16986,12 +16986,12 @@ msgstr "Informuj za pomocą Maila"
 #. Label of a Check field in DocType 'Email Account'
 #: frappe/email/doctype/email_account/email_account.json
 msgid "Notify if unreplied"
-msgstr ""
+msgstr "Informuj jeśli Tematy bez odpowiedzi"
 
 #. Label of a Int field in DocType 'Email Account'
 #: frappe/email/doctype/email_account/email_account.json
 msgid "Notify if unreplied for (in mins)"
-msgstr ""
+msgstr "Informuj jeśli Tematy bez do (w min)"
 
 #. Label of a Check field in DocType 'Note'
 #: frappe/desk/doctype/note/note.json
@@ -17107,12 +17107,12 @@ msgstr ""
 #. Name of a DocType
 #: frappe/integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
 msgid "OAuth Authorization Code"
-msgstr ""
+msgstr "Kod autoryzacji OAuth"
 
 #. Name of a DocType
 #: frappe/integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
 msgid "OAuth Bearer Token"
-msgstr ""
+msgstr "OAuth okaziciela Reklamowe"
 
 #. Name of a DocType
 #. Label of a Link in the Integrations Workspace
@@ -17124,7 +17124,7 @@ msgstr ""
 #. Label of a Section Break field in DocType 'Google Settings'
 #: frappe/integrations/doctype/google_settings/google_settings.json
 msgid "OAuth Client ID"
-msgstr ""
+msgstr "Identyfikator klienta OAuth"
 
 #. Name of a DocType
 #: frappe/integrations/doctype/oauth_client_role/oauth_client_role.json
@@ -17140,7 +17140,7 @@ msgstr ""
 #: frappe/integrations/doctype/oauth_provider_settings/oauth_provider_settings.json
 #: frappe/integrations/workspace/integrations/integrations.json
 msgid "OAuth Provider Settings"
-msgstr ""
+msgstr "Ustawienia OAuth dostawcze"
 
 #. Name of a DocType
 #: frappe/integrations/doctype/oauth_scope/oauth_scope.json
@@ -17410,7 +17410,7 @@ msgstr ""
 
 #: frappe/custom/doctype/customize_form/customize_form.py:125
 msgid "Only standard DocTypes are allowed to be customized from Customize Form."
-msgstr ""
+msgstr "Tylko standardowe DocTypes mogą być dostosowywane z Customize Form."
 
 #: frappe/desk/form/assign_to.py:198
 msgid "Only the assignee can complete this to-do."
@@ -17449,7 +17449,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/ui/keyboard.js:205
 msgid "Open Awesomebar"
-msgstr ""
+msgstr "Otwórz Awesomebar"
 
 #: frappe/public/js/frappe/form/templates/timeline_message_box.html:67
 msgid "Open Communication"
@@ -17479,7 +17479,7 @@ msgstr "Otwórz ustawienia"
 
 #: frappe/public/js/frappe/ui/toolbar/about.js:8
 msgid "Open Source Applications for the Web"
-msgstr ""
+msgstr "Open Source Wnioski o internecie"
 
 #. Label of a Check field in DocType 'Top Bar Item'
 #: frappe/website/doctype/top_bar_item/top_bar_item.json
@@ -17601,7 +17601,7 @@ msgstr "Opcje"
 
 #: frappe/core/doctype/doctype/doctype.py:1328
 msgid "Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType'"
-msgstr ""
+msgstr "Typ Opcje \"Dynamic Link 'pola muszą wskazywać na inny link Pole z opcji jak\" DocType \""
 
 #. Label of a HTML field in DocType 'Custom Field'
 #: frappe/custom/doctype/custom_field/custom_field.json
@@ -18123,7 +18123,7 @@ msgstr ""
 
 #: frappe/core/doctype/user/user.py:1026
 msgid "Password reset instructions have been sent to your email"
-msgstr ""
+msgstr "Instrukcja resetowania hasła została wysłana na Twój email"
 
 #: frappe/www/update-password.html:164
 msgid "Password set"
@@ -18356,7 +18356,7 @@ msgstr "Uprawnienia są automatycznie stosowane do standardowych raportów i wys
 
 #: frappe/core/page/permission_manager/permission_manager_help.html:5
 msgid "Permissions are set on Roles and Document Types (called DocTypes) by setting rights like Read, Write, Create, Delete, Submit, Cancel, Amend, Report, Import, Export, Print, Email and Set User Permissions."
-msgstr ""
+msgstr "Uprawnienia są ustawiane dla Roli i Typu dokumentu (zwane DocTypes) poprzez ustawianie praw takich jak: Odczyt, Zapis, Tworzenie, Usuwanie, Zatwierdzanie, Anulowanie, Poprawianie, Raportowanie, Importowanie, Exsportowanie, Drukowanie, Wysyłka e-mail oraz Ustawianie uprawnień użytkowanika."
 
 #: frappe/core/page/permission_manager/permission_manager_help.html:26
 msgid "Permissions at higher levels are Field Level permissions. All Fields have a Permission Level set against them and the rules defined at that permissions apply to the field. This is useful in case you want to hide or make certain field read-only for certain Roles."
@@ -18364,11 +18364,11 @@ msgstr "Uprawnienia na wyższych poziomach są uprawnienia terenie. Wszystkie po
 
 #: frappe/core/page/permission_manager/permission_manager_help.html:24
 msgid "Permissions at level 0 are Document Level permissions, i.e. they are primary for access to the document."
-msgstr ""
+msgstr "Uprawnienia na poziomie 0 są uprawnienia na poziomie dokumentu, czyli są one podstawowym dostępu do dokumentu."
 
 #: frappe/core/page/permission_manager/permission_manager_help.html:6
 msgid "Permissions get applied on Users based on what Roles they are assigned."
-msgstr ""
+msgstr "Uprawnienia użytkowników bazują na rolach do których zostali przypisani."
 
 #. Name of a report
 #. Label of a Link in the Users Workspace
@@ -18485,11 +18485,11 @@ msgstr ""
 
 #: frappe/website/doctype/website_theme/website_theme.py:75
 msgid "Please Duplicate this Website Theme to customize."
-msgstr ""
+msgstr "Proszę Duplikat ta strona Theme dostosować."
 
 #: frappe/integrations/doctype/ldap_settings/ldap_settings.py:162
 msgid "Please Install the ldap3 library via pip to use ldap functionality."
-msgstr ""
+msgstr "Zainstaluj bibliotekę ldap3 przez pip, aby korzystać z funkcji ldap."
 
 #: frappe/public/js/frappe/views/reports/query_report.js:308
 msgid "Please Set Chart"
@@ -18557,7 +18557,7 @@ msgstr ""
 
 #: frappe/templates/emails/password_reset.html:2
 msgid "Please click on the following link to set your new password"
-msgstr ""
+msgstr "Proszę kliknąć na poniższy link, aby ustawić nowe hasło"
 
 #: frappe/integrations/doctype/dropbox_settings/dropbox_settings.py:343
 msgid "Please close this window"
@@ -18619,11 +18619,11 @@ msgstr "Proszę upewnić się, że Twój profil jest adres e-mail"
 
 #: frappe/integrations/doctype/social_login_key/social_login_key.py:82
 msgid "Please enter Access Token URL"
-msgstr ""
+msgstr "Wprowadź adres URL tokenu dostępu"
 
 #: frappe/integrations/doctype/social_login_key/social_login_key.py:80
 msgid "Please enter Authorize URL"
-msgstr ""
+msgstr "Wprowadź Authorize URL"
 
 #: frappe/integrations/doctype/social_login_key/social_login_key.py:78
 msgid "Please enter Base URL"
@@ -18680,7 +18680,7 @@ msgstr "Dołącz załączony {0}: {1}"
 
 #: frappe/core/doctype/navbar_settings/navbar_settings.py:43
 msgid "Please hide the standard navbar items instead of deleting them"
-msgstr ""
+msgstr "Ukryj standardowe elementy paska nawigacyjnego zamiast je usuwać"
 
 #: frappe/templates/includes/comments/comments.py:31
 msgid "Please login to post a comment."
@@ -18692,7 +18692,7 @@ msgstr "Upewnij się, że referencyjne dokumenty komunikacyjne nie są połączo
 
 #: frappe/model/document.py:866
 msgid "Please refresh to get the latest document."
-msgstr ""
+msgstr "Odśwież by otrzymać aktualny dokument"
 
 #: frappe/printing/page/print/print.js:535
 msgid "Please remove the printer mapping in Printer Settings and try again."
@@ -18752,11 +18752,11 @@ msgstr ""
 
 #: frappe/utils/file_manager.py:51
 msgid "Please select a file or url"
-msgstr ""
+msgstr "Proszę wybrać plik albo url"
 
 #: frappe/model/rename_doc.py:680
 msgid "Please select a valid csv file with data"
-msgstr ""
+msgstr "Proszę wybrać poprawny plik .csv z danymi"
 
 #: frappe/utils/data.py:254
 msgid "Please select a valid date filter"
@@ -18768,7 +18768,7 @@ msgstr "Wybierz odpowiednie typy dokumentów"
 
 #: frappe/model/db_query.py:1130
 msgid "Please select atleast 1 column from {0} to sort/group"
-msgstr ""
+msgstr "Proszę wybrać conajmniej 1 kolumnę z {0} do sortowania / grupy"
 
 #: frappe/core/doctype/document_naming_settings/document_naming_settings.py:214
 msgid "Please select prefix first"
@@ -18806,7 +18806,7 @@ msgstr "Proszę ustawić filtry"
 
 #: frappe/email/doctype/auto_email_report/auto_email_report.py:251
 msgid "Please set filters value in Report Filter table."
-msgstr ""
+msgstr "Proszę ustawić wartości filtrów w tabeli Zgłoś Filter."
 
 #: frappe/model/naming.py:548
 msgid "Please set the document name"
@@ -18822,7 +18822,7 @@ msgstr "Ustaw serię, która ma być używana."
 
 #: frappe/core/doctype/system_settings/system_settings.py:121
 msgid "Please setup SMS before setting it as an authentication method, via SMS Settings"
-msgstr ""
+msgstr "Proszę skonfigurować SMS przed skonfigurowaniem go jako metody uwierzytelniania przez SMS Settings"
 
 #: frappe/automation/doctype/auto_repeat/auto_repeat.js:102
 msgid "Please setup a message first"
@@ -19130,7 +19130,7 @@ msgstr ""
 #. Label of a Small Text field in DocType 'Transaction Log'
 #: frappe/core/doctype/transaction_log/transaction_log.json
 msgid "Previous Hash"
-msgstr ""
+msgstr "Poprzedni Hash"
 
 #: frappe/public/js/frappe/form/form.js:2112
 msgid "Previous Submission"
@@ -19422,7 +19422,7 @@ msgstr ""
 #. 'Email Account'
 #: frappe/email/doctype/email_account/email_account.json
 msgid "ProTip: Add <code>Reference: {{ reference_doctype }} {{ reference_name }}</code> to send document reference"
-msgstr ""
+msgstr "Protip: Dodaj <code>Reference: {{ reference_doctype }} {{ reference_name }}</code> , aby wysłać dokument odniesienia"
 
 #: frappe/core/doctype/document_naming_rule/document_naming_rule.js:22
 msgid "Proceed"
@@ -19665,7 +19665,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/form/print_utils.js:206
 msgid "QZ Tray Failed: "
-msgstr ""
+msgstr "Taca QZ nie powiodła się:"
 
 #. Option for the 'Frequency' (Select) field in DocType 'Auto Repeat'
 #. Option for the 'Time Interval' (Select) field in DocType 'Dashboard Chart'
@@ -19892,7 +19892,7 @@ msgstr "Surowe polecenia"
 #. Label of a Code field in DocType 'Unhandled Email'
 #: frappe/email/doctype/unhandled_email/unhandled_email.json
 msgid "Raw Email"
-msgstr ""
+msgstr "Raw email"
 
 #. Label of a Check field in DocType 'Print Format'
 #. Label of a Section Break field in DocType 'Print Settings'
@@ -20101,7 +20101,7 @@ msgstr ""
 
 #: frappe/core/doctype/user_permission/user_permission_help.html:2
 msgid "Records for following doctypes will be filtered"
-msgstr ""
+msgstr "Rekordy dla następujących doctypes będą filtrowane"
 
 #: frappe/core/doctype/doctype/doctype.py:1570
 msgid "Recursive Fetch From"
@@ -20160,7 +20160,7 @@ msgstr ""
 
 #: frappe/sessions.py:148
 msgid "Redis cache server not running. Please contact Administrator / Tech support"
-msgstr ""
+msgstr "Redis serwer cache nie działa. Prosimy o kontakt administratora / wsparcia Tech"
 
 #: frappe/public/js/frappe/form/toolbar.js:463
 msgid "Redo"
@@ -20645,7 +20645,7 @@ msgstr ""
 
 #: frappe/utils/password_strength.py:99
 msgid "Repeats like \"abcabcabc\" are only slightly harder to guess than \"abc\""
-msgstr ""
+msgstr "Powtarza jak &quot;abcabcabc&quot; są tylko nieznacznie trudniejsze do odgadnięcia niż &quot;abc&quot;"
 
 #: frappe/public/js/frappe/form/sidebar/form_sidebar.js:135
 msgid "Repeats {0}"
@@ -20656,7 +20656,7 @@ msgstr "Powtórki {0}"
 #: frappe/contacts/doctype/contact/contact.json
 #: frappe/core/doctype/communication/communication.json
 msgid "Replied"
-msgstr ""
+msgstr "Odpowiedziane"
 
 #. Label of a Text Editor field in DocType 'Discussion Reply'
 #: frappe/core/doctype/communication/communication.js:57
@@ -21121,7 +21121,7 @@ msgstr "Ogranicz do domeny"
 #. Description of the 'Restrict IP' (Small Text) field in DocType 'User'
 #: frappe/core/doctype/user/user.json
 msgid "Restrict user from this IP address only. Multiple IP addresses can be added by separating with commas. Also accepts partial IP addresses like (111.111.111)"
-msgstr ""
+msgstr "Ogranicz dostęp dla użytkownika tylko dla tego adresu IP. Możesz dodać wiele adresów IP oddzielając je przecinkiem. Możesz podać również kawełek adresu IP np. (111.111.111)"
 
 #: frappe/public/js/frappe/list/list_view.js:191
 msgctxt "Title of message showing restrictions in list view"
@@ -21255,7 +21255,7 @@ msgstr ""
 #. Label of a Code field in DocType 'Website Settings'
 #: frappe/website/doctype/website_settings/website_settings.json
 msgid "Robots.txt"
-msgstr ""
+msgstr "robots.txt"
 
 #. Label of a Link field in DocType 'Custom DocPerm'
 #. Label of a Table field in DocType 'Custom Role'
@@ -21389,7 +21389,7 @@ msgstr "Role HTML"
 #. Label of a HTML field in DocType 'Role Permission for Page and Report'
 #: frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.json
 msgid "Roles Html"
-msgstr ""
+msgstr "Role Html"
 
 #: frappe/core/page/permission_manager/permission_manager_help.html:7
 msgid "Roles can be set for users from their User page."
@@ -21501,7 +21501,7 @@ msgstr "Numer wiersza"
 
 #: frappe/core/doctype/version/version_view.html:68
 msgid "Row Values Changed"
-msgstr ""
+msgstr "Zmienione wartości Row"
 
 #: frappe/core/doctype/data_import/data_import.js:372
 msgid "Row {0}"
@@ -21585,16 +21585,16 @@ msgstr "Uruchamiane tylko zaplanowane zadania, jeśli zaznaczone"
 #: frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.json
 #: frappe/integrations/workspace/integrations/integrations.json
 msgid "S3 Backup Settings"
-msgstr ""
+msgstr "S3 Ustawienia kopii zapasowej"
 
 #: frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.js:18
 msgid "S3 Backup complete!"
-msgstr ""
+msgstr "S3 Backup zakończony!"
 
 #. Label of a Section Break field in DocType 'S3 Backup Settings'
 #: frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.json
 msgid "S3 Bucket Details"
-msgstr ""
+msgstr "Szczegóły łyżki S3"
 
 #. Option for the 'Type' (Select) field in DocType 'Communication'
 #. Option for the 'Two Factor Authentication method' (Select) field in DocType
@@ -22206,7 +22206,7 @@ msgstr "Widziany przez"
 #. Label of a Table field in DocType 'Note'
 #: frappe/desk/doctype/note/note.json
 msgid "Seen By Table"
-msgstr ""
+msgstr "Widziany przez tabeli"
 
 #. Label of a Check field in DocType 'Custom DocPerm'
 #. Option for the 'Type' (Select) field in DocType 'DocField'
@@ -22300,7 +22300,7 @@ msgstr "Wybierz Typ dokumentu"
 
 #: frappe/core/page/permission_manager/permission_manager.js:172
 msgid "Select Document Type or Role to start."
-msgstr ""
+msgstr "Aby zacząć wybierz Typ Dokumentu lub Rolę"
 
 #: frappe/core/page/permission_manager/permission_manager_help.html:34
 msgid "Select Document Types to set which User Permissions are used to limit access."
@@ -22345,7 +22345,7 @@ msgstr "Wybierz Kontakty Google, z którymi kontakt powinien zostać zsynchroniz
 
 #: frappe/public/js/frappe/ui/group_by/group_by.html:10
 msgid "Select Group By..."
-msgstr ""
+msgstr "Wybierz Grupuj według ..."
 
 #: frappe/public/js/frappe/list/list_view_select.js:185
 msgid "Select Kanban"
@@ -22456,17 +22456,17 @@ msgstr ""
 
 #: frappe/printing/page/print_format_builder/print_format_builder_start.html:2
 msgid "Select an existing format to edit or start a new format."
-msgstr ""
+msgstr "Wybierz jeden z istniejących formatów aby edytować lub utworzyć nowy format."
 
 #. Description of the 'Brand Image' (Attach Image) field in DocType 'Website
 #. Settings'
 #: frappe/website/doctype/website_settings/website_settings.json
 msgid "Select an image of approx width 150px with a transparent background for best results."
-msgstr ""
+msgstr "Wybierz zdjęcie szerokości ok 150px z przezroczystym tłem aby otrzymać najlepszy rezultat."
 
 #: frappe/public/js/frappe/list/bulk_operations.js:36
 msgid "Select atleast 1 record for printing"
-msgstr ""
+msgstr "Wybierz conajmniej 1 rekordów do druku"
 
 #: frappe/core/doctype/success_action/success_action.js:18
 msgid "Select atleast 2 actions"
@@ -22485,7 +22485,7 @@ msgstr "Wybierz wiele elementów listy"
 
 #: frappe/public/js/frappe/views/calendar/calendar.js:175
 msgid "Select or drag across time slots to create a new event."
-msgstr ""
+msgstr "Wybierz albo przeciągnij pomiędzy komórkami czasu aby stworzyć wydarzenie."
 
 #: frappe/public/js/frappe/list/bulk_operations.js:239
 msgid "Select records for assignment"
@@ -22498,7 +22498,7 @@ msgstr ""
 #. Description of the 'Insert After' (Select) field in DocType 'Custom Field'
 #: frappe/custom/doctype/custom_field/custom_field.json
 msgid "Select the label after which you want to insert new field."
-msgstr ""
+msgstr "Wybierz etykietę po której chcesz dodać nowe pole."
 
 #: frappe/public/js/frappe/utils/diffview.js:102
 msgid "Select two versions to view the diff."
@@ -22728,7 +22728,7 @@ msgstr ""
 
 #: frappe/core/doctype/doctype/doctype.py:1907
 msgid "Sender Field should have Email in options"
-msgstr ""
+msgstr "Pole nadawcy powinno zawierać opcje Email"
 
 #. Label of a Data field in DocType 'Newsletter'
 #: frappe/email/doctype/newsletter/newsletter.json
@@ -22933,7 +22933,7 @@ msgstr "Ustaw wykres"
 #. Description of the 'Chart Options' (Code) field in DocType 'Dashboard'
 #: frappe/desk/doctype/dashboard/dashboard.json
 msgid "Set Default Options for all charts on this Dashboard (Ex: \"colors\": [\"#d1d8dd\", \"#ff5858\"])"
-msgstr ""
+msgstr "Ustaw opcje domyślne dla wszystkich wykresów w tym panelu (np. „Colors”: [„# d1d8dd”, „# ff5858”])"
 
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.js:467
 #: frappe/desk/doctype/number_card/number_card.js:367
@@ -22987,7 +22987,7 @@ msgstr ""
 #. Label of a Select field in DocType 'Notification'
 #: frappe/email/doctype/notification/notification.json
 msgid "Set Property After Alert"
-msgstr ""
+msgstr "Ustaw właściwość po alertu"
 
 #: frappe/public/js/frappe/form/link_selector.js:207
 #: frappe/public/js/frappe/form/link_selector.js:208
@@ -23489,7 +23489,7 @@ msgstr ""
 #. Label of a Small Text field in DocType 'Email Queue'
 #: frappe/email/doctype/email_queue/email_queue.json
 msgid "Show as cc"
-msgstr ""
+msgstr "Pokaż jako cc"
 
 #. Label of a Check field in DocType 'Website Settings'
 #: frappe/website/doctype/website_settings/website_settings.json
@@ -23536,7 +23536,7 @@ msgstr "Pokaż różnicę procentową według tego przedziału czasu"
 #. Description of the 'Title Prefix' (Data) field in DocType 'Website Settings'
 #: frappe/website/doctype/website_settings/website_settings.json
 msgid "Show title in browser window as \"Prefix - title\""
-msgstr ""
+msgstr "Pokaż tytuł w oknie przeglądarki jako &quot;Prefiks - tytuł&quot;"
 
 #: frappe/public/js/frappe/widgets/onboarding_widget.js:148
 msgid "Show {0} List"
@@ -23627,7 +23627,7 @@ msgstr "Proste wyrażenie w języku Python, przykład: Status w („Nieprawidło
 #. Rule'
 #: frappe/automation/doctype/assignment_rule/assignment_rule.json
 msgid "Simple Python Expression, Example: status == 'Open' and type == 'Bug'"
-msgstr ""
+msgstr "Simple Python Expression, Przykład: status == &#39;Open&#39; i wpisz == &#39;Bug&#39;"
 
 #. Label of a Int field in DocType 'User'
 #: frappe/core/doctype/user/user.json
@@ -23642,7 +23642,7 @@ msgstr "Nie można dostosować pojedynczych typów dokumentów."
 #: frappe/core/doctype/doctype/doctype.json
 #: frappe/core/doctype/doctype/doctype_list.js:51
 msgid "Single Types have only one record no tables associated. Values are stored in tabSingles"
-msgstr ""
+msgstr "Pojedyncze Typy mogą mieć tylko jeden rekord bez tabel powiązanych. Wartości są przechowywane w tabSingles"
 
 #: frappe/database/database.py:243
 msgid "Site is running in read only mode for maintenance or site update, this action can not be performed right now. Please try again later."
@@ -23667,7 +23667,7 @@ msgstr "Pominąć"
 #: frappe/integrations/doctype/oauth_client/oauth_client.json
 #: frappe/integrations/doctype/oauth_provider_settings/oauth_provider_settings.json
 msgid "Skip Authorization"
-msgstr ""
+msgstr "Przejdź Authorization"
 
 #: frappe/public/js/frappe/widgets/onboarding_widget.js:337
 msgid "Skip Step"
@@ -23680,7 +23680,7 @@ msgstr ""
 
 #: frappe/core/doctype/data_import/importer.py:914
 msgid "Skipping Duplicate Column {0}"
-msgstr ""
+msgstr "Pomijanie zduplikowanej kolumny {0}"
 
 #: frappe/core/doctype/data_import/importer.py:939
 msgid "Skipping Untitled Column"
@@ -23813,7 +23813,7 @@ msgstr ""
 #. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: frappe/core/doctype/communication/communication.json
 msgid "Soft-Bounced"
-msgstr ""
+msgstr "Soft-odbił"
 
 #: frappe/printing/page/print_format_builder/print_format_builder_column_selector.html:4
 msgid "Some columns might get cut off when printing to PDF. Try to keep number of columns under 10."
@@ -23943,7 +23943,7 @@ msgstr ""
 #: frappe/public/js/frappe/web_form/web_form_list.js:175
 #: frappe/templates/print_formats/standard_macros.html:44
 msgid "Sr"
-msgstr ""
+msgstr "sr"
 
 #: frappe/public/js/print_format_builder/Field.vue:143
 #: frappe/public/js/print_format_builder/Field.vue:164
@@ -24007,7 +24007,7 @@ msgstr ""
 #. Label of a Section Break field in DocType 'Portal Settings'
 #: frappe/website/doctype/portal_settings/portal_settings.json
 msgid "Standard Sidebar Menu"
-msgstr ""
+msgstr "Standardowe Sidebar Menu"
 
 #: frappe/website/doctype/web_form/web_form.js:40
 msgid "Standard Web Forms can not be modified, duplicate the Web Form instead."
@@ -24099,7 +24099,7 @@ msgstr ""
 
 #: frappe/desk/page/setup_wizard/setup_wizard.js:274
 msgid "Starting Frappe ..."
-msgstr ""
+msgstr "Uruchamianie Frappé ..."
 
 #. Label of a Datetime field in DocType 'Event'
 #: frappe/desk/doctype/event/event.json
@@ -24306,7 +24306,7 @@ msgstr "Ustawienia stylu"
 #. Description of the 'Style' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "Style represents the button color: Success - Green, Danger - Red, Inverse - Black, Primary - Dark Blue, Info - Light Blue, Warning - Orange"
-msgstr ""
+msgstr "Styl reprezentuje kolor przycisku: sukces - zielony, niebezpieczeństwo - czerwony, - odwróć - czarny, podstawowa - ciemnoniebieski, info - jasnoniebieskie, ostrzeżenie - pomarańczowy"
 
 #. Label of a Tab Break field in DocType 'Website Theme'
 #: frappe/website/doctype/website_theme/website_theme.json
@@ -24322,12 +24322,12 @@ msgstr "Waluta zdawkowa. Np. \"grosz\""
 #. Settings'
 #: frappe/website/doctype/website_settings/website_settings.json
 msgid "Sub-domain provided by erpnext.com"
-msgstr ""
+msgstr "Subdomeny obsługuje erpnext.com"
 
 #. Label of a Small Text field in DocType 'Website Settings'
 #: frappe/website/doctype/website_settings/website_settings.json
 msgid "Subdomain"
-msgstr ""
+msgstr "Subdomena"
 
 #. Label of a Data field in DocType 'Auto Repeat'
 #. Label of a Small Text field in DocType 'Activity Log'
@@ -24464,7 +24464,7 @@ msgstr "Prześlij dokumenty {0}?"
 #: frappe/public/js/frappe/ui/filters/filter.js:532
 #: frappe/website/doctype/web_form/templates/web_form.html:133
 msgid "Submitted"
-msgstr ""
+msgstr "Zgłoszny"
 
 #: frappe/workflow/doctype/workflow/workflow.py:104
 msgid "Submitted Document cannot be converted back to draft. Transition row {0}"
@@ -24692,7 +24692,7 @@ msgstr "Synchronizacja kontaktów"
 
 #: frappe/custom/doctype/customize_form/customize_form.js:256
 msgid "Sync on Migrate"
-msgstr ""
+msgstr "Synchronizacja na Migrate"
 
 #: frappe/integrations/doctype/google_calendar/google_calendar.py:298
 msgid "Sync token was invalid and has been reset, Retry syncing."
@@ -25374,7 +25374,7 @@ msgstr ""
 
 #: frappe/website/doctype/web_page/web_page.js:125
 msgid "The meta description is an HTML attribute that provides a brief summary of a web page. Search engines such as Google often display the meta description in search results, which can influence click-through rates."
-msgstr ""
+msgstr "Opis meta to atrybut HTML, który zawiera krótkie podsumowanie strony internetowej. Wyszukiwarki, takie jak Google, często wyświetlają metaopis w wynikach wyszukiwania, co może wpływać na współczynniki klikalności."
 
 #: frappe/website/doctype/web_page/web_page.js:132
 msgid "The meta image is unique image representing the content of the page. Images for this Card should be at least 280px in width, and at least 150px in height."
@@ -25424,7 +25424,7 @@ msgstr ""
 
 #: frappe/app.py:369 frappe/public/js/frappe/request.js:147
 msgid "The resource you are looking for is not available"
-msgstr ""
+msgstr "Zasób którego szukasz jest niedostępny"
 
 #: frappe/core/doctype/user_type/user_type.py:113
 msgid "The role {0} should be a custom role."
@@ -25436,7 +25436,7 @@ msgstr ""
 
 #: frappe/core/page/permission_manager/permission_manager_help.html:9
 msgid "The system provides many pre-defined roles. You can add new roles to set finer permissions."
-msgstr ""
+msgstr "System zapewnia wiele pre-definiowanych ról. Można dodać nowe role do ustawiania uprawnień."
 
 #: frappe/public/js/frappe/form/grid_row.js:649
 msgid "The total column width cannot be more than 10."
@@ -25510,7 +25510,7 @@ msgstr ""
 
 #: frappe/core/doctype/doctype/doctype.py:1405
 msgid "There can be only one Fold in a form"
-msgstr ""
+msgstr "Nie może być tylko jeden Fold w formie"
 
 #: frappe/contacts/doctype/address/address.py:183
 msgid "There is an error in your Address Template {0}"
@@ -25534,7 +25534,7 @@ msgstr "W kolejce jest już {0} z tymi samymi filtrami:"
 
 #: frappe/core/page/permission_manager/permission_manager.py:155
 msgid "There must be atleast one permission rule."
-msgstr ""
+msgstr "Musi być conajmniej jedna zasada zgody."
 
 #: frappe/www/error.py:15
 msgid "There was an error building this page"
@@ -25550,11 +25550,11 @@ msgstr "Wystąpiły błędy"
 
 #: frappe/public/js/frappe/views/interaction.js:276
 msgid "There were errors while creating the document. Please try again."
-msgstr ""
+msgstr "Wystąpiły błędy podczas tworzenia dokumentu. Proszę spróbuj ponownie."
 
 #: frappe/public/js/frappe/views/communication.js:828
 msgid "There were errors while sending email. Please try again."
-msgstr ""
+msgstr "Wystąpiły błędy podczas wysyłki e-mail. Proszę spróbuj ponownie."
 
 #: frappe/model/naming.py:468
 msgid "There were some errors setting the name, please contact the administrator"
@@ -25579,7 +25579,7 @@ msgstr ""
 #. Description of the 'Defaults' (Section Break) field in DocType 'User'
 #: frappe/core/doctype/user/user.json
 msgid "These values will be automatically updated in transactions and also will be useful to restrict permissions for this user on transactions containing these values."
-msgstr ""
+msgstr "Te wartości będą automatycznie aktualizowane w transakcjach, a także będzie przydatne aby ograniczyć uprawnienia dla tego użytkownika w transakcji zawierających te wartości."
 
 #: frappe/www/third_party_apps.html:3 frappe/www/third_party_apps.html:13
 msgid "Third Party Apps"
@@ -25604,7 +25604,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/views/kanban/kanban_view.js:391
 msgid "This Kanban Board will be private"
-msgstr ""
+msgstr "Ten Kanban Board będą prywatne"
 
 #: frappe/custom/doctype/customize_form/customize_form.js:220
 msgid "This action is irreversible. Do you wish to continue?"
@@ -25712,7 +25712,7 @@ msgstr "Format ten jest używany, jeśli Format danego kraju nie znaleziono"
 #. Slideshow'
 #: frappe/website/doctype/website_slideshow/website_slideshow.json
 msgid "This goes above the slideshow."
-msgstr ""
+msgstr "Występuje ponad slideshow"
 
 #: frappe/public/js/frappe/views/reports/query_report.js:2027
 msgid "This is a background report. Please set the appropriate filters and then generate a new one."
@@ -25804,7 +25804,7 @@ msgstr ""
 
 #: frappe/website/doctype/web_page/web_page.js:71
 msgid "This title will be used as the title of the webpage as well as in meta tags"
-msgstr ""
+msgstr "Ten tytuł będzie używany jako tytuł strony internetowej, a także w metatagach"
 
 #: frappe/public/js/frappe/form/controls/base_input.js:120
 msgid "This value is fetched from {0}'s {1} field"
@@ -25818,7 +25818,7 @@ msgstr "Zostanie to automatycznie wygenerowane po opublikowaniu strony, jeśli c
 #. 'Onboarding Step'
 #: frappe/desk/doctype/onboarding_step/onboarding_step.json
 msgid "This will be shown in a modal after routing"
-msgstr ""
+msgstr "Zostanie to pokazane w trybie modalnym po routingu"
 
 #. Description of the 'Report Description' (Data) field in DocType 'Onboarding
 #. Step'
@@ -25985,15 +25985,15 @@ msgstr "Linki na osi czasu"
 #. Label of a Dynamic Link field in DocType 'Activity Log'
 #: frappe/core/doctype/activity_log/activity_log.json
 msgid "Timeline Name"
-msgstr ""
+msgstr "Timeline Nazwa"
 
 #: frappe/core/doctype/doctype/doctype.py:1500
 msgid "Timeline field must be a Link or Dynamic Link"
-msgstr ""
+msgstr "Pole Timeline musi być Link lub Dynamic Link"
 
 #: frappe/core/doctype/doctype/doctype.py:1496
 msgid "Timeline field must be a valid fieldname"
-msgstr ""
+msgstr "Pole Timeline musi być poprawnym nazwa_pola"
 
 #. Label of a Duration field in DocType 'RQ Job'
 #: frappe/core/doctype/rq_job/rq_job.json
@@ -26519,7 +26519,7 @@ msgstr ""
 #. Label of a Small Text field in DocType 'Transaction Log'
 #: frappe/core/doctype/transaction_log/transaction_log.json
 msgid "Transaction Hash"
-msgstr ""
+msgstr "Hash transakcji"
 
 #. Name of a DocType
 #: frappe/core/doctype/transaction_log/transaction_log.json
@@ -26628,7 +26628,7 @@ msgstr ""
 #. Description of the 'Trigger Method' (Data) field in DocType 'Notification'
 #: frappe/email/doctype/notification/notification.json
 msgid "Trigger on valid methods like \"before_insert\", \"after_update\", etc (will depend on the DocType selected)"
-msgstr ""
+msgstr "Wyzwalanie prawidłowych metod, takich jak &quot;before_insert&quot;, &quot;after_update&quot;, itd (zależy od wybranego DocType)"
 
 #: frappe/custom/doctype/customize_form/customize_form.js:144
 msgid "Trim Table"
@@ -26874,7 +26874,7 @@ msgstr "Nie obserwuj"
 #. Name of a DocType
 #: frappe/email/doctype/unhandled_email/unhandled_email.json
 msgid "Unhandled Email"
-msgstr ""
+msgstr "nieobsługiwany email"
 
 #. Label of a Int field in DocType 'System Health Report'
 #: frappe/desk/doctype/system_health_report/system_health_report.json
@@ -26912,7 +26912,7 @@ msgstr "Nieznany użytkownik"
 
 #: frappe/utils/csvutils.py:52
 msgid "Unknown file encoding. Tried utf-8, windows-1250, windows-1252."
-msgstr ""
+msgstr "Nieznane kodowanie pliku. System próbował utf-8, windows-1250, windows-1252."
 
 #: frappe/core/doctype/submission_queue/submission_queue.js:7
 msgid "Unlock Reference Document"
@@ -27262,7 +27262,7 @@ msgstr ""
 
 #: frappe/model/db_query.py:404
 msgid "Use of sub-query or function is restricted"
-msgstr ""
+msgstr "Wykorzystanie pod-zapytania lub funkcji jest ograniczone"
 
 #: frappe/printing/page/print/print.js:279
 msgid "Use the new Print Format Builder"
@@ -27271,7 +27271,7 @@ msgstr ""
 #. Description of the 'Title Field' (Data) field in DocType 'Customize Form'
 #: frappe/custom/doctype/customize_form/customize_form.json
 msgid "Use this fieldname to generate title"
-msgstr ""
+msgstr "Użyj tej fieldName wygenerować tytuł"
 
 #. Label of a Check field in DocType 'User Email'
 #: frappe/core/doctype/user_email/user_email.json
@@ -27402,7 +27402,7 @@ msgstr ""
 #. Name of a DocType
 #: frappe/core/doctype/user_email/user_email.json
 msgid "User Email"
-msgstr ""
+msgstr "użytkownik Email"
 
 #. Label of a Table field in DocType 'User'
 #: frappe/core/doctype/user/user.json
@@ -27442,7 +27442,7 @@ msgstr "Właściwość identyfikatora użytkownika"
 #. Description of a DocType
 #: frappe/website/doctype/blogger/blogger.json
 msgid "User ID of a Blogger"
-msgstr ""
+msgstr "ID użytkownika który jest Bloggerem"
 
 #. Label of a Link field in DocType 'Contact'
 #: frappe/contacts/doctype/contact/contact.json
@@ -27572,7 +27572,7 @@ msgstr ""
 
 #: frappe/core/doctype/docshare/docshare.py:55
 msgid "User is mandatory for Share"
-msgstr ""
+msgstr "Konieczny jest Użytkownik by Udostępniać"
 
 #. Label of a Check field in DocType 'Document Naming Settings'
 #: frappe/core/doctype/document_naming_settings/document_naming_settings.json
@@ -27788,7 +27788,7 @@ msgstr "Wartość nie może być ujemna dla {0}: {1}"
 
 #: frappe/custom/doctype/property_setter/property_setter.js:7
 msgid "Value for a check field can be either 0 or 1"
-msgstr ""
+msgstr "Wartość dla checkboxu może wynosić 0 albo 1"
 
 #: frappe/custom/doctype/customize_form/customize_form.py:608
 msgid "Value for field {0} is too long in {1}. Length should be lesser than {2} characters"
@@ -27827,7 +27827,7 @@ msgstr "Brak wartości {0} dla {1}"
 
 #: frappe/core/doctype/data_import/importer.py:751 frappe/utils/data.py:710
 msgid "Value {0} must be in the valid duration format: d h m s"
-msgstr ""
+msgstr "Wartość {0} musi mieć prawidłowy format czasu trwania: dhms"
 
 #: frappe/core/doctype/data_import/importer.py:738
 msgid "Value {0} must in {1} format"
@@ -27947,7 +27947,7 @@ msgstr "Wyświetl dozwolone dokumenty"
 #. Label of a Button field in DocType 'Notification'
 #: frappe/email/doctype/notification/notification.json
 msgid "View Properties (via Customize Form)"
-msgstr ""
+msgstr "Właściwości widoku (przez Customize Form)"
 
 #: frappe/social/doctype/energy_point_log/energy_point_log_list.js:20
 msgid "View Ref"
@@ -28208,22 +28208,22 @@ msgstr ""
 #: frappe/integrations/doctype/webhook/webhook.json
 #: frappe/integrations/doctype/webhook_data/webhook_data.json
 msgid "Webhook Data"
-msgstr ""
+msgstr "Dane Webhook"
 
 #. Name of a DocType
 #: frappe/integrations/doctype/webhook_header/webhook_header.json
 msgid "Webhook Header"
-msgstr ""
+msgstr "Nagłówek Webhook"
 
 #. Label of a Section Break field in DocType 'Webhook'
 #: frappe/integrations/doctype/webhook/webhook.json
 msgid "Webhook Headers"
-msgstr ""
+msgstr "Nagłówki Webhook"
 
 #. Label of a Section Break field in DocType 'Webhook'
 #: frappe/integrations/doctype/webhook/webhook.json
 msgid "Webhook Request"
-msgstr ""
+msgstr "Żądanie Webhook"
 
 #. Linked DocType in Webhook's connections
 #. Name of a DocType
@@ -28235,22 +28235,22 @@ msgstr ""
 #. Label of a Password field in DocType 'Webhook'
 #: frappe/integrations/doctype/webhook/webhook.json
 msgid "Webhook Secret"
-msgstr ""
+msgstr "Secret Webhook"
 
 #. Label of a Section Break field in DocType 'Webhook'
 #: frappe/integrations/doctype/webhook/webhook.json
 msgid "Webhook Security"
-msgstr ""
+msgstr "Bezpieczeństwo Webhook"
 
 #. Label of a Section Break field in DocType 'Webhook'
 #: frappe/integrations/doctype/webhook/webhook.json
 msgid "Webhook Trigger"
-msgstr ""
+msgstr "Wyzwalacz Webhook"
 
 #. Label of a Data field in DocType 'Slack Webhook URL'
 #: frappe/integrations/doctype/slack_webhook_url/slack_webhook_url.json
 msgid "Webhook URL"
-msgstr ""
+msgstr "Adres URL webhooka"
 
 #. Group in Module Def's connections
 #. Name of a Workspace
@@ -28290,7 +28290,7 @@ msgstr ""
 #. Name of a DocType
 #: frappe/website/doctype/website_meta_tag/website_meta_tag.json
 msgid "Website Meta Tag"
-msgstr ""
+msgstr "Metatag witryny"
 
 #. Name of a DocType
 #. Label of a Link in the Website Workspace
@@ -28547,7 +28547,7 @@ msgstr ""
 #. Description of the 'Short Name' (Data) field in DocType 'Blogger'
 #: frappe/website/doctype/blogger/blogger.json
 msgid "Will be used in url (usually first name)."
-msgstr ""
+msgstr "Zostanie użyty w URL'u (zazwyczaj imię)"
 
 #: frappe/desk/page/setup_wizard/setup_wizard.js:463
 msgid "Will be your login ID"
@@ -28594,7 +28594,7 @@ msgstr ""
 #: frappe/public/js/workflow_builder/store.js:129
 #: frappe/workflow/doctype/workflow/workflow.json
 msgid "Workflow"
-msgstr ""
+msgstr "Przepływ pracy (Workflow)"
 
 #. Name of a DocType
 #: frappe/workflow/doctype/workflow_action/workflow_action.json
@@ -28687,7 +28687,7 @@ msgstr "Status przepływu pracy"
 #. Name of a DocType
 #: frappe/workflow/doctype/workflow_transition/workflow_transition.json
 msgid "Workflow Transition"
-msgstr ""
+msgstr "Tranzycja Przepływu Pracy"
 
 #. Description of a DocType
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
@@ -28952,7 +28952,7 @@ msgstr "Nie masz uprawnień, aby wydrukować ten raport"
 
 #: frappe/public/js/frappe/views/communication.js:772
 msgid "You are not allowed to send emails related to this document"
-msgstr ""
+msgstr "Nie masz uprawnień aby wysłyłać maile powiązane z tym dokumentem"
 
 #: frappe/website/doctype/web_form/web_form.py:528
 msgid "You are not allowed to update this Web Form Document"
@@ -28993,7 +28993,7 @@ msgstr ""
 
 #: frappe/printing/page/print_format_builder/print_format_builder.js:741
 msgid "You can add dynamic properties from the document by using Jinja templating."
-msgstr ""
+msgstr "Możesz dodać właściwości dynamiczne z dokumentu za pomocą Jinja templating."
 
 #: frappe/printing/doctype/letter_head/letter_head.js:32
 msgid "You can also access wkhtmltopdf variables (valid only in PDF print):"
@@ -29083,7 +29083,7 @@ msgstr "Nie można ustawić opcji dla pola {0}"
 
 #: frappe/custom/doctype/customize_form/customize_form.py:390
 msgid "You can't set 'Translatable' for field {0}"
-msgstr ""
+msgstr "Nie można ustawić opcji &quot;Translatable&quot; dla pola {0}"
 
 #: frappe/public/js/frappe/form/footer/version_timeline_content_builder.js:74
 msgctxt "Form timeline"
@@ -29216,7 +29216,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/model/create_new.js:328
 msgid "You have unsaved changes in this form. Please save before you continue."
-msgstr ""
+msgstr "Masz niezapisane zmiany na tym formularzu. Zapisz zmiany aby kontynuować."
 
 #: frappe/public/js/frappe/ui/toolbar/navbar.html:50
 msgid "You have unseen notifications"
@@ -29269,19 +29269,19 @@ msgstr ""
 
 #: frappe/website/doctype/web_form/web_form.py:92
 msgid "You need to be in developer mode to edit a Standard Web Form"
-msgstr ""
+msgstr "Musisz być w trybie programisty aby edytować standardowy formularz internetowy"
 
 #: frappe/utils/response.py:262
 msgid "You need to be logged in and have System Manager Role to be able to access backups."
-msgstr ""
+msgstr "Musisz być zalogowany jako Administrator Systemu aby mieć dostęp do backup'ów."
 
 #: frappe/www/me.py:13 frappe/www/third_party_apps.py:10
 msgid "You need to be logged in to access this page"
-msgstr ""
+msgstr "Musisz być zalogowany aby uzyskać dostęp do tej strony"
 
 #: frappe/website/doctype/web_form/web_form.py:162
 msgid "You need to be logged in to access this {0}."
-msgstr ""
+msgstr "Musisz być zalogowany aby uzyskać dostęp do tego {0}."
 
 #: frappe/public/js/frappe/widgets/links_widget.js:63
 msgid "You need to create these first: "
@@ -29297,7 +29297,7 @@ msgstr "Musisz mieć uprawnienia \"Udostępnij\""
 
 #: frappe/utils/print_format.py:261
 msgid "You need to install pycups to use this feature!"
-msgstr ""
+msgstr "Aby korzystać z tej funkcji, musisz zainstalować programy pycups!"
 
 #: frappe/core/doctype/recorder/recorder.js:38
 msgid "You need to select indexes you want to add first."
@@ -29409,7 +29409,7 @@ msgstr "Twoja prośba o połączenie z Kalendarzem Google została zaakceptowana
 
 #: frappe/www/contact.html:35
 msgid "Your email address"
-msgstr ""
+msgstr "Twój adres email"
 
 #: frappe/public/js/frappe/web_form/web_form.js:428
 msgid "Your form has been successfully updated"
@@ -29659,7 +29659,7 @@ msgstr "szewron w dół"
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "chevron-left"
-msgstr ""
+msgstr "lewy lewy"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
@@ -29728,7 +29728,7 @@ msgstr "re"
 #. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: frappe/desk/doctype/workspace/workspace.json
 msgid "darkgrey"
-msgstr ""
+msgstr "ciemno szary"
 
 #: frappe/core/page/dashboard_view/dashboard_view.js:65
 msgid "dashboard"
@@ -29737,12 +29737,12 @@ msgstr "deska rozdzielcza"
 #. Option for the 'Date Format' (Select) field in DocType 'System Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
 msgid "dd-mm-yyyy"
-msgstr ""
+msgstr "dd-mm-rrrr"
 
 #. Option for the 'Date Format' (Select) field in DocType 'System Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
 msgid "dd.mm.yyyy"
-msgstr ""
+msgstr "dd.mm.rrrr"
 
 #. Option for the 'Date Format' (Select) field in DocType 'System Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
@@ -29774,7 +29774,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/ui/toolbar/awesome_bar.js:163
 msgid "document type..., e.g. customer"
-msgstr ""
+msgstr "Typ dokumentu ..., np klienta"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
@@ -29790,35 +29790,35 @@ msgstr ""
 #. Account'
 #: frappe/email/doctype/email_account/email_account.json
 msgid "e.g. \"Support\", \"Sales\", \"Jerry Yang\""
-msgstr ""
+msgstr "np \"Pomoc \",\" Sprzedaż \",\" Jerry Yang \""
 
 #: frappe/public/js/frappe/ui/toolbar/awesome_bar.js:183
 msgid "e.g. (55 + 434) / 4 or =Math.sin(Math.PI/2)..."
-msgstr ""
+msgstr "na przykład (55 + 434) / 4 lub = Math.sin (Math.PI / 2) ..."
 
 #. Description of the 'Incoming Server' (Data) field in DocType 'Email Account'
 #. Description of the 'Incoming Server' (Data) field in DocType 'Email Domain'
 #: frappe/email/doctype/email_account/email_account.json
 #: frappe/email/doctype/email_domain/email_domain.json
 msgid "e.g. pop.gmail.com / imap.gmail.com"
-msgstr ""
+msgstr "np pop.gmail.com / imap.gmail.com"
 
 #. Description of the 'Default Incoming' (Check) field in DocType 'Email
 #. Account'
 #: frappe/email/doctype/email_account/email_account.json
 msgid "e.g. replies@yourcomany.com. All replies will come to this inbox."
-msgstr ""
+msgstr "np replies@yourcomany.com. Wszystkie odpowiedzi przyjdą do tej skrzynki."
 
 #. Description of the 'Outgoing Server' (Data) field in DocType 'Email Account'
 #. Description of the 'Outgoing Server' (Data) field in DocType 'Email Domain'
 #: frappe/email/doctype/email_account/email_account.json
 #: frappe/email/doctype/email_domain/email_domain.json
 msgid "e.g. smtp.gmail.com"
-msgstr ""
+msgstr "np smtp.gmail.com"
 
 #: frappe/custom/doctype/custom_field/custom_field.js:98
 msgid "e.g.:"
-msgstr ""
+msgstr "np:"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
@@ -29894,7 +29894,7 @@ msgstr ""
 #. Login Key'
 #: frappe/integrations/doctype/social_login_key/social_login_key.json
 msgid "fairlogin"
-msgstr ""
+msgstr "Fairlogin"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
@@ -30087,7 +30087,7 @@ msgstr "znak informacyjny"
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "italic"
-msgstr ""
+msgstr "Italic"
 
 #: frappe/templates/signup.html:11 frappe/www/login.html:10
 msgid "jane@example.com"
@@ -30191,7 +30191,7 @@ msgstr "znak minusa"
 #. Option for the 'Date Format' (Select) field in DocType 'System Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
 msgid "mm-dd-yyyy"
-msgstr ""
+msgstr "mm-dd-rrrr"
 
 #. Option for the 'Date Format' (Select) field in DocType 'System Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
@@ -30440,12 +30440,12 @@ msgstr "usunąć"
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "remove-circle"
-msgstr ""
+msgstr "usuń-koło"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "remove-sign"
-msgstr ""
+msgstr "usuń-znak"
 
 #: frappe/public/js/frappe/form/footer/version_timeline_content_builder.js:234
 msgid "removed rows for {0}"
@@ -30474,7 +30474,7 @@ msgstr "pełne przeskalowanie"
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "resize-horizontal"
-msgstr ""
+msgstr "zmień rozmiar-horyzontalnie"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
@@ -30484,7 +30484,7 @@ msgstr "zmień rozmiar-mały"
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "resize-vertical"
-msgstr ""
+msgstr "zmień rozmiar-wertykalnie"
 
 #. Label of a HTML field in DocType 'Custom Role'
 #: frappe/core/doctype/custom_role/custom_role.json
@@ -30784,17 +30784,17 @@ msgstr "przez {0}"
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "volume-down"
-msgstr ""
+msgstr "obniż-głośność"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "volume-off"
-msgstr ""
+msgstr "wyłącz-głośność"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "volume-up"
-msgstr ""
+msgstr "zwiększ-głośność"
 
 #: frappe/templates/includes/oauth_confirmation.html:5
 msgid "wants to access the following details from your account"
@@ -30838,7 +30838,7 @@ msgstr "wczoraj"
 #. Option for the 'Date Format' (Select) field in DocType 'System Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
 msgid "yyyy-mm-dd"
-msgstr ""
+msgstr "rrrr-mm-dd"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
@@ -30869,7 +30869,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/data_import/data_exporter.js:77
 msgid "{0} ({1}) (1 row mandatory)"
-msgstr ""
+msgstr "{0} ({1}) (1 wiersz obowiązkowy)"
 
 #: frappe/public/js/frappe/views/gantt/gantt_view.js:53
 msgid "{0} ({1}) - {2}%"
@@ -31328,7 +31328,7 @@ msgstr ""
 
 #: frappe/printing/doctype/print_format/print_format.py:165
 msgid "{0} is now default print format for {1} doctype"
-msgstr ""
+msgstr "{0} jest teraz domyślnym formatem drukowania dla {1} doctype"
 
 #: frappe/public/js/frappe/views/reports/report_view.js:1435
 msgid "{0} is one of {1}"
@@ -31548,7 +31548,7 @@ msgstr "{0} abonentów dodano"
 
 #: frappe/email/queue.py:68
 msgid "{0} to stop receiving emails of this type"
-msgstr ""
+msgstr "{0}, aby zatrzymać otrzymywanie e-maili tego typu"
 
 #: frappe/public/js/frappe/form/controls/date_range.js:48
 #: frappe/public/js/frappe/form/controls/date_range.js:64
@@ -31558,7 +31558,7 @@ msgstr "{0} do {1}"
 
 #: frappe/core/doctype/docshare/docshare.py:88
 msgid "{0} un-shared this document with {1}"
-msgstr ""
+msgstr "{0} nie-podzielali ten dokument z {1}"
 
 #: frappe/custom/doctype/customize_form/customize_form.py:250
 msgid "{0} updated"
@@ -31626,7 +31626,7 @@ msgstr "{0} {1}: przesłanego rekordu nie można usunąć. Najpierw musisz {2} a
 
 #: frappe/model/base_document.py:1032
 msgid "{0}, Row {1}"
-msgstr ""
+msgstr "{0}, wiersz {1}"
 
 #: frappe/utils/print_format.py:151 frappe/utils/print_format.py:195
 msgid "{0}/{1} complete | Please leave this tab open until completion."
@@ -31642,15 +31642,15 @@ msgstr "{0} Nie możesz wnieść poprawek bez anulowania"
 
 #: frappe/core/doctype/doctype/doctype.py:1780
 msgid "{0}: Cannot set Assign Amend if not Submittable"
-msgstr ""
+msgstr "{0}: Nie można ustawić Przypisz zmień, jeśli nie można przesłać"
 
 #: frappe/core/doctype/doctype/doctype.py:1778
 msgid "{0}: Cannot set Assign Submit if not Submittable"
-msgstr ""
+msgstr "{0}: Nie można ustawić Assign Submit, jeśli nie można przesłać"
 
 #: frappe/core/doctype/doctype/doctype.py:1757
 msgid "{0}: Cannot set Cancel without Submit"
-msgstr ""
+msgstr "{0} : Nie można ustawić Anuluj bez Zatwierdź"
 
 #: frappe/core/doctype/doctype/doctype.py:1764
 msgid "{0}: Cannot set Import without Create"
@@ -31658,7 +31658,7 @@ msgstr "{0}: Nie możesz ustawić importu bez jego tworzenia"
 
 #: frappe/core/doctype/doctype/doctype.py:1760
 msgid "{0}: Cannot set Submit, Cancel, Amend without Write"
-msgstr ""
+msgstr "{0} : Nie można ustawić Zatwierdź , Anuluj , Zmienić bez wypełnienia pola"
 
 #: frappe/core/doctype/doctype/doctype.py:1784
 msgid "{0}: Cannot set import as {1} is not importable"
@@ -31706,7 +31706,7 @@ msgstr "{0}: Opcje wymagane dla pola Typ łącza lub tabeli {1} w wierszu {2}"
 
 #: frappe/core/doctype/doctype/doctype.py:1284
 msgid "{0}: Options {1} must be the same as doctype name {2} for the field {3}"
-msgstr ""
+msgstr "{0}: Opcje {1} muszą być takie same jak nazwa doctype {2} dla pola {3}"
 
 #: frappe/public/js/frappe/form/workflow.js:45
 msgid "{0}: Other permission rules may also apply"
@@ -31739,7 +31739,7 @@ msgstr "{0}: {1} kontra {2}"
 
 #: frappe/core/doctype/doctype/doctype.py:1396
 msgid "{0}:Fieldtype {1} for {2} cannot be indexed"
-msgstr ""
+msgstr "{0}: Nie można zaindeksować typu pola {1} dla {2}"
 
 #: frappe/public/js/frappe/utils/datatable.js:12
 msgid "{count} cell copied"

--- a/frappe/locale/zh.po
+++ b/frappe/locale/zh.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: developers@frappe.io\n"
 "POT-Creation-Date: 2025-02-24 14:51+0000\n"
-"PO-Revision-Date: 2025-03-05 17:25\n"
+"PO-Revision-Date: 2025-03-16 21:01\n"
 "Last-Translator: developers@frappe.io\n"
 "Language-Team: Chinese Simplified\n"
 "MIME-Version: 1.0\n"
@@ -821,7 +821,7 @@ msgstr "不允许从该IP地址访问"
 #. Label of a Section Break field in DocType 'Email Account'
 #: frappe/email/doctype/email_account/email_account.json
 msgid "Account"
-msgstr "科目"
+msgstr "帐户"
 
 #. Label of a Section Break field in DocType 'Website Settings'
 #: frappe/website/doctype/website_settings/website_settings.json
@@ -833,7 +833,7 @@ msgstr ""
 #: frappe/contacts/doctype/contact/contact.json
 #: frappe/geo/doctype/currency/currency.json
 msgid "Accounts Manager"
-msgstr "会计经理"
+msgstr "账务主管"
 
 #. Name of a role
 #: frappe/automation/doctype/auto_repeat/auto_repeat.json
@@ -841,7 +841,7 @@ msgstr "会计经理"
 #: frappe/contacts/doctype/contact/contact.json
 #: frappe/geo/doctype/currency/currency.json
 msgid "Accounts User"
-msgstr "会计人员"
+msgstr "账务用户"
 
 #. Label of a Select field in DocType 'Amended Document Naming Settings'
 #. Option for the 'Item Type' (Select) field in DocType 'Navbar Item'
@@ -861,7 +861,7 @@ msgstr "会计人员"
 #: frappe/workflow/doctype/workflow_transition/workflow_transition.json
 #: frappe/workflow/page/workflow_builder/workflow_builder.js:37
 msgid "Action"
-msgstr "行动"
+msgstr "操作"
 
 #. Label of a Small Text field in DocType 'DocType Action'
 #: frappe/core/doctype/doctype_action/doctype_action.json
@@ -928,7 +928,7 @@ msgstr ""
 #: frappe/public/js/frappe/views/reports/query_report.js:214
 #: frappe/public/js/frappe/views/reports/query_report.js:780
 msgid "Actions"
-msgstr "操作"
+msgstr "操作列表"
 
 #. Label of a Check field in DocType 'Package Import'
 #: frappe/core/doctype/package_import/package_import.json
@@ -945,7 +945,7 @@ msgstr ""
 #: frappe/integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
 #: frappe/workflow/doctype/workflow/workflow_list.js:5
 msgid "Active"
-msgstr "活动"
+msgstr "启用"
 
 #. Option for the 'Directory Server' (Select) field in DocType 'LDAP Settings'
 #: frappe/integrations/doctype/ldap_settings/ldap_settings.json
@@ -1096,7 +1096,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/form/grid.js:63
 msgid "Add Multiple"
-msgstr "添加多个"
+msgstr "批量添加"
 
 #: frappe/core/page/permission_manager/permission_manager.js:438
 msgid "Add New Permission Rule"
@@ -1398,7 +1398,7 @@ msgstr "管理"
 #: frappe/desk/doctype/onboarding_step/onboarding_step.json
 #: frappe/website/doctype/website_theme/website_theme.json
 msgid "Administrator"
-msgstr "管理员"
+msgstr "系统管理员"
 
 #: frappe/core/doctype/user/user.py:1158
 msgid "Administrator Logged In"
@@ -2004,7 +2004,7 @@ msgstr ""
 #. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
 #: frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
 msgid "Annual"
-msgstr "全年"
+msgstr "年度"
 
 #. Label of a Code field in DocType 'Personal Data Deletion Request'
 #: frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.json

--- a/frappe/model/__init__.py
+++ b/frappe/model/__init__.py
@@ -115,7 +115,7 @@ core_doctypes_list = (
 	"Custom Field",
 	"Client Script",
 )
-
+CORE_DOCTYPES = frozenset(core_doctypes_list)
 log_types = (
 	"Version",
 	"Error Log",
@@ -220,7 +220,7 @@ def get_permitted_fields(
 	meta = frappe.get_meta(doctype)
 	valid_columns = meta.get_valid_columns()
 
-	if doctype in core_doctypes_list:
+	if doctype in CORE_DOCTYPES:
 		return valid_columns
 
 	# DocType has only fields of type Table (Table, Table MultiSelect)
@@ -230,24 +230,31 @@ def get_permitted_fields(
 	if permission_type is None:
 		permission_type = "select" if frappe.only_has_select_perm(doctype, user=user) else "read"
 
-	meta_fields = meta.default_fields.copy()
-	optional_meta_fields = [x for x in optional_fields if x in valid_columns]
-
-	if permitted_fields := meta.get_permitted_fieldnames(
+	permitted_fields = meta.get_permitted_fieldnames(
 		parenttype=parenttype,
 		user=user,
 		permission_type=permission_type,
 		with_virtual_fields=not ignore_virtual,
-	):
-		if permission_type == "select":
-			return permitted_fields
+	)
 
-		if meta.istable:
-			meta_fields.extend(child_table_fields)
+	if permission_type == "select":
+		return permitted_fields
 
-		return meta_fields + permitted_fields + optional_meta_fields
+	valid_columns = set(valid_columns)
+	result = [
+		*meta.default_fields,
+		*(fieldname for fieldname in optional_fields if fieldname in valid_columns),
+	]
 
-	return meta_fields + optional_meta_fields
+	if not permitted_fields:
+		return result
+
+	if meta.istable:
+		result.extend(child_table_fields)
+
+	result.extend(permitted_fields)
+
+	return result
 
 
 def is_default_field(fieldname: str) -> bool:

--- a/frappe/model/__init__.py
+++ b/frappe/model/__init__.py
@@ -62,7 +62,7 @@ no_value_fields = (
 	"Fold",
 	"Heading",
 )
-
+NO_VALUE_FIELDS = frozenset(no_value_fields)
 display_fieldtypes = (
 	"Section Break",
 	"Column Break",
@@ -88,11 +88,11 @@ default_fields = (
 	"docstatus",
 	"idx",
 )
-
+DEFAULT_FIELDS = frozenset(default_fields)
 child_table_fields = ("parent", "parentfield", "parenttype")
 
 optional_fields = ("_user_tags", "_comments", "_assign", "_liked_by", "_seen")
-
+OPTIONAL_FIELDS = frozenset(optional_fields)
 table_fields = ("Table", "Table MultiSelect")
 
 core_doctypes_list = (
@@ -224,7 +224,7 @@ def get_permitted_fields(
 		return valid_columns
 
 	# DocType has only fields of type Table (Table, Table MultiSelect)
-	if set(valid_columns).issubset(default_fields):
+	if DEFAULT_FIELDS.issuperset(valid_columns):
 		return valid_columns
 
 	if permission_type is None:

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -146,8 +146,8 @@ class BaseDocument:
 		return frappe.get_meta(self.doctype)
 
 	@cached_property
-	def permitted_fieldnames(self):
-		return get_permitted_fields(doctype=self.doctype, parenttype=getattr(self, "parenttype", None))
+	def permitted_fieldnames(self) -> set[str]:
+		return set(get_permitted_fields(doctype=self.doctype, parenttype=getattr(self, "parenttype", None)))
 
 	def __getstate__(self):
 		"""

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -15,7 +15,7 @@ import frappe.share
 from frappe import _
 from frappe.core.doctype.server_script.server_script_utils import get_server_script_map
 from frappe.database.utils import DefaultOrderBy, FallBackDateTimeStr, NestedSetHierarchy
-from frappe.model import OPTIONAL_FIELDS, get_permitted_fields
+from frappe.model import OPTIONAL_FIELDS, get_permitted_fields, optional_fields
 from frappe.model.meta import get_table_columns
 from frappe.model.utils import is_virtual_doctype
 from frappe.model.utils.user_settings import get_user_settings, update_user_settings

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -15,7 +15,7 @@ import frappe.share
 from frappe import _
 from frappe.core.doctype.server_script.server_script_utils import get_server_script_map
 from frappe.database.utils import DefaultOrderBy, FallBackDateTimeStr, NestedSetHierarchy
-from frappe.model import get_permitted_fields, optional_fields
+from frappe.model import OPTIONAL_FIELDS, get_permitted_fields
 from frappe.model.meta import get_table_columns
 from frappe.model.utils import is_virtual_doctype
 from frappe.model.utils.user_settings import get_user_settings, update_user_settings
@@ -651,12 +651,15 @@ class DatabaseQuery:
 			return
 
 		asterisk_fields = []
-		permitted_fields = get_permitted_fields(
-			doctype=self.doctype,
-			parenttype=self.parent_doctype,
-			permission_type=self.permission_map.get(self.doctype),
-			ignore_virtual=True,
+		permitted_fields = set(
+			get_permitted_fields(
+				doctype=self.doctype,
+				parenttype=self.parent_doctype,
+				permission_type=self.permission_map.get(self.doctype),
+				ignore_virtual=True,
+			)
 		)
+		permitted_child_table_fields = {}
 
 		for i, field in enumerate(self.fields):
 			# field: 'count(distinct `tabPhoto`.name) as total_count'
@@ -674,35 +677,41 @@ class DatabaseQuery:
 				continue
 
 			# handle pseudo columns
-			elif not column or column.isnumeric():
+			if not column or column.isnumeric():
 				continue
 
 			# labels / pseudo columns or frappe internals
-			elif column[0] in {"'", '"'} or column in optional_fields:
+			if column[0] in {"'", '"'}:
 				continue
 
-			# handle child / joined table fields
-			elif "." in field:
+			doctype = None
+
+			if "." in column:
 				table, column = column.split(".", 1)
-				ch_doctype = table
+				doctype = self.linked_table_aliases[table] if table in self.linked_table_aliases else table
+				doctype = doctype.replace("`", "").removeprefix("tab")
 
-				if ch_doctype in self.linked_table_aliases:
-					ch_doctype = self.linked_table_aliases[ch_doctype]
+			# handle child / joined table fields
+			if doctype and doctype != self.doctype:
+				if wrap_grave_quotes(table) not in self.query_tables:
+					raise frappe.PermissionError(doctype)
 
-				ch_doctype = ch_doctype.replace("`", "").replace("tab", "", 1)
-
-				if wrap_grave_quotes(table) in self.query_tables:
-					permitted_child_table_fields = get_permitted_fields(
-						doctype=ch_doctype, parenttype=self.doctype, ignore_virtual=True
+				if doctype not in permitted_child_table_fields:
+					permitted_child_table_fields[doctype] = set(
+						get_permitted_fields(
+							doctype=doctype,
+							parenttype=self.doctype,
+							ignore_virtual=True,
+						)
 					)
-					if column in permitted_child_table_fields or column in optional_fields:
-						continue
-					else:
-						self.remove_field(i)
-				else:
-					raise frappe.PermissionError(ch_doctype)
 
-			elif column in permitted_fields:
+				if column in permitted_child_table_fields[doctype] or column in OPTIONAL_FIELDS:
+					continue
+
+				self.remove_field(i)
+				continue
+
+			if column in OPTIONAL_FIELDS or column in permitted_fields:
 				continue
 
 			# field inside function calls / * handles things like count(*)

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -23,6 +23,7 @@ import click
 import frappe
 from frappe import _, _lt
 from frappe.model import (
+	NO_VALUE_FIELDS,
 	child_table_fields,
 	data_fieldtypes,
 	default_fields,
@@ -284,7 +285,7 @@ class Meta(Document):
 			link_fields = [df.fieldname for df in self.get_link_fields()]
 
 		for df in self.fields:
-			if df.fieldtype not in no_value_fields and getattr(df, "fetch_from", None):
+			if df.fieldtype not in NO_VALUE_FIELDS and getattr(df, "fetch_from", None):
 				if link_fieldname:
 					if df.fetch_from.startswith(link_fieldname + "."):
 						out.append(df)
@@ -611,7 +612,7 @@ class Meta(Document):
 
 	def get_permlevel_access(self, permission_type="read", parenttype=None, *, user=None):
 		has_access_to = []
-		roles = frappe.get_roles(user)
+		roles = set(frappe.get_roles(user))
 		for perm in self.get_permissions(parenttype):
 			if perm.role in roles and perm.get(permission_type):
 				if perm.permlevel not in has_access_to:

--- a/frappe/onboarding.py
+++ b/frappe/onboarding.py
@@ -1,0 +1,25 @@
+import json
+
+import frappe
+
+
+@frappe.whitelist()
+def get_onboarding_status():
+	onboarding_status = frappe.db.get_value("User", frappe.session.user, "onboarding_status")
+	return frappe.parse_json(onboarding_status) if onboarding_status else {}
+
+
+@frappe.whitelist()
+def update_user_onboarding_status(steps: str, appName: str):
+	steps = json.loads(steps)
+
+	# get the current onboarding status
+	onboarding_status = frappe.db.get_value("User", frappe.session.user, "onboarding_status")
+	onboarding_status = frappe.parse_json(onboarding_status)
+
+	# update the onboarding status
+	onboarding_status[appName + "_onboarding_status"] = steps
+
+	frappe.db.set_value(
+		"User", frappe.session.user, "onboarding_status", json.dumps(onboarding_status), update_modified=False
+	)

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -239,3 +239,4 @@ frappe.integrations.doctype.oauth_client.patches.set_default_allowed_role_in_oau
 frappe.patches.v16_0.add_app_launcher_in_navbar_settings
 frappe.patches.v15_0.remove_workspace_settings_navbar_items
 frappe.patches.v16_0.move_role_desk_settings_to_user
+frappe.patches.v14_0.fix_user_settings_collation

--- a/frappe/patches/v14_0/fix_user_settings_collation.py
+++ b/frappe/patches/v14_0/fix_user_settings_collation.py
@@ -1,0 +1,5 @@
+import frappe
+
+
+def execute():
+	frappe.db.sql("ALTER TABLE __UserSettings CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;")

--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -35,21 +35,25 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 	}
 	clear_attachment() {
 		let me = this;
-		if (this.frm) {
-			me.parse_validate_and_set_in_model(null);
-			me.refresh();
-			me.frm.attachments.remove_attachment_by_filename(me.value, async () => {
-				await me.parse_validate_and_set_in_model(null);
+		frappe.confirm(__("Are you sure you want to delete the attachment?"), function () {
+			if (me.frm) {
+				me.parse_validate_and_set_in_model(null);
+
+
 				me.refresh();
-				me.frm.doc.docstatus == 1 ? me.frm.save("Update") : me.frm.save();
-			});
-		} else {
-			this.dataurl = null;
-			this.fileobj = null;
-			this.set_input(null);
-			this.parse_validate_and_set_in_model(null);
-			this.refresh();
-		}
+				me.frm.attachments.remove_attachment_by_filename(me.value, async () => {
+					await me.parse_validate_and_set_in_model(null);
+					me.refresh();
+					me.frm.doc.docstatus == 1 ? me.frm.save("Update") : me.frm.save();
+				});
+			} else {
+				me.dataurl = null;
+				me.fileobj = null;
+				me.set_input(null);
+				me.parse_validate_and_set_in_model(null);
+				me.refresh();
+			}
+		});
 	}
 	reload_attachment() {
 		if (this.file_uploader) {

--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -107,18 +107,22 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 				this.$value
 					.toggle(true)
 					.find(".attached-file-link")
-					.html(frappe.utils.xss_sanitise(filename || this.value))
+					.text(filename || this.value)
 					.attr("href", dataurl || this.value);
 			} else {
 				this.$wrapper.html(`
-					  <div class="attached-file flex justify-between align-center">
+					<div class="attached-file flex justify-between align-center">
 						<div class="ellipsis">
-							<a href="${dataurl || this.value}" target="_blank">${frappe.utils.xss_sanitise(
-					filename || this.value
-				)}</a>
+							<a target="_blank"></a>
+
+
 						</div>
-					  </div>
+					</div>
 				`);
+				this.$wrapper
+					.find("a")
+					.text(filename || this.value)
+					.attr("href", dataurl || this.value);
 			}
 		} else {
 			this.$input.toggle(true);

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -412,11 +412,7 @@ frappe.ui.form.Form = class FrappeForm {
 			this.read_only = frappe.workflow.is_read_only(this.doctype, this.docname);
 			if (this.read_only) {
 				this.set_read_only();
-				this.dashboard.set_headline(
-					__("This form is not editable due to a Workflow."),
-					"blue",
-					true
-				);
+				frappe.show_alert(__("This form is not editable due to a Workflow."));
 			}
 
 			// check if doctype is already open

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -412,7 +412,6 @@ frappe.ui.form.Form = class FrappeForm {
 			this.read_only = frappe.workflow.is_read_only(this.doctype, this.docname);
 			if (this.read_only) {
 				this.set_read_only();
-				frappe.show_alert(__("This form is not editable due to a Workflow."));
 			}
 
 			// check if doctype is already open
@@ -432,10 +431,6 @@ frappe.ui.form.Form = class FrappeForm {
 			// load the record for the first time, if not loaded (call 'onload')
 			this.trigger_onload(switched);
 
-			// if print format is shown, refresh the format
-			// if(this.print_preview.wrapper.is(":visible")) {
-			// 	this.print_preview.preview();
-			// }
 
 			if (switched) {
 				if (this.show_print_first && this.doc.docstatus === 1) {
@@ -729,6 +724,7 @@ frappe.ui.form.Form = class FrappeForm {
 		this.show_submit_message();
 		this.clear_custom_buttons();
 		this.show_web_link();
+		this.show_workflow_read_only_banner();
 	}
 
 	// SAVE
@@ -1185,8 +1181,6 @@ frappe.ui.form.Form = class FrappeForm {
 		} else if (this.doctype == "DocType") {
 			if (frappe.views.formview[docname] || frappe.pages["List/" + docname]) {
 				window.location.reload();
-				//	frappe.msgprint(__("Cannot open {0} when its instance is open", ['DocType']))
-				// throw 'doctype open conflict'
 			}
 		} else {
 			if (
@@ -1194,8 +1188,6 @@ frappe.ui.form.Form = class FrappeForm {
 				frappe.views.formview.DocType.frm.opendocs[this.doctype]
 			) {
 				window.location.reload();
-				//	frappe.msgprint(__("Cannot open instance when its {0} is open", ['DocType']))
-				// throw 'doctype open conflict'
 			}
 		}
 	}
@@ -2143,6 +2135,25 @@ frappe.ui.form.Form = class FrappeForm {
 					wrapper.remove();
 				}
 			});
+	}
+	show_workflow_read_only_banner() {
+		if (!this.read_only) {
+			return;
+		}
+
+		const _show_read_only_banner = () => {
+			this.dashboard.set_headline(
+				__("This form is not editable due to a Workflow."),
+				"blue",
+				true
+			);
+		};
+
+		if (this.dashboard) {
+			_show_read_only_banner();
+		} else {
+			frappe.after_ajax(_show_read_only_banner);
+		}
 	}
 };
 

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -111,8 +111,9 @@ frappe.ui.form.Layout = class Layout {
 			// wrap in a block if `html` does not contain html tags
 			$html = $("<div class='form-message'></div>").text(html);
 		} else {
-			$html = $(html);
-			$html.addClass("form-message");
+			// Wrap in a block just in case the string does not begin with a tag
+			// as Jquery assumes it to be a CSS selector and breaks.
+			$html = $("<div class='form-message'>").html(html);
 		}
 
 		// Add close button to block if not permanent

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -171,7 +171,6 @@ frappe.views.BaseList = class BaseList {
 		!this.hide_card_layout && this.page.main.addClass("frappe-card");
 		this.page.page_form.removeClass("row").addClass("flex");
 		this.hide_page_form && this.page.page_form.hide();
-		this.hide_sidebar && this.$page.addClass("no-list-sidebar");
 		this.setup_page_head();
 	}
 
@@ -276,7 +275,9 @@ frappe.views.BaseList = class BaseList {
 	}
 
 	setup_side_bar() {
-		if (this.hide_sidebar || !frappe.boot.desk_settings.list_sidebar) return;
+		if (this.page.disable_sidebar_toggle) {
+			return;
+		}
 		this.list_sidebar = new frappe.views.ListSidebar({
 			doctype: this.doctype,
 			stats: this.stats,

--- a/frappe/public/js/frappe/list/list_factory.js
+++ b/frappe/public/js/frappe/list/list_factory.js
@@ -27,9 +27,11 @@ frappe.views.ListFactory = class ListFactory extends frappe.views.Factory {
 
 		frappe.provide("frappe.views.list_view." + doctype);
 
+		const hide_sidebar = view_class.no_sidebar || !frappe.boot.desk_settings.list_sidebar;
+	
 		frappe.views.list_view[me.page_name] = new view_class({
 			doctype: doctype,
-			parent: me.make_page(true, me.page_name),
+			parent: me.make_page(true, me.page_name, hide_sidebar),
 		});
 
 		me.set_cur_list();

--- a/frappe/public/js/frappe/list/list_sidebar.js
+++ b/frappe/public/js/frappe/list/list_sidebar.js
@@ -41,6 +41,8 @@ frappe.views.ListSidebar = class ListSidebar {
 
 		if (frappe.user.has_role("System Manager")) {
 			this.add_insights_banner();
+			this.add_crm_banner();
+			this.add_helpdesk_banner();
 		}
 	}
 
@@ -256,39 +258,54 @@ frappe.views.ListSidebar = class ListSidebar {
 		this.get_stats();
 	}
 
-	add_insights_banner() {
+	add_banner(message, link, cta) {
 		try {
-			if (this.list_view.view != "Report") {
-				return;
-			}
-
-			if (localStorage.getItem("show_insights_banner") == "false") {
-				return;
-			}
-
-			if (this.insights_banner) {
-				this.insights_banner.remove();
-			}
-
-			const message = __("Get more insights with");
-			const link = "https://frappe.io/s/insights";
-			const cta = __("Frappe Insights");
-
-			this.insights_banner = $(`
-				<div style="position: relative;">
-					<div class="pr-3">
-						${message} <a href="${link}" target="_blank" style="color: var(--text-color)">${cta} &rarr; </a>
-					</div>
-					<div style="position: absolute; top: -1px; right: -4px; cursor: pointer;" title="Dismiss"
-						onclick="localStorage.setItem('show_insights_banner', 'false') || this.parentElement.remove()">
-						<svg class="icon  icon-sm" style="">
-							<use class="" href="#icon-close"></use>
-						</svg>
-					</div>
+			this.banner = $(`
+				<div class="sidebar-section">
+					${message} <a href="${link}" target="_blank" style="color: var(--text-color)">${cta} &rarr; </a>
 				</div>
 			`).appendTo(this.sidebar);
 		} catch (error) {
 			console.error(error);
 		}
+	}
+
+	add_insights_banner() {
+		if (this.list_view.view != "Report") {
+			return;
+		}
+
+		if (localStorage.getItem("show_insights_banner") == "false") {
+			return;
+		}
+
+		const message = __("Get more insights with");
+		const link = "https://frappe.io/s/insights";
+		const cta = "Frappe Insights";
+		this.add_banner(message, link, cta);
+	}
+
+	add_crm_banner() {
+		if (this.list_view.meta.module != "CRM" || this.list_view.view != "List") {
+			return;
+		}
+
+		const message = "";
+		const link =
+			"https://frappe.io/crm?utm_source=crm-sidebar&utm_medium=sidebar&utm_campaign=frappe-ad";
+		const cta = __("Switch to Frappe CRM for smarter sales");
+		this.add_banner(message, link, cta);
+	}
+
+	add_helpdesk_banner() {
+		if (this.list_view.meta.module != "Support" || this.list_view.view != "List") {
+			return;
+		}
+
+		const message = "";
+		const link =
+			"https://frappe.io/helpdesk?utm_source=support-sidebar&utm_medium=sidebar&utm_campaign=frappe-ad";
+		const cta = __("Upgrade your support experience with Frappe Helpdesk");
+		this.add_banner(message, link, cta);
 	}
 };

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1745,7 +1745,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		items.push({
 			label: __("Toggle Sidebar", null, "Button in list view menu"),
 			action: () => this.toggle_side_bar(),
-			condition: () => !this.hide_sidebar,
+			condition: () => !this.page.disable_sidebar_toggle,
 			standard: true,
 			shortcut: "Ctrl+K",
 		});

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -26,7 +26,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		this.show();
 		const meta = frappe.get_meta(this.doctype);
 		this.is_large_table = meta?.is_large_table;
-		this.applied_recency_filters = false;
 		this.debounced_refresh = frappe.utils.debounce(
 			this.process_document_refreshes.bind(this),
 			2000

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -24,6 +24,9 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	constructor(opts) {
 		super(opts);
 		this.show();
+		const meta = frappe.get_meta(this.doctype);
+		this.is_large_table = meta?.is_large_table;
+		this.applied_recency_filters = false;
 		this.debounced_refresh = frappe.utils.debounce(
 			this.process_document_refreshes.bind(this),
 			2000
@@ -109,9 +112,29 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		if (this.view_name == "List") this.toggle_paging = true;
 
 		this.patch_refresh_and_load_lib();
-		return this.get_list_view_settings();
+		return this.get_list_view_settings().then(() => this.add_recent_filter_on_large_tables());
 	}
+	add_recent_filter_on_large_tables() {
+		if (!this.is_large_table || this.list_view_settings?.disable_automatic_recency_filters) {
+			return;
+		}
+		// Note: versions older than v16 should use "modified" here.
+		const recency_field = "modified";
 
+		if (this.filters.length) {
+			return;
+		}
+		this.filters.push([this.doctype, recency_field, "Timespan", "last 90 days"]);
+		frappe.show_alert(
+			{
+				message: __(
+					"Automatically applied a filter for recent data. You can disable this behavior from the list view settings."
+				),
+				indicator: "yellow",
+			},
+			3
+		);
+	}
 	on_sort_change(sort_by, sort_order) {
 		this.sort_by = sort_by;
 		this.sort_order = sort_order;

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -188,6 +188,7 @@ frappe.ui.Page = class Page {
 		let sidebar_wrapper = this.wrapper.find(".layout-side-section");
 		if (this.disable_sidebar_toggle || !sidebar_wrapper.length) {
 			sidebar_toggle.last().remove();
+			this.wrapper.addClass("no-list-sidebar");
 		} else {
 			if (!frappe.is_mobile()) {
 				sidebar_toggle.attr("title", __("Toggle Sidebar"));

--- a/frappe/public/js/frappe/ui/sort_selector.js
+++ b/frappe/public/js/frappe/ui/sort_selector.js
@@ -103,13 +103,15 @@ frappe.ui.SortSelector = class SortSelector {
 
 		var { meta_sort_field, meta_sort_order } = this.get_meta_sort_field();
 
-		if (meta_sort_field) {
-			this.args.sort_by = meta_sort_field;
-			this.args.sort_order = meta_sort_order;
-		} else {
-			// default
-			this.args.sort_by = "creation";
-			this.args.sort_order = "desc";
+		if (!this.args.sort_by) {
+			if (meta_sort_field) {
+				this.args.sort_by = meta_sort_field;
+				this.args.sort_order = meta_sort_order;
+			} else {
+				// default
+				this.args.sort_by = "creation";
+				this.args.sort_order = "desc";
+			}
 		}
 
 		if (!this.args.sort_by_label) {

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -171,16 +171,12 @@ Object.assign(frappe.utils, {
 	is_html: function (txt) {
 		if (!txt) return false;
 
-		if (
-			txt.indexOf("<br>") == -1 &&
-			txt.indexOf("<p") == -1 &&
-			txt.indexOf("<img") == -1 &&
-			txt.indexOf("<div") == -1 &&
-			!txt.includes("<span")
-		) {
-			return false;
-		}
-		return true;
+		const doc = new DOMParser().parseFromString(txt, "text/html");
+		const nodes = doc.body.childNodes || [];
+
+		// check if any of the nodes are element nodes
+		// Ref: https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
+		return [...nodes].some((node) => node.nodeType === 1);
 	},
 	is_mac: function () {
 		return window.navigator.platform === "MacIntel";

--- a/frappe/public/js/frappe/views/dashboard/dashboard_view.js
+++ b/frappe/public/js/frappe/views/dashboard/dashboard_view.js
@@ -5,6 +5,8 @@ frappe.views.DashboardView = class DashboardView extends frappe.views.ListView {
 		return "Dashboard";
 	}
 
+	static no_sidebar = true;
+
 	setup_defaults() {
 		return super.setup_defaults().then(() => {
 			this.page_title = __("{0} Dashboard", [__(this.doctype)]);
@@ -16,7 +18,6 @@ frappe.views.DashboardView = class DashboardView extends frappe.views.ListView {
 	render() {}
 
 	setup_page() {
-		this.hide_sidebar = true;
 		this.hide_page_form = true;
 		this.hide_filters = true;
 		this.hide_sort_selector = true;

--- a/frappe/public/js/frappe/views/factory.js
+++ b/frappe/public/js/frappe/views/factory.js
@@ -29,12 +29,12 @@ frappe.views.Factory = class Factory {
 		}
 	}
 
-	make_page(double_column, page_name) {
-		return frappe.make_page(double_column, page_name);
+	make_page(double_column, page_name, hide_sidebar) {
+		return frappe.make_page(double_column, page_name, hide_sidebar);
 	}
 };
 
-frappe.make_page = function (double_column, page_name) {
+frappe.make_page = function (double_column, page_name, disable_sidebar_toggle) {
 	if (!page_name) {
 		page_name = frappe.get_route_str();
 	}
@@ -44,6 +44,7 @@ frappe.make_page = function (double_column, page_name) {
 	frappe.ui.make_app_page({
 		parent: page,
 		single_column: !double_column,
+		disable_sidebar_toggle: disable_sidebar_toggle,
 	});
 
 	frappe.container.change_to(page_name);

--- a/frappe/public/js/frappe/views/kanban/kanban_board.bundle.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_board.bundle.js
@@ -585,6 +585,7 @@ frappe.provide("frappe.views");
 				animation: 150,
 				dataIdAttr: "data-name",
 				forceFallback: true,
+				fallbackTolerance: 20,
 				onStart: function () {
 					wrapper.find(".kanban-card.add-card").fadeOut(200, function () {
 						wrapper.find(".kanban-cards").height("100vh");

--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -3,6 +3,8 @@ import KanbanSettings from "./kanban_settings";
 frappe.provide("frappe.views");
 
 frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
+	static no_sidebar = true;
+
 	static load_last_view() {
 		const route = frappe.get_route();
 		if (route.length === 3) {
@@ -131,14 +133,10 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 	}
 
 	setup_page() {
-		this.hide_sidebar = true;
 		this.hide_page_form = true;
 		this.hide_card_layout = true;
 		this.hide_sort_selector = true;
 		super.setup_page();
-
-		this.page.disable_sidebar_toggle = true;
-		this.page.setup_sidebar_toggle();
 	}
 
 	setup_view() {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1264,6 +1264,10 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	}
 
 	prepare_columns(columns) {
+		let is_query_generated_report =
+			this.report_doc.query &&
+			this.report_doc.query != undefined &&
+			this.report_doc.query != "";
 		return columns.map((column) => {
 			column = frappe.report_utils.prepare_field_from_column(column);
 
@@ -1312,7 +1316,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				id: column.fieldname,
 				// The column label should have already been translated in the
 				// backend. Translating it again would cause unexpected behaviour.
-				name: column.label,
+				// Translating based on condition: when a report is generated through a query, the label is not translated.
+				name: is_query_generated_report ? __(column.label) : column.label,
 				width: parseInt(column.width) || null,
 				editable: column.editable ?? false,
 				compareValue: compareFn,

--- a/frappe/rate_limiter.py
+++ b/frappe/rate_limiter.py
@@ -84,7 +84,7 @@ class RateLimiter:
 		headers = {
 			"X-RateLimit-Reset": self.reset,
 			"X-RateLimit-Limit": self.limit,
-			"X-RateLimit-Remaining": self.remaining,
+			"X-RateLimit-Remaining": round(self.remaining, -6),
 		}
 		if self.rejected:
 			headers["Retry-After"] = self.reset

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -833,6 +833,10 @@ class TestBenchBuild(BaseTestCommands):
 
 
 class TestDBUtils(BaseTestCommands):
+	@skipIf(
+		not (frappe.conf.db_type == "mariadb"),
+		"Only for MariaDB",
+	)
 	def test_db_add_index(self):
 		field = "reset_password_key"
 		self.execute("bench --site {site} add-database-index --doctype User --column " + field, {})

--- a/frappe/tests/test_rate_limiter.py
+++ b/frappe/tests/test_rate_limiter.py
@@ -30,11 +30,11 @@ class TestRateLimiter(FrappeTestCase):
 		self.assertFalse(hasattr(frappe.local, "rate_limiter"))
 
 	def test_respond_over_limit(self):
-		limiter = RateLimiter(0.01, 86400)
-		time.sleep(0.01)
+		limiter = RateLimiter(1, 86400)
+		time.sleep(1)
 		limiter.update()
 
-		frappe.conf.rate_limit = {"window": 86400, "limit": 0.01}
+		frappe.conf.rate_limit = {"window": 86400, "limit": 1}
 		self.assertRaises(frappe.TooManyRequestsError, frappe.rate_limiter.apply)
 		frappe.rate_limiter.update()
 
@@ -49,7 +49,7 @@ class TestRateLimiter(FrappeTestCase):
 		self.assertIn("X-RateLimit-Limit", headers)
 		self.assertIn("X-RateLimit-Remaining", headers)
 		self.assertTrue(int(headers["X-RateLimit-Reset"]) <= 86400)
-		self.assertEqual(int(headers["X-RateLimit-Limit"]), 10000)
+		self.assertEqual(int(headers["X-RateLimit-Limit"]), 1000000)
 		self.assertEqual(int(headers["X-RateLimit-Remaining"]), 0)
 
 		frappe.cache.delete(limiter.key)
@@ -67,15 +67,15 @@ class TestRateLimiter(FrappeTestCase):
 		delattr(frappe.local, "rate_limiter")
 
 	def test_headers_under_limit(self):
-		frappe.conf.rate_limit = {"window": 86400, "limit": 0.01}
+		frappe.conf.rate_limit = {"window": 86400, "limit": 1}
 		frappe.rate_limiter.apply()
 		frappe.rate_limiter.update()
 		headers = frappe.local.rate_limiter.headers()
 		self.assertNotIn("Retry-After", headers)
 		self.assertIn("X-RateLimit-Reset", headers)
 		self.assertTrue(int(headers["X-RateLimit-Reset"] < 86400))
-		self.assertEqual(int(headers["X-RateLimit-Limit"]), 10000)
-		self.assertEqual(int(headers["X-RateLimit-Remaining"]), 10000)
+		self.assertEqual(int(headers["X-RateLimit-Limit"]), 1000000)
+		self.assertEqual(int(headers["X-RateLimit-Remaining"]), 1000000)
 
 		frappe.cache.delete(frappe.local.rate_limiter.key)
 		delattr(frappe.local, "rate_limiter")

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -24,7 +24,6 @@ from frappe.tests.utils import FrappeTestCase, MockedRequestTestCase, change_set
 from frappe.utils import (
 	ceil,
 	dict_to_str,
-	evaluate_filters,
 	execute_in_shell,
 	floor,
 	flt,
@@ -57,6 +56,7 @@ from frappe.utils.data import (
 	cint,
 	cstr,
 	duration_to_seconds,
+	evaluate_filters,
 	expand_relative_urls,
 	get_datetime,
 	get_first_day_of_week,
@@ -209,6 +209,18 @@ class TestFilters(FrappeTestCase):
 		for filter, expected_result in test_cases:
 			self.assertEqual(evaluate_filters(doc, filter), expected_result, msg=f"{filter}")
 
+	def test_timespan(self):
+		doc = {
+			"doctype": "User",
+			"last_password_reset_date": getdate(),
+		}
+		self.assertTrue(evaluate_filters(doc, [("last_password_reset_date", "Timespan", "today")]))
+		self.assertFalse(evaluate_filters(doc, [("last_password_reset_date", "Timespan", "last year")]))
+		doc = {
+			"doctype": "User",
+			"last_password_reset_date": None,
+		}
+		self.assertFalse(evaluate_filters(doc, [("last_password_reset_date", "Timespan", "today")]))
 
 class TestMoney(FrappeTestCase):
 	def test_money_in_words(self):

--- a/frappe/types/exporter.py
+++ b/frappe/types/exporter.py
@@ -95,7 +95,7 @@ class TypeExporter:
 
 	def _generate_code(self):
 		for field in self.doc.fields:
-			if iskeyword(field.fieldname):
+			if field.is_virtual and not field.options:
 				continue
 			if python_type := self._map_fieldtype(field):
 				self.field_types[field.fieldname] = python_type

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1737,6 +1737,12 @@ def filter_operator_is(value: str, pattern: str) -> bool:
 	else:
 		frappe.throw(frappe._(f"Invalid argument for operator 'IS': {pattern}"))
 
+def filter_operator_timespan(value: str, pattern: str) -> bool:
+	if not value:
+		return False
+
+	date_range = get_timespan_date_range(pattern)
+	return date_range[0] <= getdate(value) <= date_range[1]
 
 operator_map = {
 	# startswith
@@ -1756,6 +1762,7 @@ operator_map = {
 	"like": sql_like,
 	"not like": lambda a, b: not sql_like(a, b),
 	"is": filter_operator_is,
+	"Timespan": filter_operator_timespan,
 }
 
 
@@ -1779,7 +1786,8 @@ def evaluate_filters(doc, filters: dict | list | tuple):
 def compare(val1: Any, condition: str, val2: Any, fieldtype: str | None = None):
 	if fieldtype:
 		val1 = cast(fieldtype, val1)
-		val2 = cast(fieldtype, val2)
+		if condition != "Timespan":
+			val2 = cast(fieldtype, val2)
 	if condition in operator_map:
 		return operator_map[condition](val1, val2)
 

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1668,7 +1668,7 @@ def get_link_to_report(
 					for value in v
 				)
 			else:
-				conditions.append(str(k) + "=" + str(v))
+				conditions.append(str(k) + "=" + quote(str(v)))
 
 		filters = "&".join(conditions)
 

--- a/frappe/utils/scheduler.py
+++ b/frappe/utils/scheduler.py
@@ -15,10 +15,11 @@ import time
 from typing import NoReturn
 
 from croniter import CroniterBadCronError
+from filelock import FileLock, Timeout
 
 # imports - module imports
 import frappe
-from frappe.utils import cint, get_datetime, get_sites, now_datetime
+from frappe.utils import cint, get_bench_path, get_datetime, get_sites, now_datetime
 from frappe.utils.background_jobs import set_niceness
 from frappe.utils.caching import redis_cache
 
@@ -45,6 +46,23 @@ def start_scheduler() -> NoReturn:
 		time.sleep(tick)
 		enqueue_events_for_all_sites()
 
+def _get_scheduler_lock_file() -> True:
+	return os.path.abspath(os.path.join(get_bench_path(), "config", "scheduler_process"))
+
+
+def is_schduler_process_running() -> bool:
+	"""Checks if any other process is holding the lock.
+
+	Note: FLOCK is held by process until it exits, this function just checks if process is
+	running or not. We can't determine if process is stuck somehwere.
+	"""
+	try:
+		lock = FileLock(_get_scheduler_lock_file())
+		lock.acquire(blocking=False)
+		lock.release()
+		return False
+	except Timeout:
+		return True
 
 def enqueue_events_for_all_sites() -> None:
 	"""Loop through sites and enqueue events that are not already queued"""

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -689,6 +689,11 @@ def get_link_options(web_form_name, doctype, allow_read_on_all_link_options=Fals
 			link_options = [{"value": row.value, "label": _(row.label)} for row in link_options]
 		return json.dumps(link_options, default=str)
 	else:
+		if meta.translated_doctype:
+			# Add `label` as the translated name if "Translate Link Fields" is enabled
+			return [{"value": row.value, "label": _(row.value)} for row in link_options]
+
+		# Use the actual names as options without labels
 		return "\n".join([str(doc.value) for doc in link_options])
 
 

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -676,12 +676,17 @@ def get_link_options(web_form_name, doctype, allow_read_on_all_link_options=Fals
 	fields = ["name as value"]
 
 	meta = frappe.get_meta(doctype)
-	if meta.title_field and meta.show_title_field_in_link:
+	show_title_field = meta.title_field and meta.show_title_field_in_link
+
+	if show_title_field:
 		fields.append(f"{meta.title_field} as label")
 
 	link_options = frappe.get_all(doctype, filters, fields)
 
-	if meta.title_field and meta.show_title_field_in_link:
+	if show_title_field:
+		if meta.translated_doctype:
+			# Translate the labels if "Translate Link Fields" is enabled
+			link_options = [{"value": row.value, "label": _(row.label)} for row in link_options]
 		return json.dumps(link_options, default=str)
 	else:
 		return "\n".join([str(doc.value) for doc in link_options])

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -190,7 +190,7 @@ def get_boot_data():
 		},
 		"assets_json": get_assets_json(),
 		"sitename": frappe.local.site,
-		"is_fc_site": is_fc_site(),
+		"is_fc_site": 1 if is_fc_site() else 0,
 	}
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [
     { name = "Frappe Technologies Pvt Ltd", email = "developers@frappe.io"}
 ]
 description = "Metadata driven, full-stack low code web framework"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.14"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [
@@ -15,7 +15,7 @@ dependencies = [
     "filetype~=1.2.0",
     "GitPython~=3.1.34",
     "Jinja2~=3.1.2",
-    "Pillow~=10.3.0",
+    "Pillow~=11.0.0",
     "PyJWT~=2.8.0",
     # We depend on internal attributes,
     # do NOT add loose requirements on PyMySQL versions.
@@ -55,7 +55,7 @@ dependencies = [
     "psutil~=5.9.5",
     "psycopg2-binary~=2.9.1",
     "pyOpenSSL~=24.2.1",
-    "pydantic~=2.7.0",
+     "pydantic~=2.10.2",
     "pyotp~=2.8.0",
     "python-dateutil~=2.8.2",
     "pytz==2023.3",


### PR DESCRIPTION
### Bug Fixes

* always persist all indexes added via db.add_index 
* avoid overriding saved list filters 
* **awesomebar:** sanitise text when searching in list views 
* confirm before removing attachment on clear button in attach control 
* don't generate type information for virtual fields 
* Encode filters to handle special characters
* give prority to user setting on sorting 
* increase length for value field in sms parameter
* Kanban view link draggable issue
* **mariadb:** set collation in connection 
* Merge conflicts 
* option to opt out of automatic filters 
* report header not translated
* **report:** show add_total_row checkbox if report_type is not 'Report Builder'
* resolve conflicts
* return 1 or 0 instead of boolean for `is_fc_site` boot data 
* Round of rate limit to seconds
* support "Timespan" in `evaluate_filters
* sync translations from crowdin 
* Translate link fields in Webform
* Translate names if "Translate Link Fields" is enabled 
* Use DOMParser in `is_html` + Handle unparsable html string with jquery 
* Use jQuery.text() instead of  xss_sanitise 
* **user:** make attachments in email signature public 
* **user:** stricter name validation
* **UX:** Show reason for read only form in headline

### Features

* show helpdesk and crm banner on sidebar

### Performance Improvements

* `doc.permitted_fieldnames` is now a set 
* generate auto email reports in background
* improve `get_permitted_fields` logic 
* remove repeated calls to `get_permitted_fieldnames
