### PR TITLE
Fix: Fix for Print and PDF View Issue in Asset Depreciation Reports

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1524,10 +1524,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				const docfield = frappe.query_report.get_filter(fieldname).df;
 				const value = applied_filters[fieldname];
 
-				if (frappe.utils.is_empty(value) || docfield.hidden_due_to_dependency) {
-					return null;
-				}
-
 				if (docfield.hidden_due_to_dependency) {
 					return null;
 				}


### PR DESCRIPTION
Removed the 
"if (frappe.utils.is_empty(value) || docfield.hidden_due_to_dependency) {return null;}"
Because it was not found iin the devlop branch and it was added and it was not required in pre-prod-develop
and it was hampering all the report views and pdf views