### PR TITLE
fix: fix doc mapping issue

### DIFF
--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -15,7 +15,10 @@ def make_mapped_doc(method, source_name, selected_children=None, args=None):
 
 	Called from `open_mapped_doc` from create_new.js"""
 
-	method = frappe.get_attr(frappe.override_whitelisted_method(method))
+	for hook in reversed(frappe.get_hooks("override_whitelisted_methods", {}).get(method, [])):
+		# override using the first hook
+		method = hook
+		break
 
 	method = frappe.get_attr(method)
 


### PR DESCRIPTION
Doc Mapping Issue
--------------
File "apps/frappe/frappe/__init__.py", line 1751, in get_attr
    app_name = method_string.split(".", 1)[0]
AttributeError: 'function' object has no attribute 'split'

https://github.com/8848digital/erpnext/issues/2306