### PR TITLE
Commit may 2 to may 6

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -60,7 +60,7 @@ from .utils.jinja import (
 )
 from .utils.lazy_loader import lazy_import
 
-__version__ = "15.66.0"
+__version__ = "15.67.0"
 __title__ = "Frappe Framework"
 
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -60,7 +60,7 @@ from .utils.jinja import (
 )
 from .utils.lazy_loader import lazy_import
 
-__version__ =  "15.65.2"
+__version__ = "15.66.0"
 __title__ = "Frappe Framework"
 
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -342,6 +342,9 @@ def connect_replica() -> bool:
 	local.primary_db = local.db
 	local.db = local.replica_db
 
+	if hasattr(frappe.local, "_recorder"):
+		frappe.local._recorder._patch_sql(local.db)
+		
 	return True
 
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -60,7 +60,7 @@ from .utils.jinja import (
 )
 from .utils.lazy_loader import lazy_import
 
-__version__ = "15.67.0"
+__version__ = "15.68.0"
 __title__ = "Frappe Framework"
 
 

--- a/frappe/api/v1.py
+++ b/frappe/api/v1.py
@@ -39,6 +39,8 @@ def handle_rpc_call(method: str):
 def create_doc(doctype: str):
 	data = get_request_form_data()
 	data.pop("doctype", None)
+	if (name := data.get("name")) and isinstance(name, str):
+		frappe.flags.api_name_set = True
 	return frappe.new_doc(doctype, **data).insert()
 
 

--- a/frappe/api/v2.py
+++ b/frappe/api/v2.py
@@ -88,7 +88,20 @@ def count(doctype: str) -> int:
 def create_doc(doctype: str):
 	data = frappe.form_dict
 	data.pop("doctype", None)
+	if (name := data.get("name")) and isinstance(name, str):
+		frappe.flags.api_name_set = True
 	return frappe.new_doc(doctype, **data).insert()
+
+
+def copy_doc(doctype: str, name: str, ignore_no_copy: bool = True):
+	"""Return a clean copy of the given document that can be modified and posted as a new document."""
+	doc = frappe.get_doc(doctype, name)
+	doc.check_permission("read")
+	doc.apply_fieldlevel_read_permissions()
+
+	copy = frappe.copy_doc(doc, ignore_no_copy=ignore_no_copy)
+
+	return copy.as_dict(no_private_properties=True, no_nulls=True)
 
 
 def update_doc(doctype: str, name: str):
@@ -98,6 +111,7 @@ def update_doc(doctype: str, name: str):
 	data.pop("flags", None)
 	doc.update(data)
 	doc.save()
+	doc.apply_fieldlevel_read_permissions()
 
 	# check for child table doctype
 	if doc.get("parenttype"):
@@ -182,6 +196,7 @@ url_rules = [
 	Rule("/document/<doctype>", methods=["GET"], endpoint=document_list),
 	Rule("/document/<doctype>", methods=["POST"], endpoint=create_doc),
 	Rule("/document/<doctype>/<path:name>/", methods=["GET"], endpoint=read_doc),
+	Rule("/document/<doctype>/<path:name>/copy", methods=["GET"], endpoint=copy_doc),
 	Rule("/document/<doctype>/<path:name>/", methods=["PATCH", "PUT"], endpoint=update_doc),
 	Rule("/document/<doctype>/<path:name>/", methods=["DELETE"], endpoint=delete_doc),
 	Rule(

--- a/frappe/automation/doctype/assignment_rule/assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.py
@@ -192,7 +192,7 @@ def get_assignments(doc) -> list[dict]:
 		"ToDo",
 		fields=["name", "assignment_rule"],
 		filters=dict(
-			reference_type=doc.get("doctype"), reference_name=doc.get("name"), status=("!=", "Cancelled")
+			reference_type=doc.get("doctype"), reference_name=str(doc.get("name")), status=("!=", "Cancelled")
 		),
 		limit=5,
 	)
@@ -220,7 +220,7 @@ def reopen_closed_assignment(doc):
 		"ToDo",
 		filters={
 			"reference_type": doc.doctype,
-			"reference_name": doc.name,
+			"reference_name": str(doc.name),
 			"status": "Closed",
 		},
 		pluck="name",
@@ -312,7 +312,7 @@ def apply(doc=None, method=None, doctype=None, name=None):
 						"ToDo",
 						filters={
 							"reference_type": doc.doctype,
-							"reference_name": doc.name,
+							"reference_name": str(doc.name),
 						},
 						pluck="name",
 					)
@@ -367,7 +367,7 @@ def update_due_date(doc, state=None):
 				filters={
 					"assignment_rule": rule.get("name"),
 					"reference_type": doc.doctype,
-					"reference_name": doc.name,
+					"reference_name": str(doc.name),
 					"status": "Open",
 				},
 				pluck="name",

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -9,7 +9,6 @@ import frappe.model
 import frappe.utils
 from frappe import _
 from frappe.desk.reportview import validate_args
-from frappe.desk.search import search_link
 from frappe.model.db_query import check_parent_permission
 from frappe.model.utils import is_virtual_doctype
 from frappe.utils import get_safe_filters
@@ -296,8 +295,8 @@ def bulk_update(docs):
 
 
 @frappe.whitelist()
-def has_permission(doctype, docname, perm_type="read"):
-	"""Returns a JSON with data whether the document has the requested permission
+def has_permission(doctype: str, docname: str, perm_type: str = "read"):
+	"""Return a JSON with data whether the document has the requested permission.
 
 	:param doctype: DocType of the document to be checked
 	:param docname: `name` of the document to be checked
@@ -307,8 +306,8 @@ def has_permission(doctype, docname, perm_type="read"):
 
 
 @frappe.whitelist()
-def get_doc_permissions(doctype, docname):
-	"""Returns an evaluated document permissions dict like `{"read":1, "write":1}`
+def get_doc_permissions(doctype: str, docname: str):
+	"""Return an evaluated document permissions dict like `{"read":1, "write":1}`.
 
 	:param doctype: DocType of the document to be evaluated
 	:param docname: `name` of the document to be evaluated
@@ -318,7 +317,7 @@ def get_doc_permissions(doctype, docname):
 
 
 @frappe.whitelist()
-def get_password(doctype, name, fieldname):
+def get_password(doctype: str, name: str, fieldname: str):
 	"""Return a password type property. Only applicable for System Managers
 
 	:param doctype: DocType of the document that holds the password
@@ -406,7 +405,7 @@ def attach_file(
 
 
 @frappe.whitelist()
-def is_document_amended(doctype, docname):
+def is_document_amended(doctype: str, docname: str):
 	if frappe.permissions.has_permission(doctype):
 		try:
 			return frappe.db.exists(doctype, {"amended_from": docname})
@@ -417,40 +416,28 @@ def is_document_amended(doctype, docname):
 
 
 @frappe.whitelist()
-def validate_link(doctype: str, docname: str, fields=None, args=None):
+def validate_link(doctype: str, docname: str, fields=None):
 	if not isinstance(doctype, str):
 		frappe.throw(_("DocType must be a string"))
 
 	if not isinstance(docname, str):
 		frappe.throw(_("Document Name must be a string"))
 
-	if doctype != "DocType" and not (
-		frappe.has_permission(doctype, "select") or frappe.has_permission(doctype, "read")
-	):
-		frappe.throw(
-			_("You do not have Read or Select Permissions for {}").format(frappe.bold(doctype)),
-			frappe.PermissionError,
-		)
+	if doctype != "DocType":
+		parent_doctype = None
+		if frappe.get_meta(doctype).istable:  # needed for links to child rows
+			parent_doctype = frappe.db.get_value(doctype, docname, "parenttype")
+		if not (
+			frappe.has_permission(doctype, "select", parent_doctype=parent_doctype)
+			or frappe.has_permission(doctype, "read", parent_doctype=parent_doctype)
+		):
+			frappe.throw(
+				_("You do not have Read or Select Permissions for {}").format(frappe.bold(doctype)),
+				frappe.PermissionError,
+			)
 
 	values = frappe._dict()
-	args = frappe.parse_json(args)
-	filters = args.filters or frappe._dict()
 
-	standard_queries = frappe.get_hooks().standard_queries or {}
-
-	if not args.get("query") and doctype in standard_queries:
-		args.update({"query" : standard_queries[doctype][-1]})
-
-	if args.get("query"):
-		if not search_link(doctype, docname, args.get("query"), filters):
-			return values
-		filters = {'name' : docname}
-	else:
-		if isinstance(filters, list):
-			filters.append(["name", "=", docname])
-		else:	
-			filters.update({'name' : docname})
-			
 	if is_virtual_doctype(doctype):
 		try:
 			frappe.get_doc(doctype, docname)
@@ -462,8 +449,7 @@ def validate_link(doctype: str, docname: str, fields=None, args=None):
 			)
 		return values
 
-	result = frappe.db.get_list(doctype, filters = filters,pluck = 'name')
-	if result: values.name = result[0]
+	values.name = frappe.db.get_value(doctype, docname, cache=True)
 
 	fields = frappe.parse_json(fields)
 	if not values.name or not fields:
@@ -514,6 +500,7 @@ def delete_doc(doctype, name):
 		values = frappe.db.get_value(doctype, name, ["parenttype", "parent", "parentfield"])
 		if not values:
 			raise frappe.DoesNotExistError(doctype=doctype)
+
 		parenttype, parent, parentfield = values
 		parent = frappe.get_doc(parenttype, parent)
 		if not parent.has_permission("write"):

--- a/frappe/core/doctype/comment/comment.py
+++ b/frappe/core/doctype/comment/comment.py
@@ -66,7 +66,7 @@ class Comment(Document):
 
 	def on_update(self):
 		update_comment_in_doc(self)
-		if self.is_new():
+		if not self.is_new():
 			self.notify_change("update")
 
 	def on_trash(self):

--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -630,7 +630,10 @@ def update_first_response_time(parent, communication):
 			is_system_user(communication.sender)
 			or frappe.get_cached_value("User", frappe.session.user, "user_type") == "System User"
 		):
-			if communication.sent_or_received == "Sent":
+			if (
+				communication.sent_or_received == "Sent"
+				and communication.communication_type == "Communication"
+			):
 				first_responded_on = communication.creation
 				if parent.meta.has_field("first_responded_on"):
 					parent.db_set("first_responded_on", first_responded_on)

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -153,7 +153,7 @@ class File(Document):
 		self.validate_protected_file()
 		self._delete_file_on_disk()
 		if not self.is_folder:
-			self.add_comment_in_reference_doc("Attachment Removed", _("Removed {0}").format(self.file_name))
+			self.add_comment_in_reference_doc("Attachment Removed", self.file_name)
 
 	def on_rollback(self):
 		rollback_flags = ("new_file", "original_content", "original_path")
@@ -498,7 +498,7 @@ class File(Document):
 			msg=_("This file is attached to a protected document and cannot be deleted."),
 			title=_("Protected File"),
 		)
-		
+
 	def _delete_file_on_disk(self):
 		"""If file not attached to any other record, delete it"""
 		on_disk_file_not_shared = self.content_hash and not frappe.get_all(
@@ -716,7 +716,6 @@ class File(Document):
 
 		return {"file_name": os.path.basename(fpath), "file_url": self.file_url}
 
-
 	def check_max_file_size(self):
 		from frappe.core.api.file import get_max_file_size
 
@@ -760,7 +759,7 @@ class File(Document):
 
 		self.add_comment_in_reference_doc(
 			"Attachment",
-			_("Added {0}").format(f"<a href='{file_url}' target='_blank'>{file_name}</a>{icon}"),
+			f"<a href='{file_url}' target='_blank'>{file_name}</a>{icon}",
 		)
 
 	def add_comment_in_reference_doc(self, comment_type, text):
@@ -853,6 +852,8 @@ def has_permission(doc, ptype=None, user=None, debug=False):
 
 		try:
 			ref_doc = frappe.get_doc(attached_to_doctype, attached_to_name)
+		except ModuleNotFoundError:
+			return False
 		except frappe.DoesNotExistError:
 			frappe.clear_last_message()
 			return False

--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -486,6 +486,7 @@ def test_user(
 		user.append_roles(*roles)
 		user.insert()
 		yield user
+		commit and frappe.db.commit()
 	finally:
 		user.delete(force=True, ignore_permissions=True)
 		commit and frappe.db.commit()

--- a/frappe/core/doctype/version/version.py
+++ b/frappe/core/doctype/version/version.py
@@ -6,6 +6,9 @@ import json
 import frappe
 from frappe.model import no_value_fields, table_fields
 from frappe.model.document import Document
+from frappe.utils import cstr
+
+FIELDTYPES_TO_IGNORE = frozenset(fieldtype for fieldtype in no_value_fields if fieldtype not in table_fields)
 
 
 class Version(Document):
@@ -36,6 +39,9 @@ class Version(Document):
 			return
 		if impersonator := frappe.session.data.get("impersonated_by"):
 			data["impersonated_by"] = impersonator
+
+		if audit_user := frappe.session.data.get("audit_user"):
+			data["audit_user"] = audit_user
 
 	def set_diff(self, old: Document, new: Document) -> bool:
 		"""Set the data property with the diff of the docs if present"""
@@ -107,10 +113,12 @@ def get_diff(old, new, for_child=False, compare_cancelled=False):
 		old_row_name_field = "_amended_from" if (amended_from and amended_from == old.name) else "name"
 
 	for df in new.meta.fields:
-		if df.fieldtype in no_value_fields and df.fieldtype not in table_fields:
+		if df.fieldtype in FIELDTYPES_TO_IGNORE or getattr(df, "is_virtual", False):
 			continue
 
 		old_value, new_value = old.get(df.fieldname), new.get(df.fieldname)
+		if df.fieldtype in ("Link", "Dynamic Link"):
+			old_value, new_value = cstr(old_value), cstr(new_value)
 
 		if not for_child and df.fieldtype in table_fields:
 			old_rows_by_name = {}

--- a/frappe/core/notifications.py
+++ b/frappe/core/notifications.py
@@ -37,8 +37,8 @@ def get_things_todo(as_list=False):
 def get_todays_events(as_list: bool = False):
 	"""Returns a count of todays events in calendar"""
 	from frappe.desk.doctype.event.event import get_events
-	from frappe.utils import nowdate
+	from frappe.utils import getdate
 
-	today = nowdate()
+	today = getdate()
 	events = get_events(today, today)
 	return events if as_list else len(events)

--- a/frappe/custom/doctype/property_setter/property_setter.py
+++ b/frappe/custom/doctype/property_setter/property_setter.py
@@ -68,6 +68,7 @@ def make_property_setter(
 	property_type,
 	for_doctype=False,
 	validate_fields_for_doctype=True,
+	is_system_generated=True,
 ):
 	# WARNING: Ignores Permissions
 	property_setter = frappe.get_doc(
@@ -79,6 +80,7 @@ def make_property_setter(
 			"property": property,
 			"value": value,
 			"property_type": property_type,
+			"is_system_generated": is_system_generated,
 		}
 	)
 	property_setter.flags.ignore_permissions = True

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -27,7 +27,8 @@ class MariaDBExceptionUtil:
 
 	@staticmethod
 	def is_deadlocked(e: pymysql.Error) -> bool:
-		return e.args[0] == ER.LOCK_DEADLOCK
+		# Snapshot isolation is also treated as deadlock from User POV
+		return e.args[0] in (ER.LOCK_DEADLOCK, ER.CHECKREAD)
 
 	@staticmethod
 	def is_timedout(e: pymysql.Error) -> bool:

--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -3,7 +3,7 @@
 
 
 import json
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 
 import frappe
 from frappe import _
@@ -16,10 +16,11 @@ from frappe.model.document import Document
 from frappe.utils import (
 	add_days,
 	add_months,
-	date_diff,
+	add_years,
 	format_datetime,
 	get_fullname,
 	getdate,
+	month_diff,
 	now_datetime,
 	nowdate,
 )
@@ -238,7 +239,7 @@ def has_permission(doc, user):
 
 
 def send_event_digest():
-	today = nowdate()
+	today = getdate()
 
 	# select only those users that have event reminder email notifications enabled
 	users = [
@@ -275,7 +276,6 @@ def get_events(
 	user = user or frappe.session.user
 	EventLikeDict: TypeAlias = Event | frappe._dict
 	resolved_events: list[EventLikeDict] = []
-	days_range = (end - start).days
 
 	if isinstance(filters, str):
 		filters = json.loads(filters)
@@ -340,7 +340,7 @@ def get_events(
 		ORDER BY `tabEvent`.starts_on""".format(
 			tables=", ".join(tables),
 			filter_condition=filter_condition,
-			reminder_condition="AND coalesce(`tabEvent`.send_reminder, 0)=1" if for_reminder else "",
+			reminder_condition="AND `tabEvent`.send_reminder = 1" if for_reminder else "",
 		),
 		{
 			"start": start,
@@ -350,7 +350,7 @@ def get_events(
 		as_dict=True,
 	)
 
-	def resolve_event(e: EventLikeDict, target_date: "date"):
+	def resolve_event(e: EventLikeDict, target_date: "date", repeat_till: "date"):
 		"""Record the event if it falls within the date range and is not excluded by the weekday."""
 		if e.repeat_on == "Weekly" and not e[weekdays[target_date.weekday()]]:
 			return
@@ -369,6 +369,10 @@ def get_events(
 			return
 
 		new_event = e.copy()
+
+		new_event.original_starts_on = new_event.starts_on
+		new_event.original_ends_on = new_event.ends_on
+
 		new_event.starts_on = datetime.combine(target_date, e.starts_on.time())
 		new_event.ends_on = datetime.combine(ends_on_date, e.ends_on.time()) if ends_on_date else None
 
@@ -382,26 +386,37 @@ def get_events(
 		if e.repeat_till and e.repeat_till < start:
 			continue
 
-		event_start = e.starts_on.date()
 		repeat_till = getdate(e.repeat_till or "3000-01-01")
 
-		if e.repeat_on == "Yearly":
-			for year in range(start.year, end.year + 1):
-				resolve_event(e, target_date=event_start.replace(year=year))
+		if e.repeat_on == "Daily":
+			target_date = start
+			while target_date <= end:
+				resolve_event(e, target_date=target_date, repeat_till=repeat_till)
+				target_date = add_days(target_date, 1)
+
+		elif e.repeat_on == "Weekly":
+			target_date = start
+			while target_date <= end:
+				resolve_event(e, target_date=target_date, repeat_till=repeat_till)
+				target_date = add_days(target_date, 1)  # Increment by 1 to capture multiple days in the week
 
 		elif e.repeat_on == "Monthly":
-			try:
-				start_date = start.replace(day=event_start.day)
-			except ValueError:
-				# Handle fallback for last day of the month, e.g., 30th, 31st, 29th, 28th
-				start_date = start.replace(month=start.month + 1, day=1) + timedelta(days=-1)
+			first_occurence_in_range = e.starts_on.date()
+			jump_ahead = month_diff(start, first_occurence_in_range) - 1
+			target_date = add_months(first_occurence_in_range, jump_ahead)
 
-			for i in range((days_range // 30) + 3):
-				resolve_event(e, target_date=add_months(start_date, i))
+			while target_date <= end:
+				resolve_event(e, target_date=target_date, repeat_till=repeat_till)
+				target_date = add_months(target_date, 1)
 
-		elif e.repeat_on in ("Weekly", "Daily"):
-			for i in range(days_range + 1):
-				resolve_event(e, target_date=add_days(start, i))
+		elif e.repeat_on == "Yearly":
+			first_occurence_in_range = e.starts_on.date()
+			jump_ahead = month_diff(start, first_occurence_in_range) // 12
+			target_date = add_years(first_occurence_in_range, jump_ahead)
+
+			while target_date <= end:
+				resolve_event(e, target_date=target_date, repeat_till=repeat_till)
+				target_date = add_years(target_date, 1)
 
 	# Remove events that are not in the range and boolean weekdays fields
 	for event in resolved_events:

--- a/frappe/desk/doctype/event/test_event.py
+++ b/frappe/desk/doctype/event/test_event.py
@@ -3,9 +3,10 @@
 """Use blog post test to test user permissions logic"""
 
 import json
+from datetime import date
 
 import frappe
-import frappe.defaults
+from frappe.core.utils import find
 from frappe.desk.doctype.event.event import get_events
 from frappe.test_runner import make_test_objects
 from frappe.tests.utils import FrappeTestCase
@@ -112,7 +113,7 @@ class TestEvent(FrappeTestCase):
 		# cleanup
 		ev.delete()
 
-	def test_recurring(self):
+	def test_yearly_repeat(self):
 		ev = frappe.get_doc(
 			{
 				"doctype": "Event",
@@ -122,17 +123,173 @@ class TestEvent(FrappeTestCase):
 				"repeat_this_event": 1,
 				"repeat_on": "Yearly",
 			}
-		)
-		ev.insert()
+		).insert()
 
-		ev_list = get_events("2014-02-01", "2014-02-01", "Administrator", for_reminder=True)
-		self.assertTrue(bool(list(filter(lambda e: e.name == ev.name, ev_list))))
+		def test_record_matched(e):
+			return e.name == ev.name
 
-		ev_list1 = get_events("2015-01-20", "2015-01-20", "Administrator", for_reminder=True)
-		self.assertFalse(bool(list(filter(lambda e: e.name == ev.name, ev_list1))))
+		applicable_dates = [
+			(date(2014, 2, 1), date(2014, 2, 1)),
+			(date(2015, 2, 1), date(2015, 2, 1)),
+			(date(2016, 2, 1), date(2016, 2, 1)),
+		]
 
-		ev_list2 = get_events("2014-02-20", "2014-02-20", "Administrator", for_reminder=True)
-		self.assertFalse(bool(list(filter(lambda e: e.name == ev.name, ev_list2))))
+		for start_date, end_date in applicable_dates:
+			event_list = get_events(start_date, end_date, "Administrator", for_reminder=True)
+			with self.subTest(start_date=start_date, end_date=end_date):
+				self.assertTrue(
+					find(event_list, test_record_matched),
+					f"Event not found between {start_date} and {end_date}",
+				)
 
-		ev_list3 = get_events("2015-02-01", "2015-02-01", "Administrator", for_reminder=True)
-		self.assertTrue(bool(list(filter(lambda e: e.name == ev.name, ev_list3))))
+		unapplicable_dates = [
+			(date(2014, 1, 20), date(2014, 1, 20)),
+			(date(2015, 1, 20), date(2015, 1, 20)),
+		]
+
+		for start_date, end_date in unapplicable_dates:
+			event_list = get_events(start_date, end_date, "Administrator", for_reminder=True)
+			with self.subTest(start_date=start_date, end_date=end_date):
+				self.assertFalse(
+					find(event_list, test_record_matched), f"Event found between {start_date} and {end_date}"
+				)
+
+		ev.starts_on = date(2016, 2, 29)
+		ev.save()
+
+		applicable_dates = [
+			(date(2016, 2, 29), date(2016, 2, 29)),
+			(date(2024, 2, 28), date(2024, 2, 29)),
+		]
+		for start_date, end_date in applicable_dates:
+			event_list = get_events(start_date, end_date, "Administrator", for_reminder=True)
+			with self.subTest(start_date=start_date, end_date=end_date):
+				self.assertTrue(
+					find(event_list, test_record_matched),
+					f"Event not found between {start_date} and {end_date}",
+				)
+
+	def test_monthly_repeat(self):
+		ev = frappe.get_doc(
+			{
+				"doctype": "Event",
+				"subject": "_Test Event",
+				"starts_on": "2016-01-31",
+				"event_type": "Public",
+				"repeat_this_event": 1,
+				"repeat_on": "Monthly",
+			}
+		).insert()
+
+		def test_record_matched(e):
+			return e.name == ev.name
+
+		applicable_dates = [
+			(date(2016, 1, 31), date(2016, 1, 31)),
+			(date(2016, 2, 29), date(2016, 2, 29)),
+			(date(2016, 3, 31), date(2016, 3, 31)),
+			(date(2016, 4, 30), date(2016, 4, 30)),
+		]
+		for start_date, end_date in applicable_dates:
+			event_list = get_events(start_date, end_date, "Administrator", for_reminder=True)
+			with self.subTest(start_date=start_date, end_date=end_date):
+				self.assertTrue(
+					find(event_list, test_record_matched),
+					f"Event not found between {start_date} and {end_date}",
+				)
+
+	def test_daily_repeat(self):
+		ev = frappe.get_doc(
+			{
+				"doctype": "Event",
+				"subject": "_Test Event",
+				"starts_on": "2023-02-17",
+				"repeat_till": "2024-02-17",
+				"event_type": "Public",
+				"repeat_this_event": 1,
+				"repeat_on": "Daily",
+			}
+		).insert()
+
+		def test_record_matched(e):
+			return e.name == ev.name
+
+		applicable_dates = [
+			(date(2023, 2, 17), date(2023, 2, 17)),
+			(date(2024, 1, 1), date(2024, 1, 1)),
+		]
+		for start_date, end_date in applicable_dates:
+			event_list = get_events(start_date, end_date, "Administrator", for_reminder=True)
+			with self.subTest(start_date=start_date, end_date=end_date):
+				self.assertTrue(
+					find(event_list, test_record_matched),
+					f"Event not found between {start_date} and {end_date}",
+				)
+
+		unapplicable_dates = [
+			(
+				date(2024, 2, 17),
+				date(2024, 2, 17),
+			),  # this is unapplicable since repeat_till is 2024-02-17 00:00:00
+			(date(2022, 8, 17), date(2022, 8, 17)),
+			(date(2024, 2, 18), date(2024, 2, 18)),
+		]
+		for start_date, end_date in unapplicable_dates:
+			event_list = get_events(start_date, end_date, "Administrator", for_reminder=True)
+			with self.subTest(start_date=start_date, end_date=end_date):
+				self.assertFalse(
+					find(event_list, test_record_matched), f"Event found between {start_date} and {end_date}"
+				)
+
+	def test_weekly_repeat(self):
+		ev = frappe.get_doc(
+			{
+				"doctype": "Event",
+				"subject": "_Test Event",
+				"starts_on": "2025-04-15 16:00:00",
+				"repeat_till": "2025-05-06 23:59:59",
+				"tuesday": 1,
+				"wednesday": 1,
+				"friday": 1,
+				"event_type": "Public",
+				"repeat_this_event": 1,
+				"repeat_on": "Weekly",
+			}
+		).insert()
+
+		def test_record_matched(e):
+			return e.name == ev.name
+
+		applicable_dates = [
+			(date(2025, 4, 15), date(2025, 4, 15)),
+			(date(2025, 4, 22), date(2025, 4, 22)),
+			(date(2025, 4, 29), date(2025, 4, 29)),
+			(date(2025, 4, 30), date(2025, 4, 30)),
+			(date(2025, 5, 2), date(2025, 5, 2)),
+		]
+		for start_date, end_date in applicable_dates:
+			event_list = get_events(start_date, end_date, "Administrator", for_reminder=True)
+			with self.subTest(start_date=start_date, end_date=end_date):
+				self.assertTrue(
+					find(event_list, test_record_matched),
+					f"Event not found between {start_date} and {end_date}",
+				)
+
+		unapplicable_dates = [
+			# Test before event start date and after event end date
+			(date(2022, 8, 17), date(2022, 8, 17)),
+			(date(2024, 2, 18), date(2024, 2, 18)),
+			# Test dates that aren't part of the weekly cycle
+			(date(2023, 5, 17), date(2023, 5, 17)),
+			(date(2023, 5, 18), date(2023, 5, 18)),
+		]
+		for start_date, end_date in unapplicable_dates:
+			event_list = get_events(start_date, end_date, "Administrator", for_reminder=True)
+			with self.subTest(start_date=start_date, end_date=end_date):
+				self.assertFalse(
+					find(event_list, test_record_matched), f"Event found between {start_date} and {end_date}"
+				)
+
+		# Test occurences of events in a timespan
+		event_list = get_events(date(2025, 4, 29), date(2025, 5, 2), "Administrator", for_reminder=True)
+		self.assertEqual(len(event_list), 3)

--- a/frappe/desk/doctype/todo/todo.py
+++ b/frappe/desk/doctype/todo/todo.py
@@ -93,7 +93,7 @@ class ToDo(Document):
 				"ToDo",
 				{
 					"reference_type": self.reference_type,
-					"reference_name": self.reference_name,
+					"reference_name": str(self.reference_name),
 					"status": ("not in", ("Cancelled", "Closed")),
 					"allocated_to": ("is", "set"),
 				},

--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -79,7 +79,7 @@ def add(args=None, *, ignore_permissions=False):
 					"doctype": "ToDo",
 					"allocated_to": assign_to,
 					"reference_type": args["doctype"],
-					"reference_name": args["name"],
+					"reference_name": str(args["name"]),
 					"description": args.get("description"),
 					"priority": args.get("priority", "Medium"),
 					"status": "Open",

--- a/frappe/desk/form/document_follow.py
+++ b/frappe/desk/form/document_follow.py
@@ -225,7 +225,7 @@ def get_comments(doctype, doc_name, frequency, user):
 
 def is_document_followed(doctype, doc_name, user):
 	return frappe.db.exists(
-		"Document Follow", {"ref_doctype": doctype, "ref_docname": doc_name, "user": user}
+		"Document Follow", {"ref_doctype": doctype, "ref_docname": str(doc_name), "user": user}
 	)
 
 

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -430,6 +430,10 @@ def get_linked_docs(doctype: str, name: str, linkinfo: dict | None = None) -> di
 	is_target_doctype_table = frappe.get_meta(doctype).istable
 
 	for linked_doctype, link_context in linkinfo.items():
+		# Don't try to fetch linked documents if the user can't read the doctype
+		if not frappe.has_permission(linked_doctype):
+			continue
+
 		linked_doctype_meta = frappe.get_meta(linked_doctype)
 
 		if linked_doctype_meta.issingle:
@@ -560,7 +564,16 @@ def _get_linked_doctypes(doctype, without_ignore_user_permissions_enabled=False)
 			continue
 		ret[dt] = {"get_parent": True}
 
+	custom_doctypes = frappe.get_all(
+		doctype="DocType", filters=[["custom", "=", 1], ["name", "in", list(ret.keys())]], as_list=True
+	)
+
+	custom_doctypes = [item[0] for item in custom_doctypes]
+
 	for dt in list(ret):
+		# if the custom checkbox is checked, then don't load the module of the DocType because it doesn't belong to any app.
+		if dt in custom_doctypes:
+			continue
 		try:
 			doctype_module = load_doctype_module(dt)
 		except (ImportError, KeyError):

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -156,7 +156,7 @@ def add_comments(doc, docinfo):
 
 	comments = frappe.get_all(
 		"Comment",
-		fields=["name", "creation", "content", "owner", "comment_type"],
+		fields=["name", "creation", "content", "owner", "comment_type", "published"],
 		filters={"reference_doctype": doc.doctype, "reference_name": doc.name},
 	)
 

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -185,7 +185,7 @@ def get_milestones(doctype, name):
 	return frappe.get_all(
 		"Milestone",
 		fields=["creation", "owner", "track_field", "value"],
-		filters=dict(reference_type=doctype, reference_name=name),
+		filters=dict(reference_type=doctype, reference_name=str(name)),
 	)
 
 
@@ -193,7 +193,7 @@ def get_attachments(dt, dn):
 	return frappe.get_all(
 		"File",
 		fields=["name", "file_name", "file_url", "is_private"],
-		filters={"attached_to_name": dn, "attached_to_doctype": dt},
+		filters={"attached_to_name": str(dn), "attached_to_doctype": dt},
 	)
 
 
@@ -334,7 +334,7 @@ def get_communication_data(
 	""".format(part1=part1, part2=part2, group_by=(group_by or "")),
 		dict(
 			doctype=doctype,
-			name=name,
+			name=str(name),
 			start=frappe.utils.cint(start),
 			limit=limit,
 		),
@@ -348,7 +348,7 @@ def get_assignments(dt, dn):
 		fields=["name", "allocated_to as owner", "description", "status"],
 		filters={
 			"reference_type": dt,
-			"reference_name": dn,
+			"reference_name": str(dn),
 			"status": ("not in", ("Cancelled", "Closed")),
 			"allocated_to": ("is", "set"),
 		},
@@ -369,7 +369,7 @@ def get_view_logs(doc: "Document") -> list[dict]:
 		"View Log",
 		filters={
 			"reference_doctype": doc.doctype,
-			"reference_name": doc.name,
+			"reference_name": str(doc.name),
 		},
 		fields=["name", "creation", "owner"],
 		order_by="creation desc",
@@ -379,7 +379,7 @@ def get_view_logs(doc: "Document") -> list[dict]:
 def get_tags(doctype: str, name: str) -> str:
 	tags = frappe.get_all(
 		"Tag Link",
-		filters={"document_type": doctype, "document_name": name},
+		filters={"document_type": doctype, "document_name": str(name)},
 		fields=["tag"],
 		pluck="tag",
 	)

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -437,8 +437,8 @@ def get_title_values_for_link_and_dynamic_link_fields(doc, link_fields=None):
 
 		doctype = field.options if field.fieldtype == "Link" else doc.get(field.options)
 
-		meta = frappe.get_meta(doctype)
-		if not meta or not (meta.title_field and meta.show_title_field_in_link):
+		meta = frappe.get_meta(doctype) if doctype else None
+		if not meta or not meta.title_field or not meta.show_title_field_in_link:
 			continue
 
 		link_title = frappe.db.get_value(doctype, link_docname, meta.title_field, cache=True, order_by=None)

--- a/frappe/desk/form/utils.py
+++ b/frappe/desk/form/utils.py
@@ -69,6 +69,16 @@ def update_comment(name, content):
 
 
 @frappe.whitelist()
+def update_comment_publicity(name: str, publish: bool):
+	doc = frappe.get_doc("Comment", name)
+	if frappe.session.user != doc.owner and "System Manager" not in frappe.get_roles():
+		frappe.throw(_("Comment publicity can only be updated by the original author or a System Manager."))
+
+	doc.published = int(publish)
+	doc.save(ignore_permissions=True)
+
+
+@frappe.whitelist()
 def get_next(doctype, value, prev, filters=None, sort_order="desc", sort_field="modified"):
 	prev = int(prev)
 	if not filters:

--- a/frappe/desk/page/setup_wizard/install_fixtures.py
+++ b/frappe/desk/page/setup_wizard/install_fixtures.py
@@ -19,7 +19,6 @@ def install():
 	update_genders()
 	update_salutations()
 	update_global_search_doctypes()
-	setup_email_linking()
 	sync_dashboards()
 	add_unsubscribe()
 
@@ -54,12 +53,6 @@ def update_salutations():
 		doc = frappe.new_doc("Salutation")
 		doc.salutation = salutation
 		doc.insert(ignore_permissions=True, ignore_if_duplicate=True)
-
-
-def setup_email_linking():
-	doc = frappe.new_doc("Email Account")
-	doc.email_id = "email_linking@example.com"
-	doc.insert(ignore_permissions=True, ignore_if_duplicate=True)
 
 
 def add_unsubscribe():

--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -219,9 +219,9 @@ frappe.setup.SetupWizard = class SetupWizard extends frappe.ui.Slides {
 			? frappe.last_response.setup_wizard_failure_message
 			: __("Failed to complete setup");
 
-			this.update_setup_message(__("Could not start up: ") + fail_msg);
+		this.update_setup_message(__("Could not start up: ") + fail_msg);
 
-			this.$working_state.find(".title").html(__("Setup failed"));
+		this.$working_state.find(".title").html(__("Setup failed"));
 
 		this.$abort_btn.show();
 	}
@@ -418,10 +418,19 @@ frappe.setup.slides_settings = [
 		],
 
 		onload: function (slide) {
+			frappe.setup.utils.load_prefilled_data(slide, this.initialize_fields);
+		},
+
+		initialize_fields: function (slide) {
+			const setup_fields = function (slide) {
+				frappe.setup.utils.setup_region_fields(slide);
+				frappe.setup.utils.setup_language_field(slide);
+			};
+
 			if (frappe.setup.data.regional_data) {
-				this.setup_fields(slide);
+				setup_fields(slide);
 			} else {
-				frappe.setup.utils.load_regional_data(slide, this.setup_fields);
+				frappe.setup.utils.load_regional_data(slide, setup_fields);
 			}
 			if (!slide.get_value("language")) {
 				let session_language =
@@ -439,11 +448,6 @@ frappe.setup.slides_settings = [
 			}
 			frappe.setup.utils.bind_region_events(slide);
 			frappe.setup.utils.bind_language_events(slide);
-		},
-
-		setup_fields: function (slide) {
-			frappe.setup.utils.setup_region_fields(slide);
-			frappe.setup.utils.setup_language_field(slide);
 		},
 	},
 	{
@@ -472,6 +476,7 @@ frappe.setup.slides_settings = [
 						: __("Update Password"),
 				fieldtype: "Password",
 				length: 512,
+				depends_on: "eval:!frappe.boot.is_fc_site",
 			},
 		],
 
@@ -489,7 +494,7 @@ frappe.setup.slides_settings = [
 			} else {
 				slide.form.fields_dict.email.df.reqd = 1;
 				slide.form.fields_dict.email.refresh();
-				slide.form.fields_dict.password.df.reqd = 1;
+				if (!frappe.boot.is_fc_site) slide.form.fields_dict.password.df.reqd = 1;
 				slide.form.fields_dict.password.refresh();
 
 				frappe.setup.utils.load_user_details(slide, this.setup_fields);
@@ -509,6 +514,37 @@ frappe.setup.slides_settings = [
 ];
 
 frappe.setup.utils = {
+	load_prefilled_data: function (slide, callback) {
+		frappe.db
+			.get_value("System Settings", "System Settings", [
+				"country",
+				"timezone",
+				"currency",
+				"language",
+			])
+			.then((r) => {
+				if (r.message) {
+					frappe.wizard.values.currency = r.message.currency;
+					frappe.wizard.values.country = r.message.country;
+					frappe.wizard.values.timezone = r.message.time_zone;
+					frappe.wizard.values.language = r.message.language;
+
+					frappe.db.get_value(
+						"User",
+						{ name: ["not in", ["Administrator", "Guest"]] },
+						["full_name", "email"],
+						(r) => {
+							if (r) {
+								frappe.wizard.values.full_name = r.full_name;
+								frappe.wizard.values.email = r.email;
+							}
+						}
+					);
+				}
+				callback(slide);
+			});
+	},
+
 	load_regional_data: function (slide, callback) {
 		frappe.call({
 			method: "frappe.geo.country_info.get_country_timezone_info",
@@ -585,9 +621,12 @@ frappe.setup.utils = {
 			.get_input("language")
 			.unbind("change")
 			.on("change", function () {
+				const selected_language = $(this).val();
+				if (slide.get_field("language").value === selected_language) return;
+
 				clearTimeout(slide.language_call_timeout);
 				slide.language_call_timeout = setTimeout(() => {
-					let lang = $(this).val() || "English";
+					let lang = selected_language || "English";
 					frappe._messages = {};
 					frappe.call({
 						method: "frappe.desk.page.setup_wizard.setup_wizard.load_messages",

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -61,6 +61,28 @@ def setup_complete(args):
 		return process_setup_stages(stages, args)
 
 
+@frappe.whitelist()
+def initialize_system_settings_and_user(system_settings_data, user_data):
+	system_settings = frappe.get_single("System Settings")
+
+	if cint(system_settings.setup_complete):
+		return
+
+	system_settings_data = parse_args(sanitize_input(system_settings_data))
+	system_settings.update(
+		{
+			"language": system_settings_data.get("language"),
+			"country": system_settings_data.get("country"),
+			"currency": system_settings_data.get("currency"),
+			"time_zone": system_settings_data.get("time_zone"),
+		}
+	)
+	system_settings.save()
+
+	user_data = parse_args(sanitize_input(user_data))
+	create_or_update_user(user_data)
+
+
 @frappe.task()
 def process_setup_stages(stages, user_input, is_background_task=False):
 	from frappe.utils.telemetry import capture
@@ -262,7 +284,7 @@ def sanitize_input(args):
 	for key, value in args.items():
 		if is_html(value):
 			args[key] = strip_html_tags(value)
-			
+
 	return args
 
 

--- a/frappe/email/doctype/email_domain/test_records.json
+++ b/frappe/email/doctype/email_domain/test_records.json
@@ -28,5 +28,14 @@
   "smtp_server": "smtp.test.com",
   "smtp_port": "587",
   "password": "password"
+ },
+ {
+  "doctype": "Email Domain",
+  "domain_name": "example.com",
+  "email_id": "account@example.com",
+  "password": "pass",
+  "email_server": "imap.example.com",
+  "use_imap": 1,
+  "smtp_server": "smtp.example.com"
  }
 ]

--- a/frappe/email/doctype/email_queue/email_queue.js
+++ b/frappe/email/doctype/email_queue/email_queue.js
@@ -9,6 +9,7 @@ frappe.ui.form.on("Email Queue", {
 					method: "frappe.email.doctype.email_queue.email_queue.send_now",
 					args: {
 						name: frm.doc.name,
+						force_send: true,
 					},
 					btn: button,
 					callback: function () {
@@ -16,7 +17,7 @@ frappe.ui.form.on("Email Queue", {
 						if (cint(frappe.sys_defaults.suspend_email_queue)) {
 							frappe.show_alert(
 								__(
-									"Email queue is currently suspended. Resume to automatically send emails."
+									"Email queue is currently suspended. Resume to automatically send other emails."
 								)
 							);
 						}

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -158,9 +158,9 @@ class EmailQueue(Document):
 
 		return True
 
-	def send(self, smtp_server_instance: SMTPServer = None):
+	def send(self, smtp_server_instance: SMTPServer = None, force_send: bool = False):
 		"""Send emails to recipients."""
-		if not self.can_send_now():
+		if not self.can_send_now() and not force_send:
 			return
 
 		with SendMailContext(self, smtp_server_instance) as ctx:
@@ -446,11 +446,11 @@ def bulk_retry(queues):
 
 
 @frappe.whitelist()
-def send_now(name):
+def send_now(name, force_send: bool = False):
 	record = EmailQueue.find(name)
 	if record:
 		record.check_permission()
-		record.send()
+		record.send(force_send=force_send)
 
 
 @frappe.whitelist()

--- a/frappe/geo/utils.py
+++ b/frappe/geo/utils.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 
 import frappe
+from frappe.utils.data import flt
 
 
 @frappe.whitelist()
@@ -46,14 +47,19 @@ def merge_location_features_in_one(coords):
 
 def create_gps_markers(coords):
 	"""Build Marker based on latitude and longitude."""
-	geojson_dict = []
-	for i in coords:
-		node = {"type": "Feature", "properties": {}, "geometry": {"type": "Point", "coordinates": None}}
-		node["properties"]["name"] = i.name
-		node["geometry"]["coordinates"] = [i.longitude, i.latitude]  # geojson needs it reverse!
-		geojson_dict.append(node.copy())
-
-	return geojson_dict
+	return [
+		{
+			"type": "Feature",
+			"properties": {
+				"name": i.name,
+			},
+			"geometry": {
+				"type": "Point",
+				"coordinates": [flt(i.longitude), flt(i.latitude)],  # geojson needs it reverse!
+			},
+		}
+		for i in coords
+	]
 
 
 def return_location(doctype, filters_sql):

--- a/frappe/gettext/extractors/navbar.py
+++ b/frappe/gettext/extractors/navbar.py
@@ -32,7 +32,7 @@ def extract(fileobj, *args, **kwargs):
 		standard_help_items = module.standard_help_items
 		for help_item in standard_help_items:
 			if label := help_item.get("item_label"):
-				item_type = nav_item.get("item_type")
+				item_type = help_item.get("item_type")
 				yield (
 					None,
 					"_",

--- a/frappe/gettext/extractors/workspace.py
+++ b/frappe/gettext/extractors/workspace.py
@@ -21,10 +21,12 @@ def extract(fileobj, *args, **kwargs):
 	yield from (
 		(None, "_", chart.get("label"), [f"Label of a chart in the {workspace_name} Workspace"])
 		for chart in data.get("charts", [])
+		if chart.get("label")
 	)
 	yield from (
 		(None, "_", number_card.get("label"), [f"Label of a number card in the {workspace_name} Workspace"])
 		for number_card in data.get("number_cards", [])
+		if number_card.get("label")
 	)
 	yield from (
 		(
@@ -34,6 +36,7 @@ def extract(fileobj, *args, **kwargs):
 			[f"Label of a {link.get('type')} in the {workspace_name} Workspace"],
 		)
 		for link in data.get("links", [])
+		if link.get("label")
 	)
 	yield from (
 		(
@@ -43,6 +46,7 @@ def extract(fileobj, *args, **kwargs):
 			[f"Description of a {link.get('type')} in the {workspace_name} Workspace"],
 		)
 		for link in data.get("links", [])
+		if link.get("description")
 	)
 	yield from (
 		(
@@ -52,6 +56,7 @@ def extract(fileobj, *args, **kwargs):
 			[f"Label of a shortcut in the {workspace_name} Workspace"],
 		)
 		for shortcut in data.get("shortcuts", [])
+		if shortcut.get("label")
 	)
 	yield from (
 		(
@@ -61,15 +66,17 @@ def extract(fileobj, *args, **kwargs):
 			[f"Count format of shortcut in the {workspace_name} Workspace"],
 		)
 		for shortcut in data.get("shortcuts", [])
+		if shortcut.get("format")
 	)
 
 	content = json.loads(data.get("content", "[]"))
 	for item in content:
 		item_type = item.get("type")
 		if item_type in ("header", "paragraph"):
-			yield (
-				None,
-				"_",
-				item.get("data", {}).get("text"),
-				[f"{item_type.title()} text in the {workspace_name} Workspace"],
-			)
+			if text := item.get("data", {}).get("text"):
+				yield (
+					None,
+					"_",
+					text,
+					[f"{item_type.title()} text in the {workspace_name} Workspace"],
+				)

--- a/frappe/integrations/doctype/connected_app/test_connected_app.py
+++ b/frappe/integrations/doctype/connected_app/test_connected_app.py
@@ -128,6 +128,8 @@ class TestConnectedApp(FrappeTestCase):
 			if doc:
 				doc.delete(force=True)
 
+		frappe.db.commit()  # Avoid snapshot violation issues
+
 		delete_if_exists("token_cache")
 		delete_if_exists("connected_app")
 

--- a/frappe/integrations/frappe_providers/frappecloud_billing.py
+++ b/frappe/integrations/frappe_providers/frappecloud_billing.py
@@ -39,32 +39,6 @@ def get_headers():
 
 
 @frappe.whitelist()
-def get_token_and_base_url():
-	request = requests.post(
-		f"{get_base_url()}/api/method/press.saas.api.auth.generate_access_token",
-		headers=get_headers(),
-	)
-	if request.status_code == 200:
-		return {
-			"base_url": get_base_url(),
-			"token": request.json()["message"],
-		}
-	else:
-		frappe.throw(_("Failed to generate access token"))
-
-
-@frappe.whitelist()
-def is_access_token_valid(token):
-	headers = {"Content-Type": "application/json"}
-	request = requests.post(
-		f"{get_base_url()}/api/method/press.saas.api.auth.is_access_token_valid",
-		headers,
-		json={token},
-	)
-	return request.json()["message"]
-
-
-@frappe.whitelist()
 def current_site_info():
 	from frappe.utils import cint
 
@@ -103,8 +77,7 @@ def api(method, data=None):
 @frappe.whitelist()
 def is_fc_site() -> bool:
 	is_system_manager = frappe.get_roles(frappe.session.user).count("System Manager")
-	setup_completed = frappe.get_system_settings("setup_complete")
-	return bool(is_system_manager and setup_completed and frappe.conf.get("fc_communication_secret"))
+	return bool(is_system_manager and frappe.conf.get("fc_communication_secret"))
 
 
 # login to frappe cloud dashboard
@@ -122,13 +95,13 @@ def send_verification_code():
 
 
 @frappe.whitelist()
-def verify_and_login(verification_code: str):
+def verify_verification_code(verification_code: str, route: str):
 	request = requests.post(
-		f"{get_base_url()}/api/method/press.api.developer.saas.validate_login_to_fc",
+		f"{get_base_url()}/api/method/press.api.developer.saas.verify_verification_code",
 		headers=get_headers(),
-		json={"domain": get_site_name(), "otp": verification_code},
+		json={"domain": get_site_name(), "verification_code": verification_code, "route": route},
 	)
-	
+
 	if request.status_code == 200:
 		return {
 			"base_url": get_base_url(),

--- a/frappe/locale/de.po
+++ b/frappe/locale/de.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: developers@frappe.io\n"
 "POT-Creation-Date: 2025-03-20 13:58+0000\n"
-"PO-Revision-Date: 2025-04-09 16:02\n"
+"PO-Revision-Date: 2025-04-19 17:55\n"
 "Last-Translator: developers@frappe.io\n"
 "Language-Team: German\n"
 "MIME-Version: 1.0\n"
@@ -1805,12 +1805,12 @@ msgstr "Automatische Wiederholung zulassen"
 #: frappe/core/doctype/docfield/docfield.json
 #: frappe/custom/doctype/customize_form_field/customize_form_field.json
 msgid "Allow Bulk Edit"
-msgstr "Massenbearbeitung zulassen"
+msgstr "Stapelberarbeitung zulassen"
 
 #. Label of a Check field in DocType 'List View Settings'
 #: frappe/desk/doctype/list_view_settings/list_view_settings.json
 msgid "Allow Bulk Editing"
-msgstr "Massenbearbeitung zulassen"
+msgstr "Stapelberarbeitung zulassen"
 
 #. Label of a Check field in DocType 'Web Form'
 #: frappe/website/doctype/web_form/web_form.json
@@ -2138,7 +2138,7 @@ msgstr "Berichtigte Dokumente"
 #: frappe/core/doctype/transaction_log/transaction_log.json
 #: frappe/website/doctype/personal_data_download_request/personal_data_download_request.json
 msgid "Amended From"
-msgstr "Abgeändert von"
+msgstr "Berichtigung von"
 
 #: frappe/public/js/frappe/form/save.js:12
 msgctxt "Freeze message while amending a document"
@@ -2318,7 +2318,7 @@ msgstr "Anwendbare Dokumenttypen"
 #. Label of a Link field in DocType 'User Permission'
 #: frappe/core/doctype/user_permission/user_permission.json
 msgid "Applicable For"
-msgstr "Anwenden für"
+msgstr "Anwendbar für"
 
 #. Label of a Attach Image field in DocType 'Navbar Settings'
 #. Label of a Section Break field in DocType 'Navbar Settings'
@@ -2625,7 +2625,7 @@ msgstr "Zuweisen..."
 #. Option for the 'Type' (Select) field in DocType 'Notification Log'
 #: frappe/desk/doctype/notification_log/notification_log.json
 msgid "Assignment"
-msgstr "Zuordnung"
+msgstr "Zuweisung"
 
 #. Option for the 'Comment Type' (Select) field in DocType 'Comment'
 #. Option for the 'Comment Type' (Select) field in DocType 'Communication'
@@ -2742,7 +2742,7 @@ msgstr "Ausdruck anhängen"
 
 #: frappe/public/js/frappe/file_uploader/WebLink.vue:10
 msgid "Attach a web link"
-msgstr "Weblink anhängen"
+msgstr "Einen Weblink anhängen"
 
 #: frappe/website/doctype/website_slideshow/website_slideshow.js:8
 msgid "Attach files / urls and add in table."
@@ -2847,7 +2847,7 @@ msgstr "Authentifizierungs-URL-Daten"
 #. Label of a Check field in DocType 'Email Account'
 #: frappe/email/doctype/email_account/email_account.json
 msgid "Authenticate as Service Principal"
-msgstr "Als Service Principal authentifizieren"
+msgstr "Als Service-Prinzipal authentifizieren"
 
 #. Label of a Section Break field in DocType 'Email Account'
 #. Label of a Section Break field in DocType 'Push Notification Settings'
@@ -3256,7 +3256,7 @@ msgstr "Warteschlange für Hintergrundaufträge"
 
 #: frappe/public/js/frappe/list/bulk_operations.js:87
 msgid "Background Print (required for >25 documents)"
-msgstr "Im Hintergrund drucken (erforderlich für >25 Dokumente)"
+msgstr "Im Hintergrund drucken (erforderlich für mehr als 25 Dokumente)"
 
 #. Label of a Section Break field in DocType 'System Settings'
 #. Label of a Table field in DocType 'System Health Report'
@@ -3768,54 +3768,54 @@ msgstr "Basierend auf {0}"
 #. Label of a Check field in DocType 'User'
 #: frappe/core/doctype/user/user.json
 msgid "Bulk Actions"
-msgstr "Massenbearbeitung"
+msgstr "Stapelverarbeitung"
 
 #: frappe/core/doctype/user_permission/user_permission_list.js:142
 msgid "Bulk Delete"
-msgstr "Massenlöschung"
+msgstr "Stapel löschen"
 
 #: frappe/public/js/frappe/list/bulk_operations.js:321
 msgid "Bulk Edit"
-msgstr "Massenbearbeitung"
+msgstr "Stapel bearbeiten"
 
 #: frappe/public/js/frappe/form/grid.js:1172
 msgid "Bulk Edit {0}"
-msgstr "Massen-Bearbeitung {0}"
+msgstr "Stapel-Bearbeitung {0}"
 
 #: frappe/desk/reportview.py:578
 msgid "Bulk Operation Failed"
-msgstr "Massenvorgang fehlgeschlagen"
+msgstr "Stapelverarbeitung fehlgeschlagen"
 
 #: frappe/desk/reportview.py:582
 msgid "Bulk Operation Successful"
-msgstr "Massenvorgang erfolgreich"
+msgstr "Stapelverarbeitung erfolgreich"
 
 #: frappe/public/js/frappe/list/bulk_operations.js:131
 msgid "Bulk PDF Export"
-msgstr "Massenhafter PDF-Export"
+msgstr "Stapel-PDF-Export"
 
 #. Label of a Link in the Tools Workspace
 #. Name of a DocType
 #: frappe/automation/workspace/tools/tools.json
 #: frappe/desk/doctype/bulk_update/bulk_update.json
 msgid "Bulk Update"
-msgstr "Massen-Update"
+msgstr "Stapeländerung"
 
 #: frappe/model/workflow.py:253
 msgid "Bulk approval only support up to 500 documents."
-msgstr "Massengenehmigung unterstützt nur bis zu 500 Dokumente."
+msgstr "Stapel-Genehmigung unterstützt nur bis zu 500 Dokumente."
 
 #: frappe/desk/doctype/bulk_update/bulk_update.py:58
 msgid "Bulk operation is enqueued in background."
-msgstr "Massenoperationen werden im Hintergrund eingereiht."
+msgstr "Stapelverarbeitung wird im Hintergrund eingereiht."
 
 #: frappe/desk/doctype/bulk_update/bulk_update.py:70
 msgid "Bulk operations only support up to 500 documents."
-msgstr "Massenvorgänge unterstützen nur bis zu 500 Dokumente."
+msgstr "Stapelverarbeitung unterstützt nur bis zu 500 Dokumente."
 
 #: frappe/model/workflow.py:243
 msgid "Bulk {0} is enqueued in background."
-msgstr "Massen- {0} ist im Hintergrund eingereiht."
+msgstr "Stapel-{0} ist im Hintergrund eingereiht."
 
 #. Option for the 'Type' (Select) field in DocType 'DocField'
 #. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
@@ -4147,7 +4147,7 @@ msgstr "Dokumente stornieren"
 
 #: frappe/desk/doctype/bulk_update/bulk_update.py:93
 msgid "Cancelling {0}"
-msgstr "Abbrechen von {0}"
+msgstr "{0} wird storniert"
 
 #: frappe/core/doctype/prepared_report/prepared_report.py:259
 msgid "Cannot Download Report due to insufficient permissions"
@@ -4179,7 +4179,7 @@ msgstr "Stornierung vor Übertragen nicht möglich. Vorgang {0} beachten"
 
 #: frappe/public/js/frappe/list/bulk_operations.js:294
 msgid "Cannot cancel {0}."
-msgstr "{0} kann nicht abgebrochen werden."
+msgstr "{0} kann nicht storniert werden."
 
 #: frappe/model/document.py:891
 msgid "Cannot change docstatus from 0 (Draft) to 2 (Cancelled)"
@@ -4254,7 +4254,7 @@ msgstr "Das vom System generierte Feld <strong>{0}</strong>kann nicht gelöscht 
 
 #: frappe/public/js/frappe/list/bulk_operations.js:215
 msgid "Cannot delete {0}"
-msgstr "Kann {0} nicht löschen"
+msgstr "{0} kann nicht gelöscht werden"
 
 #: frappe/utils/nestedset.py:303
 msgid "Cannot delete {0} as it has child nodes"
@@ -4343,7 +4343,7 @@ msgstr "Kann {0} nicht mit der Berechtigung zum Buchen teilen, da der Doctype {1
 
 #: frappe/public/js/frappe/list/bulk_operations.js:291
 msgid "Cannot submit {0}."
-msgstr "Kann {0} nicht buchen."
+msgstr "{0} kann nicht gebucht werden."
 
 #: frappe/desk/doctype/workspace/workspace.py:358
 msgid "Cannot update private workspace of other users"
@@ -32043,7 +32043,7 @@ msgstr "{{{0}}} ist kein gültiges Format für Feldnamen. Es sollte sein {{field
 #. Count format of shortcut in the Website Workspace
 #: frappe/website/workspace/website/website.json
 msgid "{} Active"
-msgstr ""
+msgstr "{} Aktiv"
 
 #: frappe/public/js/frappe/form/form.js:505
 msgid "{} Complete"

--- a/frappe/locale/fa.po
+++ b/frappe/locale/fa.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: developers@frappe.io\n"
 "POT-Creation-Date: 2025-03-20 13:58+0000\n"
-"PO-Revision-Date: 2025-04-10 16:17\n"
+"PO-Revision-Date: 2025-04-15 17:06\n"
 "Last-Translator: developers@frappe.io\n"
 "Language-Team: Persian\n"
 "MIME-Version: 1.0\n"
@@ -11692,7 +11692,7 @@ msgstr "محیط کار را مخفی کنید"
 #. Permission'
 #: frappe/core/doctype/user_permission/user_permission.json
 msgid "Hide descendant records of <b>For Value</b>."
-msgstr "سوابق نسل <b>برای ارزش</b> را پنهان کنید."
+msgstr "پنهان کردن رکوردهای فرزند <b>برای مقدار</b>."
 
 #: frappe/public/js/frappe/form/layout.js:286
 msgid "Hide details"

--- a/frappe/locale/hr.po
+++ b/frappe/locale/hr.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: developers@frappe.io\n"
 "POT-Creation-Date: 2025-03-20 13:58+0000\n"
-"PO-Revision-Date: 2025-04-04 14:10\n"
+"PO-Revision-Date: 2025-04-20 17:52\n"
 "Last-Translator: developers@frappe.io\n"
 "Language-Team: Croatian\n"
 "MIME-Version: 1.0\n"
@@ -1293,7 +1293,7 @@ msgstr "Dodani zadani tipovi dokumenata dnevnika: {}"
 
 #: frappe/core/doctype/file/file.py:730
 msgid "Added {0}"
-msgstr "Dodano {0}"
+msgstr ""
 
 #: frappe/public/js/frappe/form/link_selector.js:180
 #: frappe/public/js/frappe/form/link_selector.js:202

--- a/frappe/locale/pt.po
+++ b/frappe/locale/pt.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: developers@frappe.io\n"
 "POT-Creation-Date: 2025-03-20 13:58+0000\n"
-"PO-Revision-Date: 2025-04-14 16:58\n"
+"PO-Revision-Date: 2025-04-18 17:28\n"
 "Last-Translator: developers@frappe.io\n"
 "Language-Team: Portuguese\n"
 "MIME-Version: 1.0\n"
@@ -821,7 +821,7 @@ msgstr ""
 #. Label of a Section Break field in DocType 'Email Account'
 #: frappe/email/doctype/email_account/email_account.json
 msgid "Account"
-msgstr "Conta"
+msgstr ""
 
 #. Label of a Section Break field in DocType 'Website Settings'
 #: frappe/website/doctype/website_settings/website_settings.json
@@ -833,7 +833,7 @@ msgstr ""
 #: frappe/contacts/doctype/contact/contact.json
 #: frappe/geo/doctype/currency/currency.json
 msgid "Accounts Manager"
-msgstr "Gestor de Contas"
+msgstr ""
 
 #. Name of a role
 #: frappe/automation/doctype/auto_repeat/auto_repeat.json
@@ -841,7 +841,7 @@ msgstr "Gestor de Contas"
 #: frappe/contacts/doctype/contact/contact.json
 #: frappe/geo/doctype/currency/currency.json
 msgid "Accounts User"
-msgstr "Utilizador de Contas"
+msgstr ""
 
 #. Label of a Select field in DocType 'Amended Document Naming Settings'
 #. Option for the 'Item Type' (Select) field in DocType 'Navbar Item'
@@ -861,7 +861,7 @@ msgstr "Utilizador de Contas"
 #: frappe/workflow/doctype/workflow_transition/workflow_transition.json
 #: frappe/workflow/page/workflow_builder/workflow_builder.js:37
 msgid "Action"
-msgstr "Ação"
+msgstr ""
 
 #. Label of a Small Text field in DocType 'DocType Action'
 #: frappe/core/doctype/doctype_action/doctype_action.json
@@ -928,7 +928,7 @@ msgstr ""
 #: frappe/public/js/frappe/views/reports/query_report.js:215
 #: frappe/public/js/frappe/views/reports/query_report.js:779
 msgid "Actions"
-msgstr "Ações"
+msgstr ""
 
 #. Label of a Check field in DocType 'Package Import'
 #: frappe/core/doctype/package_import/package_import.json
@@ -945,7 +945,7 @@ msgstr ""
 #: frappe/integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
 #: frappe/workflow/doctype/workflow/workflow_list.js:5
 msgid "Active"
-msgstr "Ativo"
+msgstr ""
 
 #. Option for the 'Directory Server' (Select) field in DocType 'LDAP Settings'
 #: frappe/integrations/doctype/ldap_settings/ldap_settings.json
@@ -969,7 +969,7 @@ msgstr ""
 #: frappe/public/js/frappe/form/dashboard.js:22
 #: frappe/public/js/frappe/form/footer/form_timeline.js:60
 msgid "Activity"
-msgstr "Atividade"
+msgstr ""
 
 #. Name of a DocType
 #. Linked DocType in User's connections
@@ -992,12 +992,12 @@ msgstr ""
 #: frappe/public/js/frappe/views/reports/query_report.js:295
 #: frappe/public/js/frappe/widgets/widget_dialog.js:30
 msgid "Add"
-msgstr "Adicionar"
+msgstr ""
 
 #: frappe/public/js/frappe/list/list_view.js:291
 msgctxt "Primary action in list view"
 msgid "Add"
-msgstr "Adicionar"
+msgstr ""
 
 #: frappe/public/js/frappe/form/grid_row.js:430
 msgid "Add / Remove Columns"
@@ -1046,7 +1046,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/views/treeview.js:267
 msgid "Add Child"
-msgstr "Adicionar Subgrupo"
+msgstr ""
 
 #: frappe/public/js/frappe/views/kanban/kanban_board.html:4
 #: frappe/public/js/frappe/views/reports/query_report.js:1699
@@ -1104,7 +1104,7 @@ msgstr ""
 
 #: frappe/desk/doctype/event/event.js:35 frappe/desk/doctype/event/event.js:42
 msgid "Add Participants"
-msgstr "Adicione participantes"
+msgstr ""
 
 #. Label of a Check field in DocType 'Email Group'
 #: frappe/email/doctype/email_group/email_group.json
@@ -1297,7 +1297,7 @@ msgstr ""
 #: frappe/public/js/frappe/form/link_selector.js:180
 #: frappe/public/js/frappe/form/link_selector.js:202
 msgid "Added {0} ({1})"
-msgstr "Adicionado {0} ({1})"
+msgstr ""
 
 #. Label of a Section Break field in DocType 'Custom DocPerm'
 #. Label of a Section Break field in DocType 'DocPerm'
@@ -1317,14 +1317,14 @@ msgstr ""
 #: frappe/website/doctype/contact_us_settings/contact_us_settings.json
 #: frappe/website/doctype/website_settings/website_settings.json
 msgid "Address"
-msgstr "Endereço"
+msgstr ""
 
 #. Label of a Data field in DocType 'Address'
 #. Label of a Data field in DocType 'Contact Us Settings'
 #: frappe/contacts/doctype/address/address.json
 #: frappe/website/doctype/contact_us_settings/contact_us_settings.json
 msgid "Address Line 1"
-msgstr "Endereço Linha 1"
+msgstr ""
 
 #. Label of a Data field in DocType 'Address'
 #. Label of a Data field in DocType 'Contact Us Settings'
@@ -1403,7 +1403,7 @@ msgstr ""
 #: frappe/desk/doctype/onboarding_step/onboarding_step.json
 #: frappe/website/doctype/website_theme/website_theme.json
 msgid "Administrator"
-msgstr "Administrador"
+msgstr ""
 
 #: frappe/core/doctype/user/user.py:1158
 msgid "Administrator Logged In"
@@ -1548,7 +1548,7 @@ msgstr ""
 #: frappe/website/doctype/personal_data_download_request/personal_data_download_request.json
 #: frappe/website/doctype/website_settings/website_settings.json
 msgid "All"
-msgstr "Todos"
+msgstr ""
 
 #. Label of a Check field in DocType 'Calendar View'
 #. Label of a Check field in DocType 'Event'
@@ -1556,7 +1556,7 @@ msgstr "Todos"
 #: frappe/desk/doctype/event/event.json
 #: frappe/public/js/frappe/ui/notifications/notifications.js:401
 msgid "All Day"
-msgstr "Dia Inteiro"
+msgstr ""
 
 #: frappe/website/doctype/website_slideshow/website_slideshow.py:43
 msgid "All Images attached to Website Slideshow should be public"
@@ -2427,7 +2427,7 @@ msgstr ""
 #: frappe/public/js/frappe/model/model.js:136
 #: frappe/public/js/frappe/views/interaction.js:82
 msgid "Assigned To"
-msgstr "Atribuído A"
+msgstr ""
 
 #: frappe/desk/report/todo/todo.py:40
 msgid "Assigned To/Owner"
@@ -2629,7 +2629,7 @@ msgstr ""
 #: frappe/public/js/frappe/form/templates/form_sidebar.html:65
 #: frappe/website/doctype/web_form/templates/web_form.html:103
 msgid "Attachments"
-msgstr "Anexos"
+msgstr ""
 
 #: frappe/public/js/frappe/form/print_utils.js:91
 msgid "Attempting Connection to QZ Tray..."
@@ -3211,7 +3211,7 @@ msgstr ""
 #: frappe/printing/page/print/print.js:273
 #: frappe/printing/page/print/print.js:327
 msgid "Based On"
-msgstr "Baseado Em"
+msgstr ""
 
 #. Option for the 'Rule' (Select) field in DocType 'Assignment Rule'
 #: frappe/automation/doctype/assignment_rule/assignment_rule.json
@@ -3944,7 +3944,7 @@ msgstr ""
 #: frappe/public/js/frappe/model/indicator.js:78
 #: frappe/public/js/frappe/ui/filters/filter.js:537
 msgid "Cancelled"
-msgstr "Cancelado"
+msgstr ""
 
 #: frappe/core/doctype/deleted_document/deleted_document.py:52
 msgid "Cancelled Document restored as Draft"
@@ -4699,7 +4699,7 @@ msgstr ""
 #: frappe/public/js/frappe/ui/messages.js:246
 #: frappe/website/js/bootstrap-4.js:24
 msgid "Close"
-msgstr "Fechar"
+msgstr ""
 
 #. Label of a Code field in DocType 'Assignment Rule'
 #: frappe/automation/doctype/assignment_rule/assignment_rule.json
@@ -4762,7 +4762,7 @@ msgstr ""
 #: frappe/public/js/frappe/views/reports/query_report.js:1980
 #: frappe/public/js/frappe/views/treeview.js:110
 msgid "Collapse All"
-msgstr "Recolher todos"
+msgstr ""
 
 #. Label of a Check field in DocType 'DocField'
 #. Label of a Check field in DocType 'Custom Field'
@@ -4955,7 +4955,7 @@ msgstr ""
 #: frappe/public/js/frappe/model/model.js:135
 #: frappe/website/doctype/web_form/templates/web_form.html:119
 msgid "Comments"
-msgstr "Comentários"
+msgstr ""
 
 #. Description of the 'Timeline Field' (Data) field in DocType 'DocType'
 #: frappe/core/doctype/doctype/doctype.json
@@ -4997,7 +4997,7 @@ msgstr ""
 #: frappe/email/doctype/email_queue/email_queue.json
 #: frappe/tests/test_translate.py:35 frappe/tests/test_translate.py:103
 msgid "Communication"
-msgstr "Comunicação"
+msgstr ""
 
 #. Name of a DocType
 #: frappe/core/doctype/communication_link/communication_link.json
@@ -5020,7 +5020,7 @@ msgstr ""
 
 #: frappe/desk/page/leaderboard/leaderboard.js:112
 msgid "Company"
-msgstr "Empresa"
+msgstr ""
 
 #. Name of a DocType
 #: frappe/website/doctype/company_history/company_history.json
@@ -5056,7 +5056,7 @@ msgstr ""
 #: frappe/core/doctype/scheduled_job_log/scheduled_job_log.json
 #: frappe/www/complete_signup.html:21
 msgid "Complete"
-msgstr "Concluído"
+msgstr ""
 
 #: frappe/public/js/frappe/form/sidebar/assign_to.js:202
 msgid "Complete By"
@@ -5085,7 +5085,7 @@ msgstr ""
 #: frappe/utils/goal.py:117
 #: frappe/workflow/doctype/workflow_action/workflow_action.json
 msgid "Completed"
-msgstr "Concluído"
+msgstr ""
 
 #. Label of a Link field in DocType 'Workflow Action'
 #: frappe/workflow/doctype/workflow_action/workflow_action.json
@@ -5422,7 +5422,7 @@ msgstr ""
 #: frappe/public/js/frappe/widgets/onboarding_widget.js:428
 #: frappe/public/js/frappe/widgets/onboarding_widget.js:536
 msgid "Continue"
-msgstr "Continuar"
+msgstr ""
 
 #. Label of a Check field in DocType 'Translation'
 #: frappe/core/doctype/translation/translation.json
@@ -5541,7 +5541,7 @@ msgstr ""
 #: frappe/geo/doctype/country/country.json
 #: frappe/website/doctype/contact_us_settings/contact_us_settings.json
 msgid "Country"
-msgstr "País"
+msgstr ""
 
 #: frappe/utils/__init__.py:116
 msgid "Country Code Required"
@@ -5578,7 +5578,7 @@ msgstr ""
 #: frappe/public/js/frappe/views/workspace/workspace.js:1262
 #: frappe/workflow/page/workflow_builder/workflow_builder.js:46
 msgid "Create"
-msgstr "Criar"
+msgstr ""
 
 #: frappe/core/doctype/doctype/doctype_list.js:85
 msgid "Create & Continue"
@@ -5807,7 +5807,7 @@ msgstr ""
 #: frappe/geo/doctype/currency/currency.json
 #: frappe/website/doctype/web_form_field/web_form_field.json
 msgid "Currency"
-msgstr "Moeda"
+msgstr ""
 
 #. Label of a Data field in DocType 'Currency'
 #: frappe/geo/doctype/currency/currency.json
@@ -6208,7 +6208,7 @@ msgstr ""
 #: frappe/social/doctype/energy_point_settings/energy_point_settings.json
 #: frappe/website/report/website_analytics/website_analytics.js:23
 msgid "Daily"
-msgstr "Diário"
+msgstr ""
 
 #: frappe/templates/emails/upcoming_events.html:8
 msgid "Daily Event Digest is sent for Calendar Events where reminders are set."
@@ -6428,7 +6428,7 @@ msgstr ""
 #: frappe/public/js/frappe/views/interaction.js:80
 #: frappe/website/doctype/web_form_field/web_form_field.json
 msgid "Date"
-msgstr "Data"
+msgstr ""
 
 #. Label of a Select field in DocType 'System Settings'
 #. Label of a Data field in DocType 'Country'
@@ -6504,11 +6504,11 @@ msgstr ""
 
 #: frappe/templates/emails/password_reset.html:1
 msgid "Dear"
-msgstr "Caro"
+msgstr ""
 
 #: frappe/templates/emails/administrator_logged_in.html:1
 msgid "Dear System Manager,"
-msgstr "Caro Administrador de Sistema,"
+msgstr ""
 
 #: frappe/templates/emails/account_deletion_notification.html:1
 #: frappe/templates/emails/delete_data_confirmation.html:1
@@ -6745,12 +6745,12 @@ msgstr ""
 #: frappe/templates/discussions/reply_card.html:35
 #: frappe/templates/discussions/reply_section.html:29
 msgid "Delete"
-msgstr "Eliminar"
+msgstr ""
 
 #: frappe/public/js/frappe/list/list_view.js:1957
 msgctxt "Button in list view actions menu"
 msgid "Delete"
-msgstr "Eliminar"
+msgstr ""
 
 #: frappe/www/me.html:75
 msgid "Delete Account"
@@ -6972,7 +6972,7 @@ msgstr ""
 #: frappe/website/doctype/web_page/web_page.json
 #: frappe/website/doctype/website_slideshow_item/website_slideshow_item.json
 msgid "Description"
-msgstr "Descrição"
+msgstr ""
 
 #. Description of the 'Blog Intro' (Small Text) field in DocType 'Blog Post'
 #: frappe/website/doctype/blog_post/blog_post.json
@@ -7197,7 +7197,7 @@ msgstr ""
 #: frappe/public/js/frappe/model/indicator.js:115
 #: frappe/website/doctype/blogger/blogger.json
 msgid "Disabled"
-msgstr "Desativado"
+msgstr ""
 
 #: frappe/email/doctype/email_account/email_account.js:232
 msgid "Disabled Auto Reply"
@@ -7567,7 +7567,7 @@ msgstr ""
 #: frappe/email/doctype/document_follow/document_follow.json
 #: frappe/public/js/frappe/form/form_tour.js:62
 msgid "Document Name"
-msgstr "Nome do Documento"
+msgstr ""
 
 #: frappe/client.py:424
 msgid "Document Name must be a string"
@@ -7896,12 +7896,12 @@ msgstr ""
 #: frappe/email/doctype/auto_email_report/auto_email_report.js:8
 #: frappe/public/js/frappe/form/grid.js:63
 msgid "Download"
-msgstr "Baixar"
+msgstr ""
 
 #: frappe/public/js/frappe/views/reports/report_utils.js:229
 msgctxt "Export report"
 msgid "Download"
-msgstr "Baixar"
+msgstr ""
 
 #. Label of a Link in the Tools Workspace
 #: frappe/automation/workspace/tools/tools.json
@@ -7955,7 +7955,7 @@ msgstr ""
 #: frappe/public/js/frappe/model/indicator.js:73
 #: frappe/public/js/frappe/ui/filters/filter.js:535
 msgid "Draft"
-msgstr "Esboço, projeto"
+msgstr ""
 
 #: frappe/public/js/frappe/views/workspace/blocks/header.js:46
 #: frappe/public/js/frappe/views/workspace/blocks/paragraph.js:136
@@ -8030,7 +8030,7 @@ msgstr ""
 #: frappe/public/js/frappe/views/workspace/workspace.js:853
 #: frappe/public/js/frappe/views/workspace/workspace.js:1020
 msgid "Duplicate"
-msgstr "Duplicar"
+msgstr ""
 
 #: frappe/printing/doctype/print_format_field_template/print_format_field_template.py:53
 msgid "Duplicate Entry"
@@ -8886,7 +8886,7 @@ msgstr ""
 #: frappe/public/js/frappe/utils/common.js:416
 #: frappe/website/doctype/web_page/web_page.json
 msgid "End Date"
-msgstr "Data de Término"
+msgstr ""
 
 #. Label of a Select field in DocType 'Calendar View'
 #: frappe/desk/doctype/calendar_view/calendar_view.json
@@ -8990,7 +8990,7 @@ msgstr ""
 #: frappe/public/js/frappe/ui/messages.js:94
 msgctxt "Title of prompt dialog"
 msgid "Enter Value"
-msgstr "Insira o Valor"
+msgstr ""
 
 #: frappe/public/js/frappe/form/form_tour.js:60
 msgid "Enter a name for this {0}"
@@ -9060,12 +9060,12 @@ msgstr ""
 #: frappe/model/base_document.py:741 frappe/model/base_document.py:747
 #: frappe/public/js/frappe/ui/messages.js:22
 msgid "Error"
-msgstr "Erro"
+msgstr ""
 
 #: frappe/public/js/frappe/web_form/web_form.js:240
 msgctxt "Title of error message in web form"
 msgid "Error"
-msgstr "Erro"
+msgstr ""
 
 #: frappe/www/error.html:34
 msgid "Error Code: {0}"
@@ -9305,7 +9305,7 @@ msgstr ""
 #: frappe/public/js/frappe/views/reports/query_report.js:1980
 #: frappe/public/js/frappe/views/treeview.js:114
 msgid "Expand All"
-msgstr "Expandir todos"
+msgstr ""
 
 #: frappe/public/js/frappe/form/templates/form_sidebar.html:23
 msgid "Experimental"
@@ -10698,7 +10698,7 @@ msgstr ""
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
 #: frappe/website/report/website_analytics/website_analytics.js:8
 msgid "From Date"
-msgstr "Data De"
+msgstr ""
 
 #. Label of a Select field in DocType 'Auto Email Report'
 #: frappe/email/doctype/auto_email_report/auto_email_report.json
@@ -10770,7 +10770,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/views/treeview.js:385
 msgid "Further nodes can be only created under 'Group' type nodes"
-msgstr "Só podem ser criados subgrupos em subgrupos do tipo 'Grupo'"
+msgstr ""
 
 #: frappe/core/doctype/communication/communication.js:291
 msgid "Fw: {0}"
@@ -10879,7 +10879,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/form/multi_select_dialog.js:86
 msgid "Get Items"
-msgstr "Obter Itens"
+msgstr ""
 
 #: frappe/integrations/doctype/connected_app/connected_app.js:6
 msgid "Get OpenID Configuration"
@@ -11248,7 +11248,7 @@ msgstr ""
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
 #: frappe/website/report/website_analytics/website_analytics.js:32
 msgid "Group By"
-msgstr "Agrupar por"
+msgstr ""
 
 #. Label of a Select field in DocType 'Dashboard Chart'
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -11266,7 +11266,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/views/treeview.js:384
 msgid "Group Node"
-msgstr "Subgrupo"
+msgstr ""
 
 #. Label of a Data field in DocType 'LDAP Settings'
 #: frappe/integrations/doctype/ldap_settings/ldap_settings.json
@@ -11480,7 +11480,7 @@ msgstr ""
 #: frappe/public/js/frappe/ui/toolbar/navbar.html:87
 #: frappe/public/js/frappe/utils/help.js:27
 msgid "Help"
-msgstr "Ajuda"
+msgstr ""
 
 #. Name of a DocType
 #. Label of a Link in the Website Workspace
@@ -11710,7 +11710,7 @@ msgstr ""
 #: frappe/desk/doctype/todo/todo.json
 #: frappe/public/js/frappe/form/sidebar/assign_to.js:224
 msgid "High"
-msgstr "Alto"
+msgstr ""
 
 #. Description of the 'Priority' (Int) field in DocType 'Assignment Rule'
 #: frappe/automation/doctype/assignment_rule/assignment_rule.json
@@ -11741,7 +11741,7 @@ msgstr ""
 #: frappe/www/contact.py:22 frappe/www/error.html:30 frappe/www/login.html:167
 #: frappe/www/message.html:34
 msgid "Home"
-msgstr "Início"
+msgstr ""
 
 #. Label of a Data field in DocType 'Role'
 #. Label of a Data field in DocType 'Website Settings'
@@ -12255,12 +12255,12 @@ msgstr ""
 #: frappe/core/doctype/recorder/recorder_list.js:16
 #: frappe/email/doctype/email_group/email_group.js:31
 msgid "Import"
-msgstr "Importar"
+msgstr ""
 
 #: frappe/public/js/frappe/list/list_view.js:1696
 msgctxt "Button in list view menu"
 msgid "Import"
-msgstr "Importar"
+msgstr ""
 
 #. Label of a Link in the Tools Workspace
 #. Label of a shortcut in the Tools Workspace
@@ -12414,7 +12414,7 @@ msgstr ""
 
 #: frappe/core/doctype/data_import/data_import.js:42
 msgid "In Progress"
-msgstr "Em progresso"
+msgstr ""
 
 #: frappe/database/database.py:246
 msgid "In Read Only Mode"
@@ -12861,7 +12861,7 @@ msgstr ""
 
 #: frappe/email/smtp.py:135
 msgid "Invalid Credentials"
-msgstr "Credenciais inválidas"
+msgstr ""
 
 #: frappe/utils/data.py:105 frappe/utils/data.py:257
 msgid "Invalid Date"
@@ -12968,7 +12968,7 @@ msgstr ""
 #: frappe/public/js/frappe/widgets/widget_dialog.js:570
 #: frappe/utils/csvutils.py:201 frappe/utils/csvutils.py:222
 msgid "Invalid URL"
-msgstr "URL inválida"
+msgstr ""
 
 #: frappe/email/receive.py:154
 msgid "Invalid User Name or Support Password. Please rectify and try again."
@@ -14736,7 +14736,7 @@ msgstr ""
 #: frappe/desk/doctype/todo/todo.json
 #: frappe/public/js/frappe/form/sidebar/assign_to.js:216
 msgid "Low"
-msgstr "Baixo"
+msgstr ""
 
 #: frappe/public/js/frappe/utils/number_systems.js:13
 msgctxt "Number system"
@@ -14770,13 +14770,13 @@ msgstr ""
 #. Name of a role
 #: frappe/contacts/doctype/contact/contact.json
 msgid "Maintenance Manager"
-msgstr "Gestor de Manutenção"
+msgstr ""
 
 #. Name of a role
 #: frappe/contacts/doctype/address/address.json
 #: frappe/contacts/doctype/contact/contact.json
 msgid "Maintenance User"
-msgstr "Utilizador da Manutenção"
+msgstr ""
 
 #. Label of a Int field in DocType 'Package Release'
 #: frappe/core/doctype/package_release/package_release.json
@@ -15089,7 +15089,7 @@ msgstr ""
 #: frappe/website/doctype/web_page_view/web_page_view.json
 #: frappe/website/report/website_analytics/website_analytics.js:40
 msgid "Medium"
-msgstr "Médio"
+msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Communication'
 #. Option for the 'Event Category' (Select) field in DocType 'Event'
@@ -15135,7 +15135,7 @@ msgstr ""
 #: frappe/public/js/frappe/form/toolbar.js:241
 #: frappe/public/js/frappe/model/model.js:734
 msgid "Merge with existing"
-msgstr "Unir com existente"
+msgstr ""
 
 #: frappe/utils/nestedset.py:311
 msgid "Merging is only possible between Group-to-Group or Leaf Node-to-Leaf Node"
@@ -15396,7 +15396,7 @@ msgstr ""
 #: frappe/public/js/workflow_builder/store.js:97
 #: frappe/workflow/doctype/workflow/workflow.js:71
 msgid "Missing Values Required"
-msgstr "São Necessários os Valores em Falta"
+msgstr ""
 
 #: frappe/www/login.py:105
 msgid "Mobile"
@@ -15569,7 +15569,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/views/calendar/calendar.js:269
 msgid "Month"
-msgstr "Mês"
+msgstr ""
 
 #. Option for the 'Frequency' (Select) field in DocType 'Auto Repeat'
 #. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
@@ -15595,7 +15595,7 @@ msgstr "Mês"
 #: frappe/social/doctype/energy_point_settings/energy_point_settings.json
 #: frappe/website/report/website_analytics/website_analytics.js:25
 msgid "Monthly"
-msgstr "Mensal"
+msgstr ""
 
 #. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
 #. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
@@ -15654,7 +15654,7 @@ msgstr ""
 #: frappe/core/doctype/communication/communication.js:212
 #: frappe/public/js/frappe/form/grid_row_form.js:42
 msgid "Move"
-msgstr "Mover"
+msgstr ""
 
 #: frappe/public/js/frappe/form/grid_row.js:189
 msgid "Move To"
@@ -15818,7 +15818,7 @@ msgstr ""
 #: frappe/public/js/frappe/views/file/file_view.js:97
 #: frappe/website/doctype/website_slideshow/website_slideshow.js:25
 msgid "Name"
-msgstr "Nome"
+msgstr ""
 
 #: frappe/integrations/doctype/webhook/webhook.js:29
 msgid "Name (Doc Name)"
@@ -15978,7 +15978,7 @@ msgstr ""
 #: frappe/website/doctype/web_form/templates/web_list.html:15
 #: frappe/www/list.html:19
 msgid "New"
-msgstr "Novo"
+msgstr ""
 
 #: frappe/public/js/frappe/views/interaction.js:15
 msgid "New Activity"
@@ -16277,17 +16277,17 @@ msgstr ""
 #: frappe/public/js/frappe/views/reports/query_report.js:1543
 #: frappe/website/doctype/help_article/templates/help_article.html:26
 msgid "No"
-msgstr "Não"
+msgstr ""
 
 #: frappe/public/js/frappe/ui/filters/filter.js:543
 msgctxt "Checkbox is not checked"
 msgid "No"
-msgstr "Não"
+msgstr ""
 
 #: frappe/public/js/frappe/ui/messages.js:37
 msgctxt "Dismiss confirmation dialog"
 msgid "No"
-msgstr "Não"
+msgstr ""
 
 #: frappe/www/third_party_apps.html:54
 msgid "No Active Sessions"
@@ -16311,7 +16311,7 @@ msgstr ""
 #: frappe/public/js/frappe/utils/datatable.js:10
 #: frappe/public/js/frappe/widgets/chart_widget.js:57
 msgid "No Data"
-msgstr "Sem Dados"
+msgstr ""
 
 #: frappe/desk/page/user_profile/user_profile.html:11
 #: frappe/desk/page/user_profile/user_profile.html:22
@@ -16504,7 +16504,7 @@ msgstr ""
 
 #: frappe/desk/query_report.py:343
 msgid "No data to export"
-msgstr "Nenhum dado para exportar"
+msgstr ""
 
 #: frappe/contacts/doctype/address/address.py:246
 msgid "No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template."
@@ -16674,7 +16674,7 @@ msgstr ""
 #: frappe/core/doctype/user/user.py:964
 #: frappe/templates/includes/login/login.js:258 frappe/utils/oauth.py:270
 msgid "Not Allowed"
-msgstr "Não Desejados"
+msgstr ""
 
 #: frappe/templates/includes/login/login.js:260
 msgid "Not Allowed: Disabled User"
@@ -16721,7 +16721,7 @@ msgstr ""
 #: frappe/www/login.py:191 frappe/www/qrcode.py:22 frappe/www/qrcode.py:25
 #: frappe/www/qrcode.py:37
 msgid "Not Permitted"
-msgstr "Não Permitido"
+msgstr ""
 
 #: frappe/desk/query_report.py:535
 msgid "Not Permitted to read {0}"
@@ -16782,7 +16782,7 @@ msgstr ""
 
 #: frappe/workflow/doctype/workflow/workflow_list.js:7
 msgid "Not active"
-msgstr "Não está ativo"
+msgstr ""
 
 #: frappe/permissions.py:355
 msgid "Not allowed for {0}: {1}"
@@ -16829,7 +16829,7 @@ msgstr ""
 #: frappe/website/doctype/web_form/web_form.py:683
 #: frappe/website/js/website.js:97
 msgid "Not permitted"
-msgstr "Não é permitido"
+msgstr ""
 
 #: frappe/public/js/frappe/list/list_view.js:50
 msgid "Not permitted to view {0}"
@@ -16841,7 +16841,7 @@ msgstr ""
 #: frappe/automation/workspace/tools/tools.json
 #: frappe/desk/doctype/note/note.json
 msgid "Note"
-msgstr "Nota"
+msgstr ""
 
 #. Name of a DocType
 #: frappe/desk/doctype/note_seen_by/note_seen_by.json
@@ -17451,12 +17451,12 @@ msgstr ""
 #: frappe/desk/doctype/event/event.json frappe/desk/doctype/todo/todo.json
 #: frappe/workflow/doctype/workflow_action/workflow_action.json
 msgid "Open"
-msgstr "Abrir"
+msgstr ""
 
 #: frappe/desk/doctype/todo/todo_list.js:14
 msgctxt "Access"
 msgid "Open"
-msgstr "Abrir"
+msgstr ""
 
 #: frappe/public/js/frappe/ui/keyboard.js:205
 msgid "Open Awesomebar"
@@ -17731,7 +17731,7 @@ msgstr ""
 #: frappe/core/report/transaction_log_report/transaction_log_report.py:100
 #: frappe/social/doctype/energy_point_rule/energy_point_rule.js:42
 msgid "Owner"
-msgstr "Dono"
+msgstr ""
 
 #. Option for the 'Method' (Select) field in DocType 'Recorder'
 #: frappe/core/doctype/recorder/recorder.json
@@ -17959,7 +17959,7 @@ msgstr ""
 #: frappe/public/js/frappe/web_form/web_form.js:264
 #: frappe/templates/print_formats/standard.html:34
 msgid "Page {0} of {1}"
-msgstr "Página {0} de {1}"
+msgstr ""
 
 #. Label of a Data field in DocType 'SMS Parameter'
 #: frappe/core/doctype/sms_parameter/sms_parameter.json
@@ -18735,7 +18735,7 @@ msgstr ""
 
 #: frappe/desk/page/leaderboard/leaderboard.js:244
 msgid "Please select Company"
-msgstr "Por favor, selecione a Empresa"
+msgstr ""
 
 #: frappe/printing/doctype/print_format/print_format.js:30
 msgid "Please select DocType first"
@@ -18797,7 +18797,7 @@ msgstr ""
 
 #: frappe/website/doctype/website_settings/website_settings.js:100
 msgid "Please select {0}"
-msgstr "Por favor, selecione {0}"
+msgstr ""
 
 #: frappe/integrations/doctype/dropbox_settings/dropbox_settings.py:305
 msgid "Please set Dropbox access keys in site config or doctype"
@@ -18849,7 +18849,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/model/model.js:803
 msgid "Please specify"
-msgstr "Por favor, especifique"
+msgstr ""
 
 #: frappe/permissions.py:774
 msgid "Please specify a valid parent DocType for {0}"
@@ -19091,7 +19091,7 @@ msgstr ""
 #: frappe/public/js/frappe/form/controls/markdown_editor.js:31
 #: frappe/public/js/frappe/ui/capture.js:228
 msgid "Preview"
-msgstr "Pré-visualização"
+msgstr ""
 
 #. Label of a HTML field in DocType 'File'
 #: frappe/core/doctype/file/file.json
@@ -19200,12 +19200,12 @@ msgstr ""
 #: frappe/public/js/frappe/views/reports/report_view.js:1500
 #: frappe/public/js/frappe/views/treeview.js:456 frappe/www/printview.html:18
 msgid "Print"
-msgstr "Impressão"
+msgstr ""
 
 #: frappe/public/js/frappe/list/list_view.js:1949
 msgctxt "Button in list view actions menu"
 msgid "Print"
-msgstr "Impressão"
+msgstr ""
 
 #: frappe/public/js/frappe/list/bulk_operations.js:48
 msgid "Print Documents"
@@ -19417,7 +19417,7 @@ msgstr ""
 #: frappe/public/js/frappe/form/sidebar/assign_to.js:210
 #: frappe/website/doctype/web_page/web_page.json
 msgid "Priority"
-msgstr "Prioridade"
+msgstr ""
 
 #. Label of a Check field in DocType 'Custom HTML Block'
 #. Option for the 'Event Type' (Select) field in DocType 'Event'
@@ -19472,7 +19472,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/views/kanban/kanban_view.js:406
 msgid "Project"
-msgstr "Projeto"
+msgstr ""
 
 #. Label of a Data field in DocType 'Property Setter'
 #: frappe/core/doctype/version/version_view.html:12
@@ -19620,19 +19620,19 @@ msgstr ""
 #. Name of a role
 #: frappe/contacts/doctype/contact/contact.json
 msgid "Purchase Manager"
-msgstr "Gestor de Compras"
+msgstr ""
 
 #. Name of a role
 #: frappe/contacts/doctype/contact/contact.json
 msgid "Purchase Master Manager"
-msgstr "Gestor Definidor de Compra"
+msgstr ""
 
 #. Name of a role
 #: frappe/contacts/doctype/address/address.json
 #: frappe/contacts/doctype/contact/contact.json
 #: frappe/geo/doctype/currency/currency.json
 msgid "Purchase User"
-msgstr "Utilizador de Compra"
+msgstr ""
 
 #. Option for the 'Color' (Select) field in DocType 'DocType State'
 #. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
@@ -19692,7 +19692,7 @@ msgstr ""
 #: frappe/email/doctype/auto_email_report/auto_email_report.json
 #: frappe/public/js/frappe/utils/common.js:401
 msgid "Quarterly"
-msgstr "Trimestral"
+msgstr ""
 
 #. Label of a Data field in DocType 'Recorder Query'
 #. Label of a Code field in DocType 'Report'
@@ -19866,7 +19866,7 @@ msgstr ""
 
 #: frappe/website/report/website_analytics/website_analytics.js:20
 msgid "Range"
-msgstr "Faixa"
+msgstr ""
 
 #: frappe/desk/page/user_profile/user_profile_controller.js:402
 msgid "Rank"
@@ -20031,7 +20031,7 @@ msgstr ""
 #: frappe/social/doctype/energy_point_log/energy_point_log.js:20
 #: frappe/social/doctype/energy_point_log/energy_point_log.json
 msgid "Reason"
-msgstr "Motivo"
+msgstr ""
 
 #: frappe/public/js/frappe/views/reports/query_report.js:823
 msgid "Rebuild"
@@ -20212,7 +20212,7 @@ msgstr ""
 #: frappe/integrations/doctype/integration_request/integration_request.json
 #: frappe/public/js/frappe/views/interaction.js:54
 msgid "Reference"
-msgstr "Referência"
+msgstr ""
 
 #. Label of a Select field in DocType 'Notification'
 #: frappe/email/doctype/notification/notification.json
@@ -20395,7 +20395,7 @@ msgstr ""
 #: frappe/public/js/frappe/widgets/number_card_widget.js:328
 #: frappe/public/js/print_format_builder/Preview.vue:24
 msgid "Refresh"
-msgstr "Recarregar"
+msgstr ""
 
 #: frappe/core/page/dashboard_view/dashboard_view.js:177
 msgid "Refresh All"
@@ -20593,7 +20593,7 @@ msgstr ""
 #: frappe/public/js/frappe/model/model.js:752
 #: frappe/public/js/frappe/views/treeview.js:277
 msgid "Rename"
-msgstr "Alterar Nome"
+msgstr ""
 
 #: frappe/custom/doctype/custom_field/custom_field.js:116
 #: frappe/custom/doctype/custom_field/custom_field.js:136
@@ -20615,7 +20615,7 @@ msgstr ""
 #: frappe/core/doctype/communication/communication.js:43
 #: frappe/desk/doctype/todo/todo.js:36
 msgid "Reopen"
-msgstr "Reabrir"
+msgstr ""
 
 #: frappe/public/js/frappe/form/toolbar.js:503
 msgid "Repeat"
@@ -20720,7 +20720,7 @@ msgstr ""
 #: frappe/email/doctype/auto_email_report/auto_email_report.json
 #: frappe/public/js/frappe/request.js:610
 msgid "Report"
-msgstr "Relatório"
+msgstr ""
 
 #. Option for the 'Report Type' (Select) field in DocType 'Report'
 #. Option for the 'DocType View' (Select) field in DocType 'Workspace Shortcut'
@@ -20879,7 +20879,7 @@ msgstr ""
 #: frappe/core/doctype/system_settings/system_settings.json
 #: frappe/public/js/frappe/ui/toolbar/search_utils.js:547
 msgid "Reports"
-msgstr "Relatórios"
+msgstr ""
 
 #: frappe/patches/v14_0/update_workspace2.py:50
 msgid "Reports & Masters"
@@ -20986,7 +20986,7 @@ msgstr ""
 #: frappe/desk/doctype/module_onboarding/module_onboarding.js:17
 #: frappe/website/doctype/portal_settings/portal_settings.js:19
 msgid "Reset"
-msgstr "Redefinir"
+msgstr ""
 
 #: frappe/custom/doctype/customize_form/customize_form.js:136
 msgid "Reset All Customizations"
@@ -21706,19 +21706,19 @@ msgstr ""
 #. Name of a role
 #: frappe/contacts/doctype/contact/contact.json
 msgid "Sales Manager"
-msgstr "Gestor De Vendas"
+msgstr ""
 
 #. Name of a role
 #: frappe/contacts/doctype/contact/contact.json
 msgid "Sales Master Manager"
-msgstr "Gestor de Vendas Master"
+msgstr ""
 
 #. Name of a role
 #: frappe/contacts/doctype/address/address.json
 #: frappe/contacts/doctype/contact/contact.json
 #: frappe/geo/doctype/currency/currency.json
 msgid "Sales User"
-msgstr "Utilizador de Vendas"
+msgstr ""
 
 #. Option for the 'Social Login Provider' (Select) field in DocType 'Social
 #. Login Key'
@@ -21781,7 +21781,7 @@ msgstr ""
 #: frappe/public/js/print_format_builder/print_format_builder.bundle.js:15
 #: frappe/public/js/workflow_builder/workflow_builder.bundle.js:33
 msgid "Save"
-msgstr "Salvar"
+msgstr ""
 
 #: frappe/core/doctype/user/user.js:332
 msgid "Save API Secret: {0}"
@@ -22063,7 +22063,7 @@ msgstr ""
 #: frappe/public/js/frappe/ui/toolbar/search.js:68
 #: frappe/templates/includes/search_template.html:26 frappe/www/search.py:19
 msgid "Search"
-msgstr "Pesquisar"
+msgstr ""
 
 #. Label of a Check field in DocType 'User'
 #: frappe/core/doctype/user/user.json
@@ -22255,7 +22255,7 @@ msgstr ""
 #: frappe/website/doctype/web_form_field/web_form_field.json
 #: frappe/website/doctype/web_template_field/web_template_field.json
 msgid "Select"
-msgstr "Seleção"
+msgstr ""
 
 #: frappe/public/js/frappe/data_import/data_exporter.js:149
 #: frappe/public/js/frappe/form/controls/multicheck.js:166
@@ -22624,7 +22624,7 @@ msgstr ""
 
 #: frappe/email/doctype/auto_email_report/auto_email_report.js:21
 msgid "Send Now"
-msgstr "Enviar agora"
+msgstr ""
 
 #. Label of a Check field in DocType 'Print Settings'
 #: frappe/printing/doctype/print_settings/print_settings.json
@@ -22780,7 +22780,7 @@ msgstr ""
 #: frappe/email/doctype/email_queue/email_queue.json
 #: frappe/email/doctype/newsletter/newsletter.js:201
 msgid "Sending"
-msgstr "Transmissão"
+msgstr ""
 
 #: frappe/email/doctype/newsletter/newsletter.js:203
 msgid "Sending emails"
@@ -23147,7 +23147,7 @@ msgstr ""
 #: frappe/website/doctype/web_form/web_form.json
 #: frappe/website/doctype/web_page/web_page.json
 msgid "Settings"
-msgstr "Configurações"
+msgstr ""
 
 #. Label of a Table field in DocType 'Navbar Settings'
 #: frappe/core/doctype/navbar_settings/navbar_settings.json
@@ -23914,7 +23914,7 @@ msgstr ""
 #: frappe/website/doctype/website_route_redirect/website_route_redirect.json
 #: frappe/website/report/website_analytics/website_analytics.js:38
 msgid "Source"
-msgstr "Fonte"
+msgstr ""
 
 #. Label of a Data field in DocType 'Dashboard Chart Source'
 #: frappe/desk/doctype/dashboard_chart_source/dashboard_chart_source.json
@@ -24078,7 +24078,7 @@ msgstr ""
 #: frappe/public/js/frappe/utils/common.js:409
 #: frappe/website/doctype/web_page/web_page.json
 msgid "Start Date"
-msgstr "Data de Início"
+msgstr ""
 
 #. Label of a Select field in DocType 'Calendar View'
 #: frappe/desk/doctype/calendar_view/calendar_view.json
@@ -24379,7 +24379,7 @@ msgstr ""
 #: frappe/public/js/frappe/views/communication.js:107
 #: frappe/public/js/frappe/views/inbox/inbox_view.js:63
 msgid "Subject"
-msgstr "Assunto"
+msgstr ""
 
 #. Label of a Data field in DocType 'DocType'
 #. Label of a Data field in DocType 'Customize Form'
@@ -24492,7 +24492,7 @@ msgstr ""
 #: frappe/public/js/frappe/ui/filters/filter.js:536
 #: frappe/website/doctype/web_form/templates/web_form.html:133
 msgid "Submitted"
-msgstr "Enviado"
+msgstr ""
 
 #: frappe/workflow/doctype/workflow/workflow.py:104
 msgid "Submitted Document cannot be converted back to draft. Transition row {0}"
@@ -24543,7 +24543,7 @@ msgstr ""
 #: frappe/workflow/doctype/workflow_action/workflow_action.py:167
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "Success"
-msgstr "Sucesso"
+msgstr ""
 
 #. Name of a DocType
 #: frappe/core/doctype/success_action/success_action.json
@@ -25121,7 +25121,7 @@ msgstr ""
 #: frappe/desk/doctype/todo/todo_calendar.js:19
 #: frappe/desk/doctype/todo/todo_calendar.js:25
 msgid "Task"
-msgstr "Tarefa"
+msgstr ""
 
 #. Label of a Section Break field in DocType 'About Us Settings'
 #. Label of a Table field in DocType 'About Us Settings'
@@ -26112,7 +26112,7 @@ msgstr ""
 #: frappe/website/doctype/website_sidebar/website_sidebar.json
 #: frappe/website/doctype/website_sidebar_item/website_sidebar_item.json
 msgid "Title"
-msgstr "Título"
+msgstr ""
 
 #. Label of a Data field in DocType 'DocType'
 #. Label of a Data field in DocType 'Customize Form'
@@ -26147,7 +26147,7 @@ msgstr ""
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
 #: frappe/website/report/website_analytics/website_analytics.js:14
 msgid "To Date"
-msgstr "Até à Data"
+msgstr ""
 
 #. Label of a Select field in DocType 'Auto Email Report'
 #: frappe/email/doctype/auto_email_report/auto_email_report.json
@@ -26491,7 +26491,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/views/reports/report_view.js:1219
 msgid "Totals"
-msgstr "Totais"
+msgstr ""
 
 #: frappe/public/js/frappe/views/reports/report_view.js:1194
 msgid "Totals Row"
@@ -27052,7 +27052,7 @@ msgstr ""
 #: frappe/public/js/frappe/form/grid_row.js:403
 #: frappe/public/js/frappe/views/workspace/workspace.js:692
 msgid "Update"
-msgstr "Atualizar"
+msgstr ""
 
 #. Label of a Button field in DocType 'Document Naming Settings'
 #: frappe/core/doctype/document_naming_settings/document_naming_settings.json
@@ -27390,7 +27390,7 @@ msgstr ""
 #: frappe/website/doctype/personal_data_download_request/personal_data_download_request.json
 #: frappe/workflow/doctype/workflow_action/workflow_action.json
 msgid "User"
-msgstr "Do utilizador"
+msgstr ""
 
 #. Label of a Link field in DocType 'Access Log'
 #: frappe/core/doctype/access_log/access_log.json
@@ -27680,7 +27680,7 @@ msgstr ""
 
 #: frappe/utils/oauth.py:270
 msgid "User {0} is disabled"
-msgstr "Utilizador {0} está desativado"
+msgstr ""
 
 #: frappe/sessions.py:240
 msgid "User {0} is disabled. Please contact your System Manager."
@@ -27799,7 +27799,7 @@ msgstr ""
 #: frappe/website/doctype/web_form/web_form.js:197
 #: frappe/website/doctype/website_meta_tag/website_meta_tag.json
 msgid "Value"
-msgstr "Valor"
+msgstr ""
 
 #. Label of a Select field in DocType 'Dashboard Chart'
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -28114,7 +28114,7 @@ msgstr ""
 
 #: frappe/website/doctype/help_article/templates/help_article.html:24
 msgid "Was this article helpful?"
-msgstr ""
+msgstr "Este artigo foi útil?"
 
 #: frappe/public/js/frappe/widgets/onboarding_widget.js:127
 msgid "Watch Tutorial"
@@ -28479,7 +28479,7 @@ msgstr ""
 #: frappe/social/doctype/energy_point_settings/energy_point_settings.json
 #: frappe/website/report/website_analytics/website_analytics.js:24
 msgid "Weekly"
-msgstr "Semanal"
+msgstr ""
 
 #. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
 #. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
@@ -28516,7 +28516,7 @@ msgstr ""
 
 #: frappe/core/doctype/user/user.py:418
 msgid "Welcome to {0}"
-msgstr "Bem-vindo ao {0}"
+msgstr ""
 
 #: frappe/public/js/frappe/ui/notifications/notifications.js:62
 msgid "What's New"
@@ -28876,7 +28876,7 @@ msgstr ""
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
 #: frappe/website/doctype/company_history/company_history.json
 msgid "Year"
-msgstr ""
+msgstr "Ano"
 
 #. Option for the 'Frequency' (Select) field in DocType 'Auto Repeat'
 #. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
@@ -28894,7 +28894,7 @@ msgstr ""
 #: frappe/email/doctype/auto_email_report/auto_email_report.json
 #: frappe/public/js/frappe/utils/common.js:403
 msgid "Yearly"
-msgstr "Anual"
+msgstr ""
 
 #. Option for the 'Color' (Select) field in DocType 'DocType State'
 #. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
@@ -28919,17 +28919,17 @@ msgstr ""
 #: frappe/public/js/frappe/views/reports/query_report.js:1543
 #: frappe/website/doctype/help_article/templates/help_article.html:25
 msgid "Yes"
-msgstr ""
+msgstr "Sim"
 
 #: frappe/public/js/frappe/ui/messages.js:32
 msgctxt "Approve confirmation dialog"
 msgid "Yes"
-msgstr ""
+msgstr "Sim"
 
 #: frappe/public/js/frappe/ui/filters/filter.js:542
 msgctxt "Checkbox is checked"
 msgid "Yes"
-msgstr ""
+msgstr "Sim"
 
 #: frappe/public/js/frappe/utils/user.js:33
 msgctxt "Name of the current user. For example: You edited this 5 hours ago."
@@ -29561,7 +29561,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/utils/utils.js:406 frappe/utils/data.py:1402
 msgid "and"
-msgstr "e"
+msgstr ""
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
@@ -30343,7 +30343,7 @@ msgstr ""
 #: frappe/public/js/frappe/utils/utils.js:403 frappe/www/login.html:87
 #: frappe/www/login.py:110
 msgid "or"
-msgstr "ou"
+msgstr ""
 
 #. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: frappe/desk/doctype/workspace/workspace.json
@@ -30486,7 +30486,7 @@ msgstr ""
 
 #: frappe/model/rename_doc.py:215
 msgid "renamed from {0} to {1}"
-msgstr ""
+msgstr "renomeado de {0} para {1}"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
@@ -30781,7 +30781,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/ui/filters/filter.js:357
 msgid "values separated by commas"
-msgstr ""
+msgstr "valores separados por vírgulas"
 
 #. Label of a HTML field in DocType 'Audit Trail'
 #: frappe/core/doctype/audit_trail/audit_trail.json
@@ -30866,7 +30866,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/utils/pretty_date.js:58
 msgid "yesterday"
-msgstr ""
+msgstr "ontem"
 
 #. Option for the 'Date Format' (Select) field in DocType 'System Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
@@ -31165,7 +31165,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/utils/pretty_date.js:60
 msgid "{0} days ago"
-msgstr ""
+msgstr "há {0} dias"
 
 #: frappe/website/doctype/website_settings/website_settings.py:96
 #: frappe/website/doctype/website_settings/website_settings.py:116
@@ -31226,7 +31226,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/utils/pretty_date.js:54
 msgid "{0} hours ago"
-msgstr ""
+msgstr "há {0} horas"
 
 #: frappe/website/doctype/web_form/templates/web_form.html:145
 msgid "{0} if you are not redirected within {1} seconds"
@@ -31239,7 +31239,7 @@ msgstr ""
 
 #: frappe/core/doctype/doctype/doctype.py:911
 msgid "{0} is a mandatory field"
-msgstr ""
+msgstr "{0} é um campo obrigatório"
 
 #: frappe/core/doctype/file/file.py:510
 msgid "{0} is a not a valid zip file"
@@ -31288,7 +31288,7 @@ msgstr ""
 
 #: frappe/email/doctype/email_account/email_account.py:171
 msgid "{0} is mandatory"
-msgstr "{0} é obrigatório"
+msgstr ""
 
 #: frappe/core/doctype/document_naming_rule/document_naming_rule.py:50
 msgid "{0} is not a field of doctype {1}"
@@ -31321,11 +31321,11 @@ msgstr ""
 
 #: frappe/utils/__init__.py:136
 msgid "{0} is not a valid Phone Number"
-msgstr ""
+msgstr "{0} não é um número de telefone válido"
 
 #: frappe/model/workflow.py:189
 msgid "{0} is not a valid Workflow State. Please update your Workflow and try again."
-msgstr ""
+msgstr "{0} não é um estado válido do fluxo de trabalho. Atualize o seu fluxo de trabalho e tente novamente."
 
 #: frappe/permissions.py:787
 msgid "{0} is not a valid parent DocType for {1}"
@@ -31337,7 +31337,7 @@ msgstr ""
 
 #: frappe/email/doctype/auto_email_report/auto_email_report.py:115
 msgid "{0} is not a valid report format. Report format should one of the following {1}"
-msgstr ""
+msgstr "{0} não é um formato de relatório válido. O formato do relatório deve ser um dos seguintes {1}"
 
 #: frappe/core/doctype/file/file.py:490
 msgid "{0} is not a zip file"
@@ -31372,7 +31372,7 @@ msgstr ""
 #: frappe/printing/doctype/print_format/print_format.py:92
 #: frappe/utils/csvutils.py:131
 msgid "{0} is required"
-msgstr "{0} é necessário"
+msgstr ""
 
 #: frappe/public/js/frappe/views/reports/report_view.js:1455
 msgid "{0} is set"
@@ -31384,7 +31384,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/list/list_view.js:1624
 msgid "{0} items selected"
-msgstr ""
+msgstr "{0} itens selecionados"
 
 #: frappe/core/doctype/user/user.py:1330
 msgid "{0} just impersonated as you. They gave this reason: {1}"
@@ -31409,19 +31409,19 @@ msgstr ""
 
 #: frappe/desk/notifications.py:398
 msgid "{0} mentioned you in a comment in {1} {2}"
-msgstr ""
+msgstr "{0} mencionou-o num comentário em {1} {2}"
 
 #: frappe/public/js/frappe/utils/pretty_date.js:50
 msgid "{0} minutes ago"
-msgstr ""
+msgstr "há {0} minutos"
 
 #: frappe/public/js/frappe/utils/pretty_date.js:68
 msgid "{0} months ago"
-msgstr ""
+msgstr "há {0} meses"
 
 #: frappe/model/document.py:1636
 msgid "{0} must be after {1}"
-msgstr ""
+msgstr "{0} deve ser posterior a {1}"
 
 #: frappe/model/document.py:1401
 msgid "{0} must be beginning with '{1}'"
@@ -31437,15 +31437,15 @@ msgstr ""
 
 #: frappe/model/document.py:1397 frappe/utils/csvutils.py:136
 msgid "{0} must be one of {1}"
-msgstr ""
+msgstr "{0} deve ser um dos {1}"
 
 #: frappe/model/base_document.py:808
 msgid "{0} must be set first"
-msgstr ""
+msgstr "{0} deve ser definido primeiro"
 
 #: frappe/model/base_document.py:666
 msgid "{0} must be unique"
-msgstr ""
+msgstr "{0} deve ser único"
 
 #: frappe/model/document.py:1405
 msgid "{0} must be {1} {2}"
@@ -31458,15 +31458,15 @@ msgstr ""
 
 #: frappe/workflow/doctype/workflow/workflow.py:91
 msgid "{0} not a valid State"
-msgstr ""
+msgstr "{0} não é um estado válido"
 
 #: frappe/model/rename_doc.py:391
 msgid "{0} not allowed to be renamed"
-msgstr ""
+msgstr "Não é permitido alterar o nome de {0}"
 
 #: frappe/desk/doctype/desktop_icon/desktop_icon.py:365
 msgid "{0} not found"
-msgstr ""
+msgstr "{0} não foi encontrado"
 
 #: frappe/core/doctype/report/report.py:424
 #: frappe/public/js/frappe/list/list_view.js:1015
@@ -31483,11 +31483,11 @@ msgstr ""
 
 #: frappe/utils/data.py:1552
 msgid "{0} or {1}"
-msgstr ""
+msgstr "{0} ou {1}"
 
 #: frappe/core/doctype/user_permission/user_permission_list.js:177
 msgid "{0} record deleted"
-msgstr ""
+msgstr "{0} registo eliminado"
 
 #: frappe/public/js/frappe/logtypes.js:22
 msgid "{0} records are not automatically deleted."
@@ -31499,11 +31499,11 @@ msgstr ""
 
 #: frappe/core/doctype/user_permission/user_permission_list.js:179
 msgid "{0} records deleted"
-msgstr ""
+msgstr "{0} registos eliminados"
 
 #: frappe/public/js/frappe/data_import/data_exporter.js:229
 msgid "{0} records will be exported"
-msgstr ""
+msgstr "Vão ser exportados {0} registos"
 
 #: frappe/public/js/frappe/form/footer/form_timeline.js:421
 msgctxt "Form timeline"
@@ -31517,17 +31517,17 @@ msgstr ""
 #: frappe/social/doctype/energy_point_log/energy_point_log.py:139
 #: frappe/social/doctype/energy_point_log/energy_point_log.py:178
 msgid "{0} reverted your point on {1}"
-msgstr ""
+msgstr "{0} reverteu o seu ponto em {1}"
 
 #: frappe/social/doctype/energy_point_log/energy_point_log.py:141
 #: frappe/social/doctype/energy_point_log/energy_point_log.py:180
 msgid "{0} reverted your points on {1}"
-msgstr ""
+msgstr "{0} reverteu os seus pontos em {1}"
 
 #: frappe/public/js/frappe/utils/energy_point_utils.js:44
 #: frappe/public/js/frappe/utils/energy_point_utils.js:59
 msgid "{0} reverted {1}"
-msgstr ""
+msgstr "{0} reverteu {1}"
 
 #: frappe/public/js/frappe/roles_editor.js:61
 msgid "{0} role does not have permission on any doctype"
@@ -31539,7 +31539,7 @@ msgstr ""
 
 #: frappe/desk/query_report.py:605
 msgid "{0} saved successfully"
-msgstr ""
+msgstr "{0} guardado com sucesso"
 
 #: frappe/desk/doctype/todo/todo.py:43
 msgid "{0} self assigned this task: {1}"
@@ -31611,7 +31611,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/utils/pretty_date.js:64
 msgid "{0} weeks ago"
-msgstr ""
+msgstr "há {0} semanas"
 
 #: frappe/public/js/frappe/utils/pretty_date.js:39
 msgid "{0} y"
@@ -31619,11 +31619,11 @@ msgstr ""
 
 #: frappe/public/js/frappe/utils/pretty_date.js:72
 msgid "{0} years ago"
-msgstr ""
+msgstr "há {0} anos"
 
 #: frappe/public/js/frappe/form/link_selector.js:219
 msgid "{0} {1} added"
-msgstr ""
+msgstr "{0} {1} adicionado"
 
 #: frappe/public/js/frappe/utils/dashboard_utils.js:270
 msgid "{0} {1} added to Dashboard {2}"
@@ -31631,7 +31631,7 @@ msgstr ""
 
 #: frappe/model/base_document.py:599 frappe/model/rename_doc.py:110
 msgid "{0} {1} already exists"
-msgstr ""
+msgstr "{0} {1} já existe"
 
 #: frappe/model/base_document.py:914
 msgid "{0} {1} cannot be \"{2}\". It should be one of \"{3}\""
@@ -31651,11 +31651,11 @@ msgstr ""
 
 #: frappe/model/document.py:180 frappe/permissions.py:554
 msgid "{0} {1} not found"
-msgstr ""
+msgstr "{0} {1} não foi encontrado"
 
 #: frappe/model/delete_doc.py:253
 msgid "{0} {1}: Submitted Record cannot be deleted. You must {2} Cancel {3} it first."
-msgstr ""
+msgstr "{0} {1}: O registo submetido não pode ser eliminado. Tem de {2} Cancelar {3} primeiro."
 
 #: frappe/model/base_document.py:1032
 msgid "{0}, Row {1}"
@@ -31671,7 +31671,7 @@ msgstr ""
 
 #: frappe/core/doctype/doctype/doctype.py:1763
 msgid "{0}: Cannot set Amend without Cancel"
-msgstr ""
+msgstr "{0}: Não é possível Corrigir sem Cancelar"
 
 #: frappe/core/doctype/doctype/doctype.py:1781
 msgid "{0}: Cannot set Assign Amend if not Submittable"
@@ -31683,7 +31683,7 @@ msgstr ""
 
 #: frappe/core/doctype/doctype/doctype.py:1758
 msgid "{0}: Cannot set Cancel without Submit"
-msgstr ""
+msgstr "{0}: Não é possível Cancelar sem Submeter"
 
 #: frappe/core/doctype/doctype/doctype.py:1765
 msgid "{0}: Cannot set Import without Create"
@@ -31703,7 +31703,7 @@ msgstr ""
 
 #: frappe/core/doctype/doctype/doctype.py:1389
 msgid "{0}: Field '{1}' cannot be set as Unique as it has non-unique values"
-msgstr ""
+msgstr "{0}: O campo '{1}' não pode ser definido como Único, uma vez que possui valores não exclusivos"
 
 #: frappe/core/doctype/doctype/doctype.py:1297
 msgid "{0}: Field {1} in row {2} cannot be hidden and mandatory without default"

--- a/frappe/locale/sr_CS.po
+++ b/frappe/locale/sr_CS.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: developers@frappe.io\n"
 "POT-Creation-Date: 2025-03-20 13:58+0000\n"
-"PO-Revision-Date: 2025-04-11 16:17\n"
+"PO-Revision-Date: 2025-04-27 19:25\n"
 "Last-Translator: developers@frappe.io\n"
 "Language-Team: Serbian (Latin)\n"
 "MIME-Version: 1.0\n"
@@ -760,7 +760,7 @@ msgstr ""
 #: frappe/website/doctype/about_us_settings/about_us_settings.json
 #: frappe/website/workspace/website/website.json
 msgid "About Us Settings"
-msgstr ""
+msgstr "O nama Podešavanje"
 
 #. Name of a DocType
 #: frappe/website/doctype/about_us_team_member/about_us_team_member.json
@@ -769,15 +769,15 @@ msgstr ""
 
 #: frappe/core/doctype/data_import/data_import.js:27
 msgid "About {0} minute remaining"
-msgstr ""
+msgstr "Ostalo je još oko {0} minuta"
 
 #: frappe/core/doctype/data_import/data_import.js:28
 msgid "About {0} minutes remaining"
-msgstr ""
+msgstr "Ostalo je još oko {0} minuta"
 
 #: frappe/core/doctype/data_import/data_import.js:25
 msgid "About {0} seconds remaining"
-msgstr ""
+msgstr "Ostalo je još oko {0} sekundi"
 
 #. Label of a Section Break field in DocType 'Web Form'
 #: frappe/website/doctype/web_form/web_form.json
@@ -821,7 +821,7 @@ msgstr ""
 #. Label of a Section Break field in DocType 'Email Account'
 #: frappe/email/doctype/email_account/email_account.json
 msgid "Account"
-msgstr ""
+msgstr "Račun"
 
 #. Label of a Section Break field in DocType 'Website Settings'
 #: frappe/website/doctype/website_settings/website_settings.json
@@ -833,7 +833,7 @@ msgstr ""
 #: frappe/contacts/doctype/contact/contact.json
 #: frappe/geo/doctype/currency/currency.json
 msgid "Accounts Manager"
-msgstr ""
+msgstr "Account Manager"
 
 #. Name of a role
 #: frappe/automation/doctype/auto_repeat/auto_repeat.json
@@ -841,7 +841,7 @@ msgstr ""
 #: frappe/contacts/doctype/contact/contact.json
 #: frappe/geo/doctype/currency/currency.json
 msgid "Accounts User"
-msgstr ""
+msgstr "Knjigovođa"
 
 #. Label of a Select field in DocType 'Amended Document Naming Settings'
 #. Option for the 'Item Type' (Select) field in DocType 'Navbar Item'
@@ -861,7 +861,7 @@ msgstr ""
 #: frappe/workflow/doctype/workflow_transition/workflow_transition.json
 #: frappe/workflow/page/workflow_builder/workflow_builder.js:37
 msgid "Action"
-msgstr ""
+msgstr "Radnja"
 
 #. Label of a Small Text field in DocType 'DocType Action'
 #: frappe/core/doctype/doctype_action/doctype_action.json
@@ -928,7 +928,7 @@ msgstr ""
 #: frappe/public/js/frappe/views/reports/query_report.js:215
 #: frappe/public/js/frappe/views/reports/query_report.js:779
 msgid "Actions"
-msgstr ""
+msgstr "Radnje"
 
 #. Label of a Check field in DocType 'Package Import'
 #: frappe/core/doctype/package_import/package_import.json
@@ -945,7 +945,7 @@ msgstr ""
 #: frappe/integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
 #: frappe/workflow/doctype/workflow/workflow_list.js:5
 msgid "Active"
-msgstr ""
+msgstr "Aktivan"
 
 #. Option for the 'Directory Server' (Select) field in DocType 'LDAP Settings'
 #: frappe/integrations/doctype/ldap_settings/ldap_settings.json
@@ -969,7 +969,7 @@ msgstr ""
 #: frappe/public/js/frappe/form/dashboard.js:22
 #: frappe/public/js/frappe/form/footer/form_timeline.js:60
 msgid "Activity"
-msgstr ""
+msgstr "Aktivnost"
 
 #. Name of a DocType
 #. Linked DocType in User's connections
@@ -992,12 +992,12 @@ msgstr ""
 #: frappe/public/js/frappe/views/reports/query_report.js:295
 #: frappe/public/js/frappe/widgets/widget_dialog.js:30
 msgid "Add"
-msgstr ""
+msgstr "Dodaj"
 
 #: frappe/public/js/frappe/list/list_view.js:291
 msgctxt "Primary action in list view"
 msgid "Add"
-msgstr ""
+msgstr "Dodaj"
 
 #: frappe/public/js/frappe/form/grid_row.js:430
 msgid "Add / Remove Columns"
@@ -1046,7 +1046,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/views/treeview.js:267
 msgid "Add Child"
-msgstr ""
+msgstr "Dodaj zavisni element"
 
 #: frappe/public/js/frappe/views/kanban/kanban_board.html:4
 #: frappe/public/js/frappe/views/reports/query_report.js:1699
@@ -1096,7 +1096,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/form/grid.js:63
 msgid "Add Multiple"
-msgstr ""
+msgstr "Dodaj višestruko"
 
 #: frappe/core/page/permission_manager/permission_manager.js:438
 msgid "Add New Permission Rule"
@@ -1104,7 +1104,7 @@ msgstr ""
 
 #: frappe/desk/doctype/event/event.js:35 frappe/desk/doctype/event/event.js:42
 msgid "Add Participants"
-msgstr ""
+msgstr "Dodaj korisnike"
 
 #. Label of a Check field in DocType 'Email Group'
 #: frappe/email/doctype/email_group/email_group.json
@@ -1297,7 +1297,7 @@ msgstr ""
 #: frappe/public/js/frappe/form/link_selector.js:180
 #: frappe/public/js/frappe/form/link_selector.js:202
 msgid "Added {0} ({1})"
-msgstr ""
+msgstr "Dodato {0} ({1})"
 
 #. Label of a Section Break field in DocType 'Custom DocPerm'
 #. Label of a Section Break field in DocType 'DocPerm'
@@ -1317,21 +1317,21 @@ msgstr ""
 #: frappe/website/doctype/contact_us_settings/contact_us_settings.json
 #: frappe/website/doctype/website_settings/website_settings.json
 msgid "Address"
-msgstr ""
+msgstr "Adresa"
 
 #. Label of a Data field in DocType 'Address'
 #. Label of a Data field in DocType 'Contact Us Settings'
 #: frappe/contacts/doctype/address/address.json
 #: frappe/website/doctype/contact_us_settings/contact_us_settings.json
 msgid "Address Line 1"
-msgstr ""
+msgstr "Adresa, red 1"
 
 #. Label of a Data field in DocType 'Address'
 #. Label of a Data field in DocType 'Contact Us Settings'
 #: frappe/contacts/doctype/address/address.json
 #: frappe/website/doctype/contact_us_settings/contact_us_settings.json
 msgid "Address Line 2"
-msgstr ""
+msgstr "Adresa, red 2"
 
 #. Name of a DocType
 #: frappe/contacts/doctype/address_template/address_template.json
@@ -1403,7 +1403,7 @@ msgstr ""
 #: frappe/desk/doctype/onboarding_step/onboarding_step.json
 #: frappe/website/doctype/website_theme/website_theme.json
 msgid "Administrator"
-msgstr ""
+msgstr "Administrator"
 
 #: frappe/core/doctype/user/user.py:1158
 msgid "Administrator Logged In"
@@ -1548,7 +1548,7 @@ msgstr ""
 #: frappe/website/doctype/personal_data_download_request/personal_data_download_request.json
 #: frappe/website/doctype/website_settings/website_settings.json
 msgid "All"
-msgstr ""
+msgstr "Sve"
 
 #. Label of a Check field in DocType 'Calendar View'
 #. Label of a Check field in DocType 'Event'
@@ -1556,7 +1556,7 @@ msgstr ""
 #: frappe/desk/doctype/event/event.json
 #: frappe/public/js/frappe/ui/notifications/notifications.js:401
 msgid "All Day"
-msgstr ""
+msgstr "Svi dani"
 
 #: frappe/website/doctype/website_slideshow/website_slideshow.py:43
 msgid "All Images attached to Website Slideshow should be public"
@@ -2008,7 +2008,7 @@ msgstr ""
 #. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
 #: frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
 msgid "Annual"
-msgstr ""
+msgstr "Godišnji"
 
 #. Label of a Code field in DocType 'Personal Data Deletion Request'
 #: frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.json
@@ -2427,7 +2427,7 @@ msgstr ""
 #: frappe/public/js/frappe/model/model.js:136
 #: frappe/public/js/frappe/views/interaction.js:82
 msgid "Assigned To"
-msgstr ""
+msgstr "Dodeljeno"
 
 #: frappe/desk/report/todo/todo.py:40
 msgid "Assigned To/Owner"
@@ -2440,7 +2440,7 @@ msgstr ""
 #. Option for the 'Type' (Select) field in DocType 'Notification Log'
 #: frappe/desk/doctype/notification_log/notification_log.json
 msgid "Assignment"
-msgstr ""
+msgstr "Zadatak"
 
 #. Option for the 'Comment Type' (Select) field in DocType 'Comment'
 #. Option for the 'Comment Type' (Select) field in DocType 'Communication'
@@ -2629,7 +2629,7 @@ msgstr ""
 #: frappe/public/js/frappe/form/templates/form_sidebar.html:65
 #: frappe/website/doctype/web_form/templates/web_form.html:103
 msgid "Attachments"
-msgstr ""
+msgstr "Prilozi"
 
 #: frappe/public/js/frappe/form/print_utils.js:91
 msgid "Attempting Connection to QZ Tray..."
@@ -2756,7 +2756,7 @@ msgstr ""
 #: frappe/automation/workspace/tools/tools.json
 #: frappe/email/doctype/auto_email_report/auto_email_report.json
 msgid "Auto Email Report"
-msgstr ""
+msgstr "Automatski imejl izveštaj"
 
 #. Label of a Data field in DocType 'DocType'
 #. Label of a Data field in DocType 'Customize Form'
@@ -3185,7 +3185,7 @@ msgstr ""
 #. Option for the 'Type' (Select) field in DocType 'Dashboard Chart'
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
 msgid "Bar"
-msgstr ""
+msgstr "Bar"
 
 #. Option for the 'Type' (Select) field in DocType 'DocField'
 #. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
@@ -3194,7 +3194,7 @@ msgstr ""
 #: frappe/custom/doctype/custom_field/custom_field.json
 #: frappe/custom/doctype/customize_form_field/customize_form_field.json
 msgid "Barcode"
-msgstr ""
+msgstr "Bar-kod"
 
 #. Label of a Data field in DocType 'LDAP Settings'
 #: frappe/integrations/doctype/ldap_settings/ldap_settings.json
@@ -3211,7 +3211,7 @@ msgstr ""
 #: frappe/printing/page/print/print.js:273
 #: frappe/printing/page/print/print.js:327
 msgid "Based On"
-msgstr ""
+msgstr "Na osnovu"
 
 #. Option for the 'Rule' (Select) field in DocType 'Assignment Rule'
 #: frappe/automation/doctype/assignment_rule/assignment_rule.json
@@ -3429,7 +3429,7 @@ msgstr ""
 #: frappe/core/doctype/doctype_state/doctype_state.json
 #: frappe/desk/doctype/kanban_board_column/kanban_board_column.json
 msgid "Blue"
-msgstr ""
+msgstr "Plava"
 
 #. Label of a Check field in DocType 'DocField'
 #. Label of a Check field in DocType 'Custom Field'
@@ -3490,7 +3490,7 @@ msgstr ""
 #. Label of a Section Break field in DocType 'Website Settings'
 #: frappe/website/doctype/website_settings/website_settings.json
 msgid "Brand"
-msgstr ""
+msgstr "Brend"
 
 #. Label of a Code field in DocType 'Website Settings'
 #: frappe/website/doctype/website_settings/website_settings.json
@@ -3613,7 +3613,7 @@ msgstr ""
 #: frappe/automation/workspace/tools/tools.json
 #: frappe/desk/doctype/bulk_update/bulk_update.json
 msgid "Bulk Update"
-msgstr ""
+msgstr "Masovno ažuriranje"
 
 #: frappe/model/workflow.py:253
 msgid "Bulk approval only support up to 500 documents."
@@ -3843,7 +3843,7 @@ msgstr ""
 #: frappe/website/doctype/web_page_view/web_page_view.json
 #: frappe/website/report/website_analytics/website_analytics.js:39
 msgid "Campaign"
-msgstr ""
+msgstr "Kampanja"
 
 #. Label of a Small Text field in DocType 'Marketing Campaign'
 #: frappe/website/doctype/marketing_campaign/marketing_campaign.json
@@ -3944,7 +3944,7 @@ msgstr ""
 #: frappe/public/js/frappe/model/indicator.js:78
 #: frappe/public/js/frappe/ui/filters/filter.js:537
 msgid "Cancelled"
-msgstr ""
+msgstr "Otkazano"
 
 #: frappe/core/doctype/deleted_document/deleted_document.py:52
 msgid "Cancelled Document restored as Draft"
@@ -4319,7 +4319,7 @@ msgstr ""
 #. Label of a Link field in DocType 'Dashboard Chart Link'
 #: frappe/desk/doctype/dashboard_chart_link/dashboard_chart_link.json
 msgid "Chart"
-msgstr ""
+msgstr "Dijagram"
 
 #. Label of a Code field in DocType 'Dashboard Settings'
 #: frappe/desk/doctype/dashboard_settings/dashboard_settings.json
@@ -4487,7 +4487,7 @@ msgstr ""
 #. Label of a Data field in DocType 'Contact Us Settings'
 #: frappe/website/doctype/contact_us_settings/contact_us_settings.json
 msgid "City"
-msgstr ""
+msgstr "Grad"
 
 #. Label of a Data field in DocType 'Address'
 #: frappe/contacts/doctype/address/address.json
@@ -4699,7 +4699,7 @@ msgstr ""
 #: frappe/public/js/frappe/ui/messages.js:246
 #: frappe/website/js/bootstrap-4.js:24
 msgid "Close"
-msgstr ""
+msgstr "Zatvori"
 
 #. Label of a Code field in DocType 'Assignment Rule'
 #: frappe/automation/doctype/assignment_rule/assignment_rule.json
@@ -4718,7 +4718,7 @@ msgstr ""
 #: frappe/core/doctype/communication/communication.json
 #: frappe/desk/doctype/event/event.json frappe/desk/doctype/todo/todo.json
 msgid "Closed"
-msgstr ""
+msgstr "Zatvoreno"
 
 #: frappe/templates/discussions/comment_box.html:25
 #: frappe/templates/discussions/reply_section.html:53
@@ -4762,7 +4762,7 @@ msgstr ""
 #: frappe/public/js/frappe/views/reports/query_report.js:1980
 #: frappe/public/js/frappe/views/treeview.js:110
 msgid "Collapse All"
-msgstr ""
+msgstr "Sažmi sve"
 
 #. Label of a Check field in DocType 'DocField'
 #. Label of a Check field in DocType 'Custom Field'
@@ -4955,7 +4955,7 @@ msgstr ""
 #: frappe/public/js/frappe/model/model.js:135
 #: frappe/website/doctype/web_form/templates/web_form.html:119
 msgid "Comments"
-msgstr ""
+msgstr "Komentari"
 
 #. Description of the 'Timeline Field' (Data) field in DocType 'DocType'
 #: frappe/core/doctype/doctype/doctype.json
@@ -4997,7 +4997,7 @@ msgstr ""
 #: frappe/email/doctype/email_queue/email_queue.json
 #: frappe/tests/test_translate.py:35 frappe/tests/test_translate.py:103
 msgid "Communication"
-msgstr ""
+msgstr "Komunikacija"
 
 #. Name of a DocType
 #: frappe/core/doctype/communication_link/communication_link.json
@@ -5020,7 +5020,7 @@ msgstr ""
 
 #: frappe/desk/page/leaderboard/leaderboard.js:112
 msgid "Company"
-msgstr ""
+msgstr "Kompanija"
 
 #. Name of a DocType
 #: frappe/website/doctype/company_history/company_history.json
@@ -5036,7 +5036,7 @@ msgstr ""
 #. Label of a Data field in DocType 'Contact'
 #: frappe/contacts/doctype/contact/contact.json
 msgid "Company Name"
-msgstr ""
+msgstr "Naziv kompanije"
 
 #: frappe/core/doctype/server_script/server_script.js:14
 #: frappe/custom/doctype/client_script/client_script.js:54
@@ -5056,7 +5056,7 @@ msgstr ""
 #: frappe/core/doctype/scheduled_job_log/scheduled_job_log.json
 #: frappe/www/complete_signup.html:21
 msgid "Complete"
-msgstr ""
+msgstr "Završeno"
 
 #: frappe/public/js/frappe/form/sidebar/assign_to.js:202
 msgid "Complete By"
@@ -5085,7 +5085,7 @@ msgstr ""
 #: frappe/utils/goal.py:117
 #: frappe/workflow/doctype/workflow_action/workflow_action.json
 msgid "Completed"
-msgstr ""
+msgstr "Završeno"
 
 #. Label of a Link field in DocType 'Workflow Action'
 #: frappe/workflow/doctype/workflow_action/workflow_action.json
@@ -5336,7 +5336,7 @@ msgstr ""
 #: frappe/website/doctype/contact_us_settings/contact_us_settings.json
 #: frappe/website/workspace/website/website.json
 msgid "Contact Us Settings"
-msgstr ""
+msgstr "Podešavanje za kontaktiranje"
 
 #. Description of the 'Query Options' (Small Text) field in DocType 'Contact Us
 #. Settings'
@@ -5422,7 +5422,7 @@ msgstr ""
 #: frappe/public/js/frappe/widgets/onboarding_widget.js:428
 #: frappe/public/js/frappe/widgets/onboarding_widget.js:536
 msgid "Continue"
-msgstr ""
+msgstr "Nastavi"
 
 #. Label of a Check field in DocType 'Translation'
 #: frappe/core/doctype/translation/translation.json
@@ -5541,7 +5541,7 @@ msgstr ""
 #: frappe/geo/doctype/country/country.json
 #: frappe/website/doctype/contact_us_settings/contact_us_settings.json
 msgid "Country"
-msgstr ""
+msgstr "Država"
 
 #: frappe/utils/__init__.py:116
 msgid "Country Code Required"
@@ -5561,7 +5561,7 @@ msgstr ""
 #: frappe/public/js/frappe/utils/number_systems.js:45
 msgctxt "Number system"
 msgid "Cr"
-msgstr ""
+msgstr "Potražuje"
 
 #. Label of a Check field in DocType 'Custom DocPerm'
 #. Label of a Check field in DocType 'DocPerm'
@@ -5578,7 +5578,7 @@ msgstr ""
 #: frappe/public/js/frappe/views/workspace/workspace.js:1262
 #: frappe/workflow/page/workflow_builder/workflow_builder.js:46
 msgid "Create"
-msgstr ""
+msgstr "Kreiraj"
 
 #: frappe/core/doctype/doctype/doctype_list.js:85
 msgid "Create & Continue"
@@ -5735,7 +5735,7 @@ msgstr ""
 #: frappe/public/js/frappe/model/model.js:125
 #: frappe/public/js/frappe/views/dashboard/dashboard_view.js:479
 msgid "Created On"
-msgstr ""
+msgstr "Kreirano na"
 
 #: frappe/public/js/frappe/desk.js:500
 #: frappe/public/js/frappe/views/treeview.js:359
@@ -5807,7 +5807,7 @@ msgstr ""
 #: frappe/geo/doctype/currency/currency.json
 #: frappe/website/doctype/web_form_field/web_form_field.json
 msgid "Currency"
-msgstr ""
+msgstr "Valuta"
 
 #. Label of a Data field in DocType 'Currency'
 #: frappe/geo/doctype/currency/currency.json
@@ -6208,7 +6208,7 @@ msgstr ""
 #: frappe/social/doctype/energy_point_settings/energy_point_settings.json
 #: frappe/website/report/website_analytics/website_analytics.js:23
 msgid "Daily"
-msgstr ""
+msgstr "Dnevno"
 
 #: frappe/templates/emails/upcoming_events.html:8
 msgid "Daily Event Digest is sent for Calendar Events where reminders are set."
@@ -6258,7 +6258,7 @@ msgstr ""
 #: frappe/desk/doctype/workspace_shortcut/workspace_shortcut.json
 #: frappe/public/js/frappe/ui/toolbar/search_utils.js:562
 msgid "Dashboard"
-msgstr ""
+msgstr "Kontrolna tabla"
 
 #. Label of a Link in the Build Workspace
 #. Name of a DocType
@@ -6428,7 +6428,7 @@ msgstr ""
 #: frappe/public/js/frappe/views/interaction.js:80
 #: frappe/website/doctype/web_form_field/web_form_field.json
 msgid "Date"
-msgstr ""
+msgstr "Datum"
 
 #. Label of a Select field in DocType 'System Settings'
 #. Label of a Data field in DocType 'Country'
@@ -6504,11 +6504,11 @@ msgstr ""
 
 #: frappe/templates/emails/password_reset.html:1
 msgid "Dear"
-msgstr ""
+msgstr "Poštovani/na"
 
 #: frappe/templates/emails/administrator_logged_in.html:1
 msgid "Dear System Manager,"
-msgstr ""
+msgstr "Poštovani menadžeru sistema,"
 
 #: frappe/templates/emails/account_deletion_notification.html:1
 #: frappe/templates/emails/delete_data_confirmation.html:1
@@ -6538,7 +6538,7 @@ msgstr ""
 #: frappe/website/doctype/web_form_field/web_form_field.json
 #: frappe/website/doctype/web_template_field/web_template_field.json
 msgid "Default"
-msgstr ""
+msgstr "Podrazumevano"
 
 #: frappe/contacts/doctype/address_template/address_template.py:41
 msgid "Default Address Template cannot be deleted"
@@ -6727,7 +6727,7 @@ msgstr ""
 #. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: frappe/core/doctype/communication/communication.json
 msgid "Delayed"
-msgstr ""
+msgstr "Kašnjenje"
 
 #. Label of a Check field in DocType 'Custom DocPerm'
 #. Label of a Check field in DocType 'DocPerm'
@@ -6745,12 +6745,12 @@ msgstr ""
 #: frappe/templates/discussions/reply_card.html:35
 #: frappe/templates/discussions/reply_section.html:29
 msgid "Delete"
-msgstr ""
+msgstr "Obriši"
 
 #: frappe/public/js/frappe/list/list_view.js:1957
 msgctxt "Button in list view actions menu"
 msgid "Delete"
-msgstr ""
+msgstr "Obriši"
 
 #: frappe/www/me.html:75
 msgid "Delete Account"
@@ -6865,7 +6865,7 @@ msgstr ""
 #. Label of a Link in the Tools Workspace
 #: frappe/automation/workspace/tools/tools.json
 msgid "Deleted Documents"
-msgstr ""
+msgstr "Obrisani dokumenti"
 
 #. Label of a Data field in DocType 'Deleted Document'
 #: frappe/core/doctype/deleted_document/deleted_document.json
@@ -6900,7 +6900,7 @@ msgstr ""
 #. Label of a Select field in DocType 'Communication'
 #: frappe/core/doctype/communication/communication.json
 msgid "Delivery Status"
-msgstr ""
+msgstr "Status isporuke"
 
 #. Option for the 'Sign ups' (Select) field in DocType 'Social Login Key'
 #: frappe/integrations/doctype/social_login_key/social_login_key.json
@@ -6911,7 +6911,7 @@ msgstr ""
 #. Label of a Data field in DocType 'Contact'
 #: frappe/contacts/doctype/contact/contact.json
 msgid "Department"
-msgstr ""
+msgstr "Odeljenje"
 
 #. Label of a Data field in DocType 'Workspace Link'
 #: frappe/desk/doctype/workspace_link/workspace_link.json
@@ -6972,7 +6972,7 @@ msgstr ""
 #: frappe/website/doctype/web_page/web_page.json
 #: frappe/website/doctype/website_slideshow_item/website_slideshow_item.json
 msgid "Description"
-msgstr ""
+msgstr "Opis"
 
 #. Description of the 'Blog Intro' (Small Text) field in DocType 'Blog Post'
 #: frappe/website/doctype/blog_post/blog_post.json
@@ -6988,7 +6988,7 @@ msgstr ""
 #. Label of a Data field in DocType 'Contact'
 #: frappe/contacts/doctype/contact/contact.json
 msgid "Designation"
-msgstr ""
+msgstr "Uloga"
 
 #. Label of a Check field in DocType 'Role'
 #: frappe/core/doctype/role/role.json
@@ -7037,7 +7037,7 @@ msgstr ""
 #: frappe/workflow/doctype/workflow_action/workflow_action.json
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "Desk User"
-msgstr ""
+msgstr "Recepcionar"
 
 #. Name of a DocType
 #: frappe/desk/doctype/desktop_icon/desktop_icon.json
@@ -7197,7 +7197,7 @@ msgstr ""
 #: frappe/public/js/frappe/model/indicator.js:115
 #: frappe/website/doctype/blogger/blogger.json
 msgid "Disabled"
-msgstr ""
+msgstr "Onemogućeno"
 
 #: frappe/email/doctype/email_account/email_account.js:232
 msgid "Disabled Auto Reply"
@@ -7477,7 +7477,7 @@ msgstr ""
 #: frappe/email/doctype/document_follow/document_follow.json
 #: frappe/public/js/frappe/widgets/widget_dialog.js:650
 msgid "Doctype"
-msgstr ""
+msgstr "DocType"
 
 #: frappe/core/doctype/doctype/doctype.py:999
 msgid "Doctype name is limited to {0} characters ({1})"
@@ -7567,7 +7567,7 @@ msgstr ""
 #: frappe/email/doctype/document_follow/document_follow.json
 #: frappe/public/js/frappe/form/form_tour.js:62
 msgid "Document Name"
-msgstr ""
+msgstr "Naziv dokumenta"
 
 #: frappe/client.py:424
 msgid "Document Name must be a string"
@@ -7700,7 +7700,7 @@ msgstr ""
 #: frappe/website/doctype/personal_data_deletion_step/personal_data_deletion_step.json
 #: frappe/workflow/doctype/workflow/workflow.json
 msgid "Document Type"
-msgstr ""
+msgstr "Vrsta dokumenta"
 
 #: frappe/desk/doctype/number_card/number_card.py:57
 msgid "Document Type and Function are required to create a number card"
@@ -7833,7 +7833,7 @@ msgstr ""
 #. Name of a DocType
 #: frappe/core/doctype/domain_settings/domain_settings.json
 msgid "Domain Settings"
-msgstr ""
+msgstr "Postavke domena"
 
 #. Label of a HTML field in DocType 'Domain Settings'
 #: frappe/core/doctype/domain_settings/domain_settings.json
@@ -7881,7 +7881,7 @@ msgstr ""
 #: frappe/public/js/print_format_builder/HTMLEditor.vue:5
 #: frappe/public/js/print_format_builder/LetterHeadEditor.vue:52
 msgid "Done"
-msgstr ""
+msgstr "Završeno"
 
 #. Option for the 'Type' (Select) field in DocType 'Dashboard Chart'
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -7896,18 +7896,18 @@ msgstr ""
 #: frappe/email/doctype/auto_email_report/auto_email_report.js:8
 #: frappe/public/js/frappe/form/grid.js:63
 msgid "Download"
-msgstr ""
+msgstr "Preuzmi"
 
 #: frappe/public/js/frappe/views/reports/report_utils.js:229
 msgctxt "Export report"
 msgid "Download"
-msgstr ""
+msgstr "Preuzmi"
 
 #. Label of a Link in the Tools Workspace
 #: frappe/automation/workspace/tools/tools.json
 #: frappe/desk/page/backups/backups.js:4
 msgid "Download Backups"
-msgstr ""
+msgstr "Preuzmi rezervne kopije"
 
 #: frappe/templates/emails/download_data.html:6
 msgid "Download Data"
@@ -7923,7 +7923,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/list/bulk_operations.js:134
 msgid "Download PDF"
-msgstr ""
+msgstr "Preuzmi PDF"
 
 #: frappe/public/js/frappe/views/reports/query_report.js:769
 msgid "Download Report"
@@ -7932,7 +7932,7 @@ msgstr ""
 #. Label of a Button field in DocType 'Data Import'
 #: frappe/core/doctype/data_import/data_import.json
 msgid "Download Template"
-msgstr ""
+msgstr "Preuzmi šablon"
 
 #: frappe/website/doctype/personal_data_download_request/personal_data_download_request.py:61
 #: frappe/website/doctype/personal_data_download_request/personal_data_download_request.py:69
@@ -7950,12 +7950,12 @@ msgstr ""
 
 #: frappe/desk/page/setup_wizard/install_fixtures.py:47
 msgid "Dr"
-msgstr ""
+msgstr "Duguje"
 
 #: frappe/public/js/frappe/model/indicator.js:73
 #: frappe/public/js/frappe/ui/filters/filter.js:535
 msgid "Draft"
-msgstr ""
+msgstr "Nacrt"
 
 #: frappe/public/js/frappe/views/workspace/blocks/header.js:46
 #: frappe/public/js/frappe/views/workspace/blocks/paragraph.js:136
@@ -8018,7 +8018,7 @@ msgstr ""
 #. Label of a Date field in DocType 'ToDo'
 #: frappe/desk/doctype/todo/todo.json
 msgid "Due Date"
-msgstr ""
+msgstr "Datum dospeća"
 
 #. Label of a Select field in DocType 'Assignment Rule'
 #: frappe/automation/doctype/assignment_rule/assignment_rule.json
@@ -8030,7 +8030,7 @@ msgstr ""
 #: frappe/public/js/frappe/views/workspace/workspace.js:853
 #: frappe/public/js/frappe/views/workspace/workspace.js:1020
 msgid "Duplicate"
-msgstr ""
+msgstr "Duplikat"
 
 #: frappe/printing/doctype/print_format_field_template/print_format_field_template.py:53
 msgid "Duplicate Entry"
@@ -8076,7 +8076,7 @@ msgstr ""
 #: frappe/custom/doctype/customize_form_field/customize_form_field.json
 #: frappe/website/doctype/web_form_field/web_form_field.json
 msgid "Duration"
-msgstr ""
+msgstr "Trajanje"
 
 #. Label of a Section Break field in DocType 'Dashboard Chart'
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -8158,22 +8158,22 @@ msgstr ""
 #: frappe/workflow/page/workflow_builder/workflow_builder.js:46
 #: frappe/workflow/page/workflow_builder/workflow_builder.js:84
 msgid "Edit"
-msgstr ""
+msgstr "Izmeni"
 
 #: frappe/public/js/frappe/list/list_view.js:2043
 msgctxt "Button in list view actions menu"
 msgid "Edit"
-msgstr ""
+msgstr "Izmeni"
 
 #: frappe/website/doctype/web_form/templates/web_form.html:20
 msgctxt "Button in web form"
 msgid "Edit"
-msgstr ""
+msgstr "Izmeni"
 
 #: frappe/public/js/frappe/form/grid_row.js:337
 msgctxt "Edit grid row"
 msgid "Edit"
-msgstr ""
+msgstr "Izmeni"
 
 #: frappe/templates/emails/auto_email_report.html:63
 msgid "Edit Auto Email Report Settings"
@@ -8211,7 +8211,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/form/quick_entry.js:291
 msgid "Edit Full Form"
-msgstr ""
+msgstr "Izmeni puni obrazac"
 
 #: frappe/printing/page/print_format_builder/print_format_builder_field.html:26
 #: frappe/public/js/print_format_builder/Field.vue:83
@@ -8349,7 +8349,7 @@ msgstr ""
 #: frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.json
 #: frappe/www/login.html:7 frappe/www/login.py:102
 msgid "Email"
-msgstr ""
+msgstr "Imejl"
 
 #. Label of a Link in the Tools Workspace
 #. Label of a Link field in DocType 'Communication'
@@ -8419,7 +8419,7 @@ msgstr ""
 #: frappe/automation/workspace/tools/tools.json
 #: frappe/email/doctype/email_domain/email_domain.json
 msgid "Email Domain"
-msgstr ""
+msgstr "Imejl domen"
 
 #. Name of a DocType
 #: frappe/email/doctype/email_flag_queue/email_flag_queue.json
@@ -8467,7 +8467,7 @@ msgstr ""
 #. Label of a Data field in DocType 'Contact Us Settings'
 #: frappe/website/doctype/contact_us_settings/contact_us_settings.json
 msgid "Email Id"
-msgstr ""
+msgstr "Imejl ID"
 
 #. Label of a Section Break field in DocType 'Communication'
 #: frappe/core/doctype/communication/communication.json
@@ -8581,7 +8581,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/views/communication.js:807
 msgid "Email not sent to {0} (unsubscribed / disabled)"
-msgstr ""
+msgstr "Imejl nije poslat {0} (otkazana pretplata / onemogućeno)"
 
 #: frappe/utils/oauth.py:164
 msgid "Email not verified with {0}"
@@ -8886,7 +8886,7 @@ msgstr ""
 #: frappe/public/js/frappe/utils/common.js:416
 #: frappe/website/doctype/web_page/web_page.json
 msgid "End Date"
-msgstr ""
+msgstr "Datum završetka"
 
 #. Label of a Select field in DocType 'Calendar View'
 #: frappe/desk/doctype/calendar_view/calendar_view.json
@@ -8990,7 +8990,7 @@ msgstr ""
 #: frappe/public/js/frappe/ui/messages.js:94
 msgctxt "Title of prompt dialog"
 msgid "Enter Value"
-msgstr ""
+msgstr "Unesite vrednost"
 
 #: frappe/public/js/frappe/form/form_tour.js:60
 msgid "Enter a name for this {0}"
@@ -9033,7 +9033,7 @@ msgstr ""
 
 #: frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.js:9
 msgid "Entity Type"
-msgstr ""
+msgstr "Vrsta entiteta"
 
 #: frappe/public/js/frappe/ui/filters/filter.js:16
 msgid "Equals"
@@ -9060,12 +9060,12 @@ msgstr ""
 #: frappe/model/base_document.py:741 frappe/model/base_document.py:747
 #: frappe/public/js/frappe/ui/messages.js:22
 msgid "Error"
-msgstr ""
+msgstr "Greška"
 
 #: frappe/public/js/frappe/web_form/web_form.js:240
 msgctxt "Title of error message in web form"
 msgid "Error"
-msgstr ""
+msgstr "Greška"
 
 #: frappe/www/error.html:34
 msgid "Error Code: {0}"
@@ -9305,7 +9305,7 @@ msgstr ""
 #: frappe/public/js/frappe/views/reports/query_report.js:1980
 #: frappe/public/js/frappe/views/treeview.js:114
 msgid "Expand All"
-msgstr ""
+msgstr "Proširi sve"
 
 #: frappe/public/js/frappe/form/templates/form_sidebar.html:23
 msgid "Experimental"
@@ -9331,7 +9331,7 @@ msgstr ""
 #. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: frappe/core/doctype/communication/communication.json
 msgid "Expired"
-msgstr ""
+msgstr "Isteklo"
 
 #. Label of a Int field in DocType 'OAuth Bearer Token'
 #. Label of a Int field in DocType 'Token Cache'
@@ -9343,7 +9343,7 @@ msgstr ""
 #. Label of a Date field in DocType 'Document Share Key'
 #: frappe/core/doctype/document_share_key/document_share_key.json
 msgid "Expires On"
-msgstr ""
+msgstr "Ističe na"
 
 #. Label of a Int field in DocType 'System Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
@@ -9383,12 +9383,12 @@ msgstr ""
 #: frappe/automation/workspace/tools/tools.json
 #: frappe/public/js/frappe/data_import/data_exporter.js:14
 msgid "Export Data"
-msgstr ""
+msgstr "Izvoz podataka"
 
 #: frappe/core/doctype/data_import/data_import.js:86
 #: frappe/public/js/frappe/data_import/import_preview.js:199
 msgid "Export Errored Rows"
-msgstr ""
+msgstr "Izvezi redove koji sadrže grešku"
 
 #. Label of a Data field in DocType 'Access Log'
 #: frappe/core/doctype/access_log/access_log.json
@@ -9494,7 +9494,7 @@ msgstr ""
 #: frappe/core/doctype/submission_queue/submission_queue.json
 #: frappe/integrations/doctype/integration_request/integration_request.json
 msgid "Failed"
-msgstr ""
+msgstr "Neuspešno"
 
 #. Label of a Int field in DocType 'System Health Report'
 #: frappe/desk/doctype/system_health_report/system_health_report.json
@@ -9621,7 +9621,7 @@ msgstr ""
 
 #: frappe/core/doctype/data_import/data_import.js:464
 msgid "Failure"
-msgstr ""
+msgstr "Neuspeh"
 
 #. Label of a Percent field in DocType 'System Health Report Failing Jobs'
 #: frappe/desk/doctype/system_health_report_failing_jobs/system_health_report_failing_jobs.json
@@ -9650,7 +9650,7 @@ msgstr ""
 #: frappe/core/doctype/communication/communication.json
 #: frappe/public/js/frappe/form/templates/form_sidebar.html:33
 msgid "Feedback"
-msgstr ""
+msgstr "Povratna informacija"
 
 #. Label of a Data field in DocType 'Communication'
 #: frappe/core/doctype/communication/communication.json
@@ -10099,7 +10099,7 @@ msgstr ""
 #: frappe/email/doctype/auto_email_report/auto_email_report.json
 #: frappe/email/doctype/notification/notification.json
 msgid "Filters"
-msgstr ""
+msgstr "FIlteri"
 
 #. Label of a Code field in DocType 'Number Card'
 #: frappe/desk/doctype/number_card/number_card.json
@@ -10692,13 +10692,13 @@ msgstr ""
 #: frappe/public/js/frappe/views/communication.js:185
 #: frappe/public/js/frappe/views/inbox/inbox_view.js:70
 msgid "From"
-msgstr ""
+msgstr "Od"
 
 #. Label of a Date field in DocType 'Dashboard Chart'
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
 #: frappe/website/report/website_analytics/website_analytics.js:8
 msgid "From Date"
-msgstr ""
+msgstr "Datum početka"
 
 #. Label of a Select field in DocType 'Auto Email Report'
 #: frappe/email/doctype/auto_email_report/auto_email_report.json
@@ -10770,7 +10770,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/views/treeview.js:385
 msgid "Further nodes can be only created under 'Group' type nodes"
-msgstr ""
+msgstr "Dalje čvorove je moguće kreirati samo u okviru čvorova vrste 'Grupa'"
 
 #: frappe/core/doctype/communication/communication.js:291
 msgid "Fw: {0}"
@@ -10879,7 +10879,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/form/multi_select_dialog.js:86
 msgid "Get Items"
-msgstr ""
+msgstr "Prikaži stavke"
 
 #: frappe/integrations/doctype/connected_app/connected_app.js:6
 msgid "Get OpenID Configuration"
@@ -11008,7 +11008,7 @@ msgstr ""
 #: frappe/custom/doctype/doctype_layout/doctype_layout.js:42
 #: frappe/workflow/doctype/workflow/workflow.js:44
 msgid "Go to {0} List"
-msgstr ""
+msgstr "Idi na listu {0}"
 
 #: frappe/core/doctype/page/page.js:11
 msgid "Go to {0} Page"
@@ -11220,7 +11220,7 @@ msgstr ""
 #: frappe/core/doctype/doctype_state/doctype_state.json
 #: frappe/desk/doctype/kanban_board_column/kanban_board_column.json
 msgid "Green"
-msgstr ""
+msgstr "Zelena"
 
 #: frappe/public/js/form_builder/components/controls/TableControl.vue:46
 msgid "Grid Empty State"
@@ -11242,13 +11242,13 @@ msgstr ""
 #: frappe/core/doctype/doctype_link/doctype_link.json
 #: frappe/website/doctype/website_sidebar_item/website_sidebar_item.json
 msgid "Group"
-msgstr ""
+msgstr "Grupa"
 
 #. Option for the 'Chart Type' (Select) field in DocType 'Dashboard Chart'
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
 #: frappe/website/report/website_analytics/website_analytics.js:32
 msgid "Group By"
-msgstr ""
+msgstr "Grupisano po"
 
 #. Label of a Select field in DocType 'Dashboard Chart'
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -11266,7 +11266,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/views/treeview.js:384
 msgid "Group Node"
-msgstr ""
+msgstr "Čvor grupe"
 
 #. Label of a Data field in DocType 'LDAP Settings'
 #: frappe/integrations/doctype/ldap_settings/ldap_settings.json
@@ -11480,7 +11480,7 @@ msgstr ""
 #: frappe/public/js/frappe/ui/toolbar/navbar.html:87
 #: frappe/public/js/frappe/utils/help.js:27
 msgid "Help"
-msgstr ""
+msgstr "Pomoć"
 
 #. Name of a DocType
 #. Label of a Link in the Website Workspace
@@ -11492,7 +11492,7 @@ msgstr ""
 #. Label of a Int field in DocType 'Help Category'
 #: frappe/website/doctype/help_category/help_category.json
 msgid "Help Articles"
-msgstr ""
+msgstr "Pomoćni članci"
 
 #. Name of a DocType
 #. Label of a Link in the Website Workspace
@@ -11710,7 +11710,7 @@ msgstr ""
 #: frappe/desk/doctype/todo/todo.json
 #: frappe/public/js/frappe/form/sidebar/assign_to.js:224
 msgid "High"
-msgstr ""
+msgstr "Visok"
 
 #. Description of the 'Priority' (Int) field in DocType 'Assignment Rule'
 #: frappe/automation/doctype/assignment_rule/assignment_rule.json
@@ -11741,7 +11741,7 @@ msgstr ""
 #: frappe/www/contact.py:22 frappe/www/error.html:30 frappe/www/login.html:167
 #: frappe/www/message.html:34
 msgid "Home"
-msgstr ""
+msgstr "Početna stranica"
 
 #. Label of a Data field in DocType 'Role'
 #. Label of a Data field in DocType 'Website Settings'
@@ -11814,13 +11814,13 @@ msgstr ""
 #: frappe/public/js/frappe/model/meta.js:197
 #: frappe/public/js/frappe/model/model.js:122
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #: frappe/desk/reportview.py:470
 #: frappe/public/js/frappe/views/reports/report_view.js:958
 msgctxt "Label of name column in report"
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #: frappe/public/js/print_format_builder/PrintFormatControls.vue:199
 msgid "ID (name)"
@@ -12190,7 +12190,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/list/base_list.js:207
 msgid "Image View"
-msgstr ""
+msgstr "Pregled slike"
 
 #. Label of a Float field in DocType 'Letter Head'
 #: frappe/printing/doctype/letter_head/letter_head.json
@@ -12255,18 +12255,18 @@ msgstr ""
 #: frappe/core/doctype/recorder/recorder_list.js:16
 #: frappe/email/doctype/email_group/email_group.js:31
 msgid "Import"
-msgstr ""
+msgstr "Uvoz"
 
 #: frappe/public/js/frappe/list/list_view.js:1696
 msgctxt "Button in list view menu"
 msgid "Import"
-msgstr ""
+msgstr "Uvoz"
 
 #. Label of a Link in the Tools Workspace
 #. Label of a shortcut in the Tools Workspace
 #: frappe/automation/workspace/tools/tools.json
 msgid "Import Data"
-msgstr ""
+msgstr "Uvezi podatke"
 
 #: frappe/email/doctype/email_group/email_group.js:14
 msgid "Import Email From"
@@ -12299,7 +12299,7 @@ msgstr ""
 
 #: frappe/core/doctype/data_import/data_import.js:41
 msgid "Import Progress"
-msgstr ""
+msgstr "Napredak uvoza"
 
 #: frappe/email/doctype/email_group/email_group.js:8
 #: frappe/email/doctype/email_group/email_group.js:30
@@ -12347,7 +12347,7 @@ msgstr ""
 
 #: frappe/core/doctype/data_import/data_import.js:35
 msgid "Importing {0} of {1}, {2}"
-msgstr ""
+msgstr "Uvoz {0}, od {1}, {2}"
 
 #: frappe/public/js/frappe/ui/filters/filter.js:20
 msgid "In"
@@ -12401,7 +12401,7 @@ msgstr ""
 
 #: frappe/core/report/prepared_report_analytics/prepared_report_analytics.js:19
 msgid "In Minutes"
-msgstr ""
+msgstr "U minutima"
 
 #. Label of a Check field in DocType 'DocField'
 #. Label of a Check field in DocType 'Custom Field'
@@ -12414,7 +12414,7 @@ msgstr ""
 
 #: frappe/core/doctype/data_import/data_import.js:42
 msgid "In Progress"
-msgstr ""
+msgstr "U toku"
 
 #: frappe/database/database.py:246
 msgid "In Read Only Mode"
@@ -12826,7 +12826,7 @@ msgstr ""
 #. Code'
 #: frappe/integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
 msgid "Invalid"
-msgstr ""
+msgstr "Nevažeće"
 
 #: frappe/public/js/form_builder/utils.js:221
 #: frappe/public/js/frappe/form/grid_row.js:782
@@ -12861,7 +12861,7 @@ msgstr ""
 
 #: frappe/email/smtp.py:135
 msgid "Invalid Credentials"
-msgstr ""
+msgstr "Nevažeći kredencijali"
 
 #: frappe/utils/data.py:105 frappe/utils/data.py:257
 msgid "Invalid Date"
@@ -12968,7 +12968,7 @@ msgstr ""
 #: frappe/public/js/frappe/widgets/widget_dialog.js:570
 #: frappe/utils/csvutils.py:201 frappe/utils/csvutils.py:222
 msgid "Invalid URL"
-msgstr ""
+msgstr "Nevažeći URL"
 
 #: frappe/email/receive.py:154
 msgid "Invalid User Name or Support Password. Please rectify and try again."
@@ -13090,7 +13090,7 @@ msgstr ""
 #. Label of a Check field in DocType 'Workflow'
 #: frappe/workflow/doctype/workflow/workflow.json
 msgid "Is Active"
-msgstr ""
+msgstr "Aktivno"
 
 #. Label of a Check field in DocType 'File'
 #: frappe/core/doctype/file/file.json
@@ -13459,7 +13459,7 @@ msgstr ""
 #: frappe/desk/doctype/workspace_shortcut/workspace_shortcut.json
 #: frappe/public/js/frappe/widgets/widget_dialog.js:475
 msgid "Kanban Board"
-msgstr ""
+msgstr "Kanban tabla"
 
 #. Name of a DocType
 #: frappe/desk/doctype/kanban_board_column/kanban_board_column.json
@@ -13909,7 +13909,7 @@ msgstr ""
 #: frappe/desk/page/leaderboard/leaderboard.js:15
 #: frappe/desk/page/user_profile/user_profile_sidebar.html:55
 msgid "Leaderboard"
-msgstr ""
+msgstr "Rang lista"
 
 #. Label of an action in the Onboarding Step 'Customize Print Formats'
 #: frappe/custom/onboarding_step/print_format/print_format.json
@@ -13953,7 +13953,7 @@ msgstr ""
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: frappe/printing/doctype/print_settings/print_settings.json
 msgid "Ledger"
-msgstr ""
+msgstr "Glavna knjiga"
 
 #. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #. Option for the 'Align' (Select) field in DocType 'Letter Head'
@@ -13987,7 +13987,7 @@ msgstr ""
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: frappe/printing/doctype/print_settings/print_settings.json
 msgid "Legal"
-msgstr ""
+msgstr "Pravno"
 
 #. Label of a Int field in DocType 'DocField'
 #. Label of a Int field in DocType 'Custom Field'
@@ -13996,7 +13996,7 @@ msgstr ""
 #: frappe/custom/doctype/custom_field/custom_field.json
 #: frappe/custom/doctype/customize_form_field/customize_form_field.json
 msgid "Length"
-msgstr ""
+msgstr "Dužina"
 
 #: frappe/public/js/frappe/ui/chart.js:11
 msgid "Length of passed data array is greater than value of maximum allowed label points!"
@@ -14184,7 +14184,7 @@ msgstr ""
 #. Label of a Int field in DocType 'Help Article'
 #: frappe/website/doctype/help_article/help_article.json
 msgid "Likes"
-msgstr ""
+msgstr "Lajkovanja"
 
 #. Label of a Int field in DocType 'Bulk Update'
 #: frappe/desk/doctype/bulk_update/bulk_update.json
@@ -14225,7 +14225,7 @@ msgstr ""
 #: frappe/website/doctype/web_form_field/web_form_field.json
 #: frappe/website/doctype/web_template_field/web_template_field.json
 msgid "Link"
-msgstr ""
+msgstr "Povezivanje"
 
 #. Label of a Tab Break field in DocType 'Workspace'
 #: frappe/desk/doctype/workspace/workspace.json
@@ -14475,7 +14475,7 @@ msgstr ""
 
 #: frappe/core/doctype/data_import/data_import.js:262
 msgid "Loading import file..."
-msgstr ""
+msgstr "Učitvanje fajlova za uvoz..."
 
 #: frappe/desk/page/user_profile/user_profile_controller.js:20
 msgid "Loading user profile"
@@ -14499,7 +14499,7 @@ msgstr ""
 #. Label of a Data field in DocType 'User'
 #: frappe/core/doctype/user/user.json
 msgid "Location"
-msgstr ""
+msgstr "Lokacija"
 
 #. Label of a Code field in DocType 'Package Import'
 #: frappe/core/doctype/package_import/package_import.json
@@ -14736,7 +14736,7 @@ msgstr ""
 #: frappe/desk/doctype/todo/todo.json
 #: frappe/public/js/frappe/form/sidebar/assign_to.js:216
 msgid "Low"
-msgstr ""
+msgstr "Nizak"
 
 #: frappe/public/js/frappe/utils/number_systems.js:13
 msgctxt "Number system"
@@ -14770,13 +14770,13 @@ msgstr ""
 #. Name of a role
 #: frappe/contacts/doctype/contact/contact.json
 msgid "Maintenance Manager"
-msgstr ""
+msgstr "Menadžer održavanja"
 
 #. Name of a role
 #: frappe/contacts/doctype/address/address.json
 #: frappe/contacts/doctype/contact/contact.json
 msgid "Maintenance User"
-msgstr ""
+msgstr "Korisnik održavanja"
 
 #. Label of a Int field in DocType 'Package Release'
 #: frappe/core/doctype/package_release/package_release.json
@@ -14841,7 +14841,7 @@ msgstr ""
 #: frappe/website/doctype/web_form_field/web_form_field.json
 #: frappe/website/doctype/web_template_field/web_template_field.json
 msgid "Mandatory"
-msgstr ""
+msgstr "Obavezno"
 
 #. Label of a Code field in DocType 'Custom Field'
 #. Label of a Code field in DocType 'Customize Form Field'
@@ -14991,7 +14991,7 @@ msgstr ""
 
 #: frappe/desk/page/setup_wizard/install_fixtures.py:51
 msgid "Master"
-msgstr ""
+msgstr "Master"
 
 #. Description of the 'Limit' (Int) field in DocType 'Bulk Update'
 #: frappe/desk/doctype/bulk_update/bulk_update.json
@@ -15089,14 +15089,14 @@ msgstr ""
 #: frappe/website/doctype/web_page_view/web_page_view.json
 #: frappe/website/report/website_analytics/website_analytics.js:40
 msgid "Medium"
-msgstr ""
+msgstr "Srednje"
 
 #. Option for the 'Type' (Select) field in DocType 'Communication'
 #. Option for the 'Event Category' (Select) field in DocType 'Event'
 #: frappe/core/doctype/communication/communication.json
 #: frappe/desk/doctype/event/event.json
 msgid "Meeting"
-msgstr ""
+msgstr "Sastanak"
 
 #. Label of a Data field in DocType 'Webhook'
 #: frappe/integrations/doctype/webhook/webhook.json
@@ -15135,7 +15135,7 @@ msgstr ""
 #: frappe/public/js/frappe/form/toolbar.js:241
 #: frappe/public/js/frappe/model/model.js:734
 msgid "Merge with existing"
-msgstr ""
+msgstr "Spoji sa postojećim"
 
 #: frappe/utils/nestedset.py:311
 msgid "Merging is only possible between Group-to-Group or Leaf Node-to-Leaf Node"
@@ -15204,7 +15204,7 @@ msgstr ""
 
 #: frappe/templates/includes/contact.js:36
 msgid "Message Sent"
-msgstr ""
+msgstr "Poruka poslata"
 
 #. Label of a Select field in DocType 'Notification'
 #: frappe/email/doctype/notification/notification.json
@@ -15396,11 +15396,11 @@ msgstr ""
 #: frappe/public/js/workflow_builder/store.js:97
 #: frappe/workflow/doctype/workflow/workflow.js:71
 msgid "Missing Values Required"
-msgstr ""
+msgstr "Nedostaju obavezne vrednosti"
 
 #: frappe/www/login.py:105
 msgid "Mobile"
-msgstr ""
+msgstr "Mobilni"
 
 #. Label of a Data field in DocType 'Contact'
 #. Label of a Data field in DocType 'User'
@@ -15424,7 +15424,7 @@ msgstr ""
 #: frappe/core/report/transaction_log_report/transaction_log_report.py:106
 #: frappe/social/doctype/energy_point_rule/energy_point_rule.js:43
 msgid "Modified By"
-msgstr ""
+msgstr "Izmenjeno od strane"
 
 #. Label of a Data field in DocType 'Block Module'
 #. Label of a Link field in DocType 'DocType'
@@ -15569,7 +15569,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/views/calendar/calendar.js:269
 msgid "Month"
-msgstr ""
+msgstr "Mesec"
 
 #. Option for the 'Frequency' (Select) field in DocType 'Auto Repeat'
 #. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
@@ -15595,7 +15595,7 @@ msgstr ""
 #: frappe/social/doctype/energy_point_settings/energy_point_settings.json
 #: frappe/website/report/website_analytics/website_analytics.js:25
 msgid "Monthly"
-msgstr ""
+msgstr "Mesečno"
 
 #. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
 #. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
@@ -15654,7 +15654,7 @@ msgstr ""
 #: frappe/core/doctype/communication/communication.js:212
 #: frappe/public/js/frappe/form/grid_row_form.js:42
 msgid "Move"
-msgstr ""
+msgstr "Premesti"
 
 #: frappe/public/js/frappe/form/grid_row.js:189
 msgid "Move To"
@@ -15818,7 +15818,7 @@ msgstr ""
 #: frappe/public/js/frappe/views/file/file_view.js:97
 #: frappe/website/doctype/website_slideshow/website_slideshow.js:25
 msgid "Name"
-msgstr ""
+msgstr "Ime"
 
 #: frappe/integrations/doctype/webhook/webhook.js:29
 msgid "Name (Doc Name)"
@@ -15978,7 +15978,7 @@ msgstr ""
 #: frappe/website/doctype/web_form/templates/web_list.html:15
 #: frappe/www/list.html:19
 msgid "New"
-msgstr ""
+msgstr "Novi"
 
 #: frappe/public/js/frappe/views/interaction.js:15
 msgid "New Activity"
@@ -16022,7 +16022,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/form/footer/form_timeline.js:47
 msgid "New Event"
-msgstr ""
+msgstr "Novi događaj"
 
 #: frappe/public/js/frappe/views/file/file_view.js:94
 msgid "New Folder"
@@ -16152,7 +16152,7 @@ msgstr ""
 #: frappe/automation/workspace/tools/tools.json
 #: frappe/email/doctype/newsletter/newsletter.json
 msgid "Newsletter"
-msgstr ""
+msgstr "Bilten"
 
 #. Name of a DocType
 #: frappe/email/doctype/newsletter_attachment/newsletter_attachment.json
@@ -16196,12 +16196,12 @@ msgstr ""
 #: frappe/templates/includes/slideshow.html:38 frappe/website/utils.py:258
 #: frappe/website/web_template/slideshow/slideshow.html:44
 msgid "Next"
-msgstr ""
+msgstr "Sledeće"
 
 #: frappe/public/js/frappe/ui/slides.js:359
 msgctxt "Go to next slide"
 msgid "Next"
-msgstr ""
+msgstr "Sledeće"
 
 #. Label of a Link field in DocType 'Workflow Document State'
 #: frappe/workflow/doctype/workflow_document_state/workflow_document_state.json
@@ -16277,17 +16277,17 @@ msgstr ""
 #: frappe/public/js/frappe/views/reports/query_report.js:1543
 #: frappe/website/doctype/help_article/templates/help_article.html:26
 msgid "No"
-msgstr ""
+msgstr "Ne"
 
 #: frappe/public/js/frappe/ui/filters/filter.js:543
 msgctxt "Checkbox is not checked"
 msgid "No"
-msgstr ""
+msgstr "Ne"
 
 #: frappe/public/js/frappe/ui/messages.js:37
 msgctxt "Dismiss confirmation dialog"
 msgid "No"
-msgstr ""
+msgstr "Ne"
 
 #: frappe/www/third_party_apps.html:54
 msgid "No Active Sessions"
@@ -16311,7 +16311,7 @@ msgstr ""
 #: frappe/public/js/frappe/utils/datatable.js:10
 #: frappe/public/js/frappe/widgets/chart_widget.js:57
 msgid "No Data"
-msgstr ""
+msgstr "Nema podataka"
 
 #: frappe/desk/page/user_profile/user_profile.html:11
 #: frappe/desk/page/user_profile/user_profile.html:22
@@ -16504,7 +16504,7 @@ msgstr ""
 
 #: frappe/desk/query_report.py:343
 msgid "No data to export"
-msgstr ""
+msgstr "Nema podataka za izvoz"
 
 #: frappe/contacts/doctype/address/address.py:246
 msgid "No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template."
@@ -16636,7 +16636,7 @@ msgstr ""
 #: frappe/public/js/frappe/form/grid_row.js:252
 msgctxt "Title of the 'row number' column"
 msgid "No."
-msgstr ""
+msgstr "Br."
 
 #. Label of a Check field in DocType 'DocField'
 #. Label of a Check field in DocType 'Custom Field'
@@ -16674,7 +16674,7 @@ msgstr ""
 #: frappe/core/doctype/user/user.py:964
 #: frappe/templates/includes/login/login.js:258 frappe/utils/oauth.py:270
 msgid "Not Allowed"
-msgstr ""
+msgstr "Nije dozvoljeno"
 
 #: frappe/templates/includes/login/login.js:260
 msgid "Not Allowed: Disabled User"
@@ -16721,7 +16721,7 @@ msgstr ""
 #: frappe/www/login.py:191 frappe/www/qrcode.py:22 frappe/www/qrcode.py:25
 #: frappe/www/qrcode.py:37
 msgid "Not Permitted"
-msgstr ""
+msgstr "Nije dozvoljeno"
 
 #: frappe/desk/query_report.py:535
 msgid "Not Permitted to read {0}"
@@ -16782,7 +16782,7 @@ msgstr ""
 
 #: frappe/workflow/doctype/workflow/workflow_list.js:7
 msgid "Not active"
-msgstr ""
+msgstr "Nije aktivno"
 
 #: frappe/permissions.py:355
 msgid "Not allowed for {0}: {1}"
@@ -16829,7 +16829,7 @@ msgstr ""
 #: frappe/website/doctype/web_form/web_form.py:683
 #: frappe/website/js/website.js:97
 msgid "Not permitted"
-msgstr ""
+msgstr "Nije dozvoljeno"
 
 #: frappe/public/js/frappe/list/list_view.js:50
 msgid "Not permitted to view {0}"
@@ -16841,7 +16841,7 @@ msgstr ""
 #: frappe/automation/workspace/tools/tools.json
 #: frappe/desk/doctype/note/note.json
 msgid "Note"
-msgstr ""
+msgstr "Napomena"
 
 #. Name of a DocType
 #: frappe/desk/doctype/note_seen_by/note_seen_by.json
@@ -16933,7 +16933,7 @@ msgstr ""
 #: frappe/email/doctype/notification/notification.json
 #: frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.json
 msgid "Notification"
-msgstr ""
+msgstr "Obaveštenje"
 
 #. Name of a DocType
 #: frappe/desk/doctype/notification_log/notification_log.json
@@ -16951,7 +16951,7 @@ msgstr ""
 #: frappe/desk/doctype/notification_settings/notification_settings.json
 #: frappe/public/js/frappe/ui/notifications/notifications.js:37
 msgid "Notification Settings"
-msgstr ""
+msgstr "Podešavanje obaveštenja"
 
 #. Name of a DocType
 #: frappe/desk/doctype/notification_subscribed_document/notification_subscribed_document.json
@@ -17256,7 +17256,7 @@ msgstr ""
 #. Request'
 #: frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.json
 msgid "On Hold"
-msgstr ""
+msgstr "Na čekanju"
 
 #. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: frappe/core/doctype/server_script/server_script.json
@@ -17451,12 +17451,12 @@ msgstr ""
 #: frappe/desk/doctype/event/event.json frappe/desk/doctype/todo/todo.json
 #: frappe/workflow/doctype/workflow_action/workflow_action.json
 msgid "Open"
-msgstr ""
+msgstr "Otvoreno"
 
 #: frappe/desk/doctype/todo/todo_list.js:14
 msgctxt "Access"
 msgid "Open"
-msgstr ""
+msgstr "Otvoreno"
 
 #: frappe/public/js/frappe/ui/keyboard.js:205
 msgid "Open Awesomebar"
@@ -17550,7 +17550,7 @@ msgstr ""
 #. Label of a Select field in DocType 'Activity Log'
 #: frappe/core/doctype/activity_log/activity_log.json
 msgid "Operation"
-msgstr ""
+msgstr "Operacija"
 
 #: frappe/utils/data.py:1884
 msgid "Operator must be one of {0}"
@@ -17731,7 +17731,7 @@ msgstr ""
 #: frappe/core/report/transaction_log_report/transaction_log_report.py:100
 #: frappe/social/doctype/energy_point_rule/energy_point_rule.js:42
 msgid "Owner"
-msgstr ""
+msgstr "Vlasnik"
 
 #. Option for the 'Method' (Select) field in DocType 'Recorder'
 #: frappe/core/doctype/recorder/recorder.json
@@ -17959,7 +17959,7 @@ msgstr ""
 #: frappe/public/js/frappe/web_form/web_form.js:264
 #: frappe/templates/print_formats/standard.html:34
 msgid "Page {0} of {1}"
-msgstr ""
+msgstr "Strana {0} od {1}"
 
 #. Label of a Data field in DocType 'SMS Parameter'
 #: frappe/core/doctype/sms_parameter/sms_parameter.json
@@ -18229,7 +18229,7 @@ msgstr ""
 #: frappe/core/doctype/translation/translation.json
 #: frappe/website/doctype/personal_data_deletion_step/personal_data_deletion_step.json
 msgid "Pending"
-msgstr ""
+msgstr "Na čekanju"
 
 #. Option for the 'Status' (Select) field in DocType 'Personal Data Deletion
 #. Request'
@@ -18270,7 +18270,7 @@ msgstr ""
 #. Label of a Select field in DocType 'Auto Email Report'
 #: frappe/email/doctype/auto_email_report/auto_email_report.json
 msgid "Period"
-msgstr ""
+msgstr "Period"
 
 #. Label of a Int field in DocType 'DocField'
 #. Label of a Int field in DocType 'Customize Form Field'
@@ -18437,7 +18437,7 @@ msgstr ""
 #: frappe/website/doctype/contact_us_settings/contact_us_settings.json
 #: frappe/website/doctype/web_form_field/web_form_field.json
 msgid "Phone"
-msgstr ""
+msgstr "Telefon"
 
 #. Label of a Data field in DocType 'Communication'
 #: frappe/core/doctype/communication/communication.json
@@ -18613,7 +18613,7 @@ msgstr ""
 #: frappe/public/js/frappe/list/bulk_operations.js:161
 #: frappe/public/js/frappe/utils/utils.js:1434
 msgid "Please enable pop-ups"
-msgstr ""
+msgstr "Molimo Vas da omogućite iskačuće prozore (pop-ups)"
 
 #: frappe/public/js/frappe/microtemplate.js:162
 #: frappe/public/js/frappe/microtemplate.js:177
@@ -18735,7 +18735,7 @@ msgstr ""
 
 #: frappe/desk/page/leaderboard/leaderboard.js:244
 msgid "Please select Company"
-msgstr ""
+msgstr "Molimo Vas da izaberete kompaniju"
 
 #: frappe/printing/doctype/print_format/print_format.js:30
 msgid "Please select DocType first"
@@ -18797,7 +18797,7 @@ msgstr ""
 
 #: frappe/website/doctype/website_settings/website_settings.js:100
 msgid "Please select {0}"
-msgstr ""
+msgstr "Molimo Vas da izaberete {0}"
 
 #: frappe/integrations/doctype/dropbox_settings/dropbox_settings.py:305
 msgid "Please set Dropbox access keys in site config or doctype"
@@ -18813,7 +18813,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/views/reports/query_report.js:1337
 msgid "Please set filters"
-msgstr ""
+msgstr "Molimo Vas da postavite filtere"
 
 #: frappe/email/doctype/auto_email_report/auto_email_report.py:251
 msgid "Please set filters value in Report Filter table."
@@ -18849,7 +18849,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/model/model.js:803
 msgid "Please specify"
-msgstr ""
+msgstr "Molimo Vas da precizirate"
 
 #: frappe/permissions.py:774
 msgid "Please specify a valid parent DocType for {0}"
@@ -18977,7 +18977,7 @@ msgstr ""
 #. Label of a Data field in DocType 'Address'
 #: frappe/contacts/doctype/address/address.json
 msgid "Postal Code"
-msgstr ""
+msgstr "Poštanski broj"
 
 #. Label of a Datetime field in DocType 'Changelog Feed'
 #: frappe/desk/doctype/changelog_feed/changelog_feed.json
@@ -19091,7 +19091,7 @@ msgstr ""
 #: frappe/public/js/frappe/form/controls/markdown_editor.js:31
 #: frappe/public/js/frappe/ui/capture.js:228
 msgid "Preview"
-msgstr ""
+msgstr "Pregeld"
 
 #. Label of a HTML field in DocType 'File'
 #: frappe/core/doctype/file/file.json
@@ -19200,12 +19200,12 @@ msgstr ""
 #: frappe/public/js/frappe/views/reports/report_view.js:1500
 #: frappe/public/js/frappe/views/treeview.js:456 frappe/www/printview.html:18
 msgid "Print"
-msgstr ""
+msgstr "Štampa"
 
 #: frappe/public/js/frappe/list/list_view.js:1949
 msgctxt "Button in list view actions menu"
 msgid "Print"
-msgstr ""
+msgstr "Štampa"
 
 #: frappe/public/js/frappe/list/bulk_operations.js:48
 msgid "Print Documents"
@@ -19241,7 +19241,7 @@ msgstr ""
 #: frappe/printing/page/print_format_builder/print_format_builder.js:67
 #: frappe/printing/page/print_format_builder_beta/print_format_builder_beta.js:4
 msgid "Print Format Builder"
-msgstr ""
+msgstr "Alata za kreiranje formata štampe"
 
 #. Label of a Link in the Tools Workspace
 #: frappe/automation/workspace/tools/tools.json
@@ -19287,7 +19287,7 @@ msgstr ""
 #: frappe/automation/workspace/tools/tools.json
 #: frappe/printing/doctype/print_heading/print_heading.json
 msgid "Print Heading"
-msgstr ""
+msgstr "Naslov štampe"
 
 #. Label of a Check field in DocType 'DocField'
 #. Label of a Check field in DocType 'Custom Field'
@@ -19339,7 +19339,7 @@ msgstr ""
 #: frappe/printing/doctype/print_settings/print_settings.json
 #: frappe/printing/doctype/print_style/print_style.json
 msgid "Print Style"
-msgstr ""
+msgstr "Stil štampe"
 
 #. Label of a Data field in DocType 'Print Style'
 #: frappe/printing/doctype/print_style/print_style.json
@@ -19399,7 +19399,7 @@ msgstr ""
 #. Label of a Card Break in the Tools Workspace
 #: frappe/automation/workspace/tools/tools.json
 msgid "Printing"
-msgstr ""
+msgstr "Štampanje"
 
 #: frappe/utils/print_format.py:284
 msgid "Printing failed"
@@ -19417,7 +19417,7 @@ msgstr ""
 #: frappe/public/js/frappe/form/sidebar/assign_to.js:210
 #: frappe/website/doctype/web_page/web_page.json
 msgid "Priority"
-msgstr ""
+msgstr "Prioritet"
 
 #. Label of a Check field in DocType 'Custom HTML Block'
 #. Option for the 'Event Type' (Select) field in DocType 'Event'
@@ -19468,11 +19468,11 @@ msgstr ""
 
 #: frappe/public/js/frappe/socketio_client.js:82
 msgid "Progress"
-msgstr ""
+msgstr "Napredak"
 
 #: frappe/public/js/frappe/views/kanban/kanban_view.js:406
 msgid "Project"
-msgstr ""
+msgstr "Projekat"
 
 #. Label of a Data field in DocType 'Property Setter'
 #: frappe/core/doctype/version/version_view.html:12
@@ -19620,19 +19620,19 @@ msgstr ""
 #. Name of a role
 #: frappe/contacts/doctype/contact/contact.json
 msgid "Purchase Manager"
-msgstr ""
+msgstr "Menadžer nabavke"
 
 #. Name of a role
 #: frappe/contacts/doctype/contact/contact.json
 msgid "Purchase Master Manager"
-msgstr ""
+msgstr "Glavni mendžer za nabavku"
 
 #. Name of a role
 #: frappe/contacts/doctype/address/address.json
 #: frappe/contacts/doctype/contact/contact.json
 #: frappe/geo/doctype/currency/currency.json
 msgid "Purchase User"
-msgstr ""
+msgstr "Korisnik nabavke"
 
 #. Option for the 'Color' (Select) field in DocType 'DocType State'
 #. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
@@ -19692,7 +19692,7 @@ msgstr ""
 #: frappe/email/doctype/auto_email_report/auto_email_report.json
 #: frappe/public/js/frappe/utils/common.js:401
 msgid "Quarterly"
-msgstr ""
+msgstr "Kvartalno"
 
 #. Label of a Data field in DocType 'Recorder Query'
 #. Label of a Code field in DocType 'Report'
@@ -19821,7 +19821,7 @@ msgstr ""
 #: frappe/core/doctype/doctype/doctype.json
 #: frappe/custom/doctype/customize_form/customize_form.json
 msgid "Quick Entry"
-msgstr ""
+msgstr "Brzi unos"
 
 #: frappe/core/page/permission_manager/permission_manager_help.html:3
 msgid "Quick Help for Setting Permissions"
@@ -19866,7 +19866,7 @@ msgstr ""
 
 #: frappe/website/report/website_analytics/website_analytics.js:20
 msgid "Range"
-msgstr ""
+msgstr "Opseg"
 
 #: frappe/desk/page/user_profile/user_profile_controller.js:402
 msgid "Rank"
@@ -20031,7 +20031,7 @@ msgstr ""
 #: frappe/social/doctype/energy_point_log/energy_point_log.js:20
 #: frappe/social/doctype/energy_point_log/energy_point_log.json
 msgid "Reason"
-msgstr ""
+msgstr "Razlog"
 
 #: frappe/public/js/frappe/views/reports/query_report.js:823
 msgid "Rebuild"
@@ -20039,7 +20039,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/views/treeview.js:475
 msgid "Rebuild Tree"
-msgstr ""
+msgstr "Ponovo izgraditi stablo"
 
 #: frappe/utils/nestedset.py:181
 msgid "Rebuilding of tree is not supported for {}"
@@ -20048,7 +20048,7 @@ msgstr ""
 #. Option for the 'Sent or Received' (Select) field in DocType 'Communication'
 #: frappe/core/doctype/communication/communication.json
 msgid "Received"
-msgstr ""
+msgstr "Primljeno"
 
 #: frappe/integrations/doctype/token_cache/token_cache.py:50
 msgid "Received an invalid token type."
@@ -20129,7 +20129,7 @@ msgstr ""
 #: frappe/core/doctype/doctype_state/doctype_state.json
 #: frappe/desk/doctype/kanban_board_column/kanban_board_column.json
 msgid "Red"
-msgstr ""
+msgstr "Crveno"
 
 #. Label of a Select field in DocType 'Website Route Redirect'
 #: frappe/website/doctype/website_route_redirect/website_route_redirect.json
@@ -20212,12 +20212,12 @@ msgstr ""
 #: frappe/integrations/doctype/integration_request/integration_request.json
 #: frappe/public/js/frappe/views/interaction.js:54
 msgid "Reference"
-msgstr ""
+msgstr "Referenca"
 
 #. Label of a Select field in DocType 'Notification'
 #: frappe/email/doctype/notification/notification.json
 msgid "Reference Date"
-msgstr ""
+msgstr "Datum reference"
 
 #. Label of a Data field in DocType 'Email Queue'
 #: frappe/email/doctype/email_queue/email_queue.json
@@ -20315,7 +20315,7 @@ msgstr ""
 #: frappe/website/doctype/portal_menu_item/portal_menu_item.json
 #: frappe/workflow/doctype/workflow_action/workflow_action.json
 msgid "Reference Document Type"
-msgstr ""
+msgstr "Vrsta referentnog dokumenta"
 
 #. Label of a Dynamic Link field in DocType 'Activity Log'
 #. Label of a Dynamic Link field in DocType 'Comment'
@@ -20340,7 +20340,7 @@ msgstr ""
 #: frappe/social/doctype/energy_point_log/energy_point_log.json
 #: frappe/workflow/doctype/workflow_action/workflow_action.json
 msgid "Reference Name"
-msgstr ""
+msgstr "Naziv reference"
 
 #. Label of a Read Only field in DocType 'Activity Log'
 #. Label of a Data field in DocType 'Comment'
@@ -20395,7 +20395,7 @@ msgstr ""
 #: frappe/public/js/frappe/widgets/number_card_widget.js:328
 #: frappe/public/js/print_format_builder/Preview.vue:24
 msgid "Refresh"
-msgstr ""
+msgstr "Osveži"
 
 #: frappe/core/page/dashboard_view/dashboard_view.js:177
 msgid "Refresh All"
@@ -20593,7 +20593,7 @@ msgstr ""
 #: frappe/public/js/frappe/model/model.js:752
 #: frappe/public/js/frappe/views/treeview.js:277
 msgid "Rename"
-msgstr ""
+msgstr "Preimenuj"
 
 #: frappe/custom/doctype/custom_field/custom_field.js:116
 #: frappe/custom/doctype/custom_field/custom_field.js:136
@@ -20615,7 +20615,7 @@ msgstr ""
 #: frappe/core/doctype/communication/communication.js:43
 #: frappe/desk/doctype/todo/todo.js:36
 msgid "Reopen"
-msgstr ""
+msgstr "Ponovo otvori"
 
 #: frappe/public/js/frappe/form/toolbar.js:503
 msgid "Repeat"
@@ -20673,7 +20673,7 @@ msgstr ""
 #: frappe/contacts/doctype/contact/contact.json
 #: frappe/core/doctype/communication/communication.json
 msgid "Replied"
-msgstr ""
+msgstr "Odgovoreno"
 
 #. Label of a Text Editor field in DocType 'Discussion Reply'
 #: frappe/core/doctype/communication/communication.js:57
@@ -20720,7 +20720,7 @@ msgstr ""
 #: frappe/email/doctype/auto_email_report/auto_email_report.json
 #: frappe/public/js/frappe/request.js:610
 msgid "Report"
-msgstr ""
+msgstr "Izveštaj"
 
 #. Option for the 'Report Type' (Select) field in DocType 'Report'
 #. Option for the 'DocType View' (Select) field in DocType 'Workspace Shortcut'
@@ -20814,7 +20814,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/list/base_list.js:202
 msgid "Report View"
-msgstr ""
+msgstr "Prikaz izveštaja"
 
 #: frappe/core/doctype/doctype/doctype.py:1772
 msgid "Report cannot be set for Single types"
@@ -20879,7 +20879,7 @@ msgstr ""
 #: frappe/core/doctype/system_settings/system_settings.json
 #: frappe/public/js/frappe/ui/toolbar/search_utils.js:547
 msgid "Reports"
-msgstr ""
+msgstr "Izveštaji"
 
 #: frappe/patches/v14_0/update_workspace2.py:50
 msgid "Reports & Masters"
@@ -20953,7 +20953,7 @@ msgstr ""
 #: frappe/integrations/doctype/webhook/webhook.json
 #: frappe/public/js/frappe/request.js:241
 msgid "Request Timeout"
-msgstr ""
+msgstr "Vreme čekanja zahteva"
 
 #. Label of a Small Text field in DocType 'Webhook'
 #: frappe/integrations/doctype/webhook/webhook.json
@@ -20986,7 +20986,7 @@ msgstr ""
 #: frappe/desk/doctype/module_onboarding/module_onboarding.js:17
 #: frappe/website/doctype/portal_settings/portal_settings.js:19
 msgid "Reset"
-msgstr ""
+msgstr "Resetuj"
 
 #: frappe/custom/doctype/customize_form/customize_form.js:136
 msgid "Reset All Customizations"
@@ -21161,7 +21161,7 @@ msgstr ""
 #: frappe/desk/page/setup_wizard/setup_wizard.js:285
 #: frappe/email/doctype/email_queue/email_queue.json
 msgid "Retry"
-msgstr ""
+msgstr "Ponovo pokušaj"
 
 #: frappe/email/doctype/email_queue/email_queue_list.js:47
 msgid "Retry Sending"
@@ -21200,7 +21200,7 @@ msgstr ""
 #. Option for the 'Type' (Select) field in DocType 'Energy Point Log'
 #: frappe/social/doctype/energy_point_log/energy_point_log.json
 msgid "Review"
-msgstr ""
+msgstr "Pregled"
 
 #. Name of a DocType
 #: frappe/social/doctype/review_level/review_level.json
@@ -21484,7 +21484,7 @@ msgstr ""
 
 #: frappe/core/doctype/version/version_view.html:73
 msgid "Row #"
-msgstr ""
+msgstr "Red #"
 
 #: frappe/core/doctype/doctype/doctype.py:1794
 #: frappe/core/doctype/doctype/doctype.py:1804
@@ -21648,7 +21648,7 @@ msgstr ""
 #: frappe/core/doctype/sms_settings/sms_settings.json
 #: frappe/integrations/workspace/integrations/integrations.json
 msgid "SMS Settings"
-msgstr ""
+msgstr "SMS Podešavanje"
 
 #: frappe/core/doctype/sms_settings/sms_settings.py:109
 msgid "SMS sent successfully"
@@ -21706,19 +21706,19 @@ msgstr ""
 #. Name of a role
 #: frappe/contacts/doctype/contact/contact.json
 msgid "Sales Manager"
-msgstr ""
+msgstr "Menadžer prodaje"
 
 #. Name of a role
 #: frappe/contacts/doctype/contact/contact.json
 msgid "Sales Master Manager"
-msgstr ""
+msgstr "Glavni menadžer prodaje"
 
 #. Name of a role
 #: frappe/contacts/doctype/address/address.json
 #: frappe/contacts/doctype/contact/contact.json
 #: frappe/geo/doctype/currency/currency.json
 msgid "Sales User"
-msgstr ""
+msgstr "Korisnik prodaje"
 
 #. Option for the 'Social Login Provider' (Select) field in DocType 'Social
 #. Login Key'
@@ -21781,7 +21781,7 @@ msgstr ""
 #: frappe/public/js/print_format_builder/print_format_builder.bundle.js:15
 #: frappe/public/js/workflow_builder/workflow_builder.bundle.js:33
 msgid "Save"
-msgstr ""
+msgstr "Sačuvaj"
 
 #: frappe/core/doctype/user/user.js:332
 msgid "Save API Secret: {0}"
@@ -21960,7 +21960,7 @@ msgstr ""
 
 #: frappe/core/doctype/data_import/data_import.py:97
 msgid "Scheduler Inactive"
-msgstr ""
+msgstr "Planer je neaktivan"
 
 #. Label of a Data field in DocType 'System Health Report'
 #: frappe/desk/doctype/system_health_report/system_health_report.json
@@ -21973,7 +21973,7 @@ msgstr ""
 
 #: frappe/core/doctype/data_import/data_import.py:97
 msgid "Scheduler is inactive. Cannot import data."
-msgstr ""
+msgstr "Planer je neaktivan. Nema mogućnosti uvoza podataka."
 
 #: frappe/core/doctype/rq_job/rq_job_list.js:19
 msgid "Scheduler: Active"
@@ -22063,7 +22063,7 @@ msgstr ""
 #: frappe/public/js/frappe/ui/toolbar/search.js:68
 #: frappe/templates/includes/search_template.html:26 frappe/www/search.py:19
 msgid "Search"
-msgstr ""
+msgstr "Pretraga"
 
 #. Label of a Check field in DocType 'User'
 #: frappe/core/doctype/user/user.json
@@ -22255,7 +22255,7 @@ msgstr ""
 #: frappe/website/doctype/web_form_field/web_form_field.json
 #: frappe/website/doctype/web_template_field/web_template_field.json
 msgid "Select"
-msgstr ""
+msgstr "Izaberite"
 
 #: frappe/public/js/frappe/data_import/data_exporter.js:149
 #: frappe/public/js/frappe/form/controls/multicheck.js:166
@@ -22548,7 +22548,7 @@ msgstr ""
 #: frappe/email/doctype/newsletter/newsletter.js:162
 #: frappe/public/js/frappe/views/communication.js:26 frappe/www/contact.html:41
 msgid "Send"
-msgstr ""
+msgstr "Pošalji"
 
 #. Label of a Datetime field in DocType 'Communication'
 #. Label of a Datetime field in DocType 'Email Queue'
@@ -22624,7 +22624,7 @@ msgstr ""
 
 #: frappe/email/doctype/auto_email_report/auto_email_report.js:21
 msgid "Send Now"
-msgstr ""
+msgstr "Pošalji sada"
 
 #. Label of a Check field in DocType 'Print Settings'
 #: frappe/printing/doctype/print_settings/print_settings.json
@@ -22780,7 +22780,7 @@ msgstr ""
 #: frappe/email/doctype/email_queue/email_queue.json
 #: frappe/email/doctype/newsletter/newsletter.js:201
 msgid "Sending"
-msgstr ""
+msgstr "Slanje"
 
 #: frappe/email/doctype/newsletter/newsletter.js:203
 msgid "Sending emails"
@@ -22832,7 +22832,7 @@ msgstr ""
 #. Label of a Float field in DocType 'Workspace'
 #: frappe/desk/doctype/workspace/workspace.json
 msgid "Sequence Id"
-msgstr ""
+msgstr "ID sekvence"
 
 #. Label of a Text field in DocType 'Document Naming Settings'
 #: frappe/core/doctype/document_naming_settings/document_naming_settings.json
@@ -22898,7 +22898,7 @@ msgstr ""
 #: frappe/email/doctype/email_account/email_account.json
 #: frappe/integrations/doctype/integration_request/integration_request.json
 msgid "Service"
-msgstr ""
+msgstr "Usluga"
 
 #. Name of a DocType
 #: frappe/core/doctype/session_default/session_default.json
@@ -23019,7 +23019,7 @@ msgstr ""
 #: frappe/public/js/frappe/form/link_selector.js:207
 #: frappe/public/js/frappe/form/link_selector.js:208
 msgid "Set Quantity"
-msgstr ""
+msgstr "Postavi količinu"
 
 #. Label of a Select field in DocType 'Role Permission for Page and Report'
 #: frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.json
@@ -23147,7 +23147,7 @@ msgstr ""
 #: frappe/website/doctype/web_form/web_form.json
 #: frappe/website/doctype/web_page/web_page.json
 msgid "Settings"
-msgstr ""
+msgstr "Podešavanja"
 
 #. Label of a Table field in DocType 'Navbar Settings'
 #: frappe/core/doctype/navbar_settings/navbar_settings.json
@@ -23268,7 +23268,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/form/templates/address_list.html:25
 msgid "Shipping Address"
-msgstr ""
+msgstr "Adresa za isporuku"
 
 #. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: frappe/contacts/doctype/address/address.json
@@ -23417,7 +23417,7 @@ msgstr ""
 #: frappe/public/js/print_format_builder/print_format_builder.bundle.js:18
 #: frappe/public/js/print_format_builder/print_format_builder.bundle.js:54
 msgid "Show Preview"
-msgstr ""
+msgstr "Prikaži pregled"
 
 #. Label of a Check field in DocType 'DocType'
 #. Label of a Check field in DocType 'Customize Form'
@@ -23677,7 +23677,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/views/file/file_view.js:318
 msgid "Size"
-msgstr ""
+msgstr "Veličina"
 
 #. Label of a Float field in DocType 'System Health Report Tables'
 #: frappe/desk/doctype/system_health_report_tables/system_health_report_tables.json
@@ -23723,7 +23723,7 @@ msgstr ""
 
 #: frappe/core/doctype/data_import/data_import.js:39
 msgid "Skipping {0} of {1}, {2}"
-msgstr ""
+msgstr "Preskakanje {0} od {1}, {2}"
 
 #. Label of a Data field in DocType 'Contact Us Settings'
 #: frappe/website/doctype/contact_us_settings/contact_us_settings.json
@@ -23914,7 +23914,7 @@ msgstr ""
 #: frappe/website/doctype/website_route_redirect/website_route_redirect.json
 #: frappe/website/report/website_analytics/website_analytics.js:38
 msgid "Source"
-msgstr ""
+msgstr "Izvor"
 
 #. Label of a Data field in DocType 'Dashboard Chart Source'
 #: frappe/desk/doctype/dashboard_chart_source/dashboard_chart_source.json
@@ -23970,7 +23970,7 @@ msgstr ""
 #: frappe/public/js/frappe/web_form/web_form_list.js:175
 #: frappe/templates/print_formats/standard_macros.html:44
 msgid "Sr"
-msgstr ""
+msgstr "Sr"
 
 #: frappe/public/js/print_format_builder/Field.vue:143
 #: frappe/public/js/print_format_builder/Field.vue:164
@@ -24069,7 +24069,7 @@ msgstr ""
 #: frappe/printing/page/print/print.js:296
 #: frappe/printing/page/print/print.js:343
 msgid "Start"
-msgstr ""
+msgstr "Početak"
 
 #. Label of a Date field in DocType 'Auto Repeat'
 #. Label of a Datetime field in DocType 'Web Page'
@@ -24078,7 +24078,7 @@ msgstr ""
 #: frappe/public/js/frappe/utils/common.js:409
 #: frappe/website/doctype/web_page/web_page.json
 msgid "Start Date"
-msgstr ""
+msgstr "Datum početka"
 
 #. Label of a Select field in DocType 'Calendar View'
 #: frappe/desk/doctype/calendar_view/calendar_view.json
@@ -24087,7 +24087,7 @@ msgstr ""
 
 #: frappe/core/doctype/data_import/data_import.js:110
 msgid "Start Import"
-msgstr ""
+msgstr "Početak uvoza"
 
 #: frappe/core/doctype/recorder/recorder_list.js:201
 msgid "Start Recording"
@@ -24146,7 +24146,7 @@ msgstr ""
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 #: frappe/workflow/doctype/workflow_transition/workflow_transition.json
 msgid "State"
-msgstr ""
+msgstr "Stanje"
 
 #: frappe/public/js/workflow_builder/components/Properties.vue:24
 msgid "State Properties"
@@ -24245,7 +24245,7 @@ msgstr ""
 #: frappe/website/doctype/personal_data_deletion_step/personal_data_deletion_step.json
 #: frappe/workflow/doctype/workflow_action/workflow_action.json
 msgid "Status"
-msgstr ""
+msgstr "Status"
 
 #: frappe/www/update-password.html:161
 msgid "Status Updated"
@@ -24273,12 +24273,12 @@ msgstr ""
 
 #: frappe/core/doctype/recorder/recorder_list.js:87
 msgid "Stop"
-msgstr ""
+msgstr "Zaustavi"
 
 #. Label of a Check field in DocType 'Scheduled Job Type'
 #: frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
 msgid "Stopped"
-msgstr ""
+msgstr "Zaustavljeno"
 
 #. Label of a Float field in DocType 'System Health Report'
 #: frappe/desk/doctype/system_health_report/system_health_report.json
@@ -24379,7 +24379,7 @@ msgstr ""
 #: frappe/public/js/frappe/views/communication.js:107
 #: frappe/public/js/frappe/views/inbox/inbox_view.js:63
 msgid "Subject"
-msgstr ""
+msgstr "Predmet"
 
 #. Label of a Data field in DocType 'DocType'
 #. Label of a Data field in DocType 'Customize Form'
@@ -24419,32 +24419,32 @@ msgstr ""
 #: frappe/social/doctype/energy_point_rule/energy_point_rule.json
 #: frappe/social/doctype/energy_point_settings/energy_point_settings.js:47
 msgid "Submit"
-msgstr ""
+msgstr "Podnesi"
 
 #: frappe/public/js/frappe/list/list_view.js:2016
 msgctxt "Button in list view actions menu"
 msgid "Submit"
-msgstr ""
+msgstr "Podnesi"
 
 #: frappe/website/doctype/web_form/templates/web_form.html:44
 msgctxt "Button in web form"
 msgid "Submit"
-msgstr ""
+msgstr "Podnesi"
 
 #: frappe/public/js/frappe/ui/dialog.js:60
 msgctxt "Primary action in dialog"
 msgid "Submit"
-msgstr ""
+msgstr "Podnesi"
 
 #: frappe/public/js/frappe/ui/messages.js:97
 msgctxt "Primary action of prompt dialog"
 msgid "Submit"
-msgstr ""
+msgstr "Podnesi"
 
 #: frappe/public/js/frappe/desk.js:212
 msgctxt "Submit password for Email Account"
 msgid "Submit"
-msgstr ""
+msgstr "Podnesi"
 
 #. Label of a Check field in DocType 'Data Import'
 #: frappe/core/doctype/data_import/data_import.json
@@ -24492,7 +24492,7 @@ msgstr ""
 #: frappe/public/js/frappe/ui/filters/filter.js:536
 #: frappe/website/doctype/web_form/templates/web_form.html:133
 msgid "Submitted"
-msgstr ""
+msgstr "Podneto"
 
 #: frappe/workflow/doctype/workflow/workflow.py:104
 msgid "Submitted Document cannot be converted back to draft. Transition row {0}"
@@ -24543,7 +24543,7 @@ msgstr ""
 #: frappe/workflow/doctype/workflow_action/workflow_action.py:167
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "Success"
-msgstr ""
+msgstr "Uspeh"
 
 #. Name of a DocType
 #: frappe/core/doctype/success_action/success_action.json
@@ -24603,7 +24603,7 @@ msgstr ""
 
 #: frappe/core/doctype/data_import/data_import.js:428
 msgid "Successfully imported {0}"
-msgstr ""
+msgstr "Uspešno uvezeno {0}"
 
 #: frappe/desk/doctype/form_tour/form_tour.py:87
 msgid "Successfully reset onboarding status for all users."
@@ -24615,7 +24615,7 @@ msgstr ""
 
 #: frappe/core/doctype/data_import/data_import.js:436
 msgid "Successfully updated {0}"
-msgstr ""
+msgstr "Uspešno ažurirano {0}"
 
 #: frappe/core/doctype/data_import/data_import.js:149
 msgid "Successfully {0} 1 record."
@@ -24959,7 +24959,7 @@ msgstr ""
 #: frappe/workflow/doctype/workflow_action_master/workflow_action_master.json
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "System Manager"
-msgstr ""
+msgstr "Sistem menadžer"
 
 #: frappe/desk/page/backups/backups.js:36
 msgid "System Manager privileges required."
@@ -24985,7 +24985,7 @@ msgstr ""
 #: frappe/core/doctype/system_settings/system_settings.json
 #: frappe/core/workspace/build/build.json
 msgid "System Settings"
-msgstr ""
+msgstr "Podešavanje sistema"
 
 #. Description of the 'Allow Roles' (Table MultiSelect) field in DocType
 #. 'Module Onboarding'
@@ -25080,7 +25080,7 @@ msgstr ""
 #. Name of a DocType
 #: frappe/desk/doctype/tag/tag.json
 msgid "Tag"
-msgstr ""
+msgstr "Oznaka"
 
 #. Name of a DocType
 #: frappe/desk/doctype/tag_link/tag_link.json
@@ -25116,12 +25116,12 @@ msgstr ""
 #: frappe/website/doctype/portal_menu_item/portal_menu_item.json
 #: frappe/website/doctype/website_route_redirect/website_route_redirect.json
 msgid "Target"
-msgstr ""
+msgstr "Cilj"
 
 #: frappe/desk/doctype/todo/todo_calendar.js:19
 #: frappe/desk/doctype/todo/todo_calendar.js:25
 msgid "Task"
-msgstr ""
+msgstr "Zadatak"
 
 #. Label of a Section Break field in DocType 'About Us Settings'
 #. Label of a Table field in DocType 'About Us Settings'
@@ -25154,7 +25154,7 @@ msgstr ""
 #: frappe/printing/doctype/print_format_field_template/print_format_field_template.json
 #: frappe/website/doctype/web_template/web_template.json
 msgid "Template"
-msgstr ""
+msgstr "Šablon"
 
 #: frappe/core/doctype/data_import/importer.py:476
 #: frappe/core/doctype/data_import/importer.py:603
@@ -25297,7 +25297,7 @@ msgstr ""
 
 #: frappe/email/doctype/notification/notification.py:131
 msgid "The Condition '{0}' is invalid"
-msgstr ""
+msgstr "Uslov '{0}' je nevažeći"
 
 #: frappe/core/doctype/file/file.py:204
 msgid "The File URL you've entered is incorrect"
@@ -25591,7 +25591,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/views/communication.js:828
 msgid "There were errors while sending email. Please try again."
-msgstr ""
+msgstr "Došlo je do greške prilikom slanja imejla. Molimo Vas da pokušate ponovo."
 
 #: frappe/model/naming.py:476
 msgid "There were some errors setting the name, please contact the administrator"
@@ -26112,7 +26112,7 @@ msgstr ""
 #: frappe/website/doctype/website_sidebar/website_sidebar.json
 #: frappe/website/doctype/website_sidebar_item/website_sidebar_item.json
 msgid "Title"
-msgstr ""
+msgstr "Naslov"
 
 #. Label of a Data field in DocType 'DocType'
 #. Label of a Data field in DocType 'Customize Form'
@@ -26141,13 +26141,13 @@ msgstr ""
 #: frappe/public/js/frappe/views/communication.js:53
 #: frappe/public/js/frappe/views/inbox/inbox_view.js:70
 msgid "To"
-msgstr ""
+msgstr "Za"
 
 #. Label of a Date field in DocType 'Dashboard Chart'
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
 #: frappe/website/report/website_analytics/website_analytics.js:14
 msgid "To Date"
-msgstr ""
+msgstr "Datum završetka"
 
 #. Label of a Select field in DocType 'Auto Email Report'
 #: frappe/email/doctype/auto_email_report/auto_email_report.json
@@ -26360,7 +26360,7 @@ msgstr ""
 #. Label of a Card Break in the Tools Workspace
 #: frappe/automation/workspace/tools/tools.json
 msgid "Tools"
-msgstr ""
+msgstr "Alati"
 
 #. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #: frappe/desk/doctype/form_tour_step/form_tour_step.json
@@ -26431,7 +26431,7 @@ msgstr ""
 #: frappe/public/js/frappe/views/reports/query_report.js:1254
 #: frappe/public/js/frappe/views/reports/report_view.js:1514
 msgid "Total"
-msgstr ""
+msgstr "Ukupno"
 
 #. Label of a Int field in DocType 'System Health Report'
 #: frappe/desk/doctype/system_health_report/system_health_report.json
@@ -26472,7 +26472,7 @@ msgstr ""
 #. Label of a Int field in DocType 'Newsletter'
 #: frappe/email/doctype/newsletter/newsletter.json
 msgid "Total Views"
-msgstr ""
+msgstr "Ukupno pregleda"
 
 #. Label of a Duration field in DocType 'RQ Worker'
 #: frappe/core/doctype/rq_worker/rq_worker.json
@@ -26491,7 +26491,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/views/reports/report_view.js:1219
 msgid "Totals"
-msgstr ""
+msgstr "Ukupno"
 
 #: frappe/public/js/frappe/views/reports/report_view.js:1194
 msgid "Totals Row"
@@ -26757,7 +26757,7 @@ msgstr ""
 #: frappe/social/doctype/energy_point_log/energy_point_log.json
 #: frappe/website/doctype/web_template/web_template.json
 msgid "Type"
-msgstr ""
+msgstr "Vrsta"
 
 #: frappe/desk/page/user_profile/user_profile.html:17
 msgid "Type Distribution"
@@ -26942,7 +26942,7 @@ msgstr ""
 
 #: frappe/website/report/website_analytics/website_analytics.js:59
 msgid "Unknown"
-msgstr ""
+msgstr "Nepoznat"
 
 #: frappe/public/js/frappe/model/model.js:209
 msgid "Unknown Column: {0}"
@@ -27052,7 +27052,7 @@ msgstr ""
 #: frappe/public/js/frappe/form/grid_row.js:403
 #: frappe/public/js/frappe/views/workspace/workspace.js:692
 msgid "Update"
-msgstr ""
+msgstr "Ažuriraj"
 
 #. Label of a Button field in DocType 'Document Naming Settings'
 #: frappe/core/doctype/document_naming_settings/document_naming_settings.json
@@ -27181,7 +27181,7 @@ msgstr ""
 
 #: frappe/core/doctype/data_import/data_import.js:36
 msgid "Updating {0} of {1}, {2}"
-msgstr ""
+msgstr "Ažuriranje {0} od {1}, {2}"
 
 #: frappe/public/js/billing.bundle.js:131
 msgid "Upgrade plan"
@@ -27390,7 +27390,7 @@ msgstr ""
 #: frappe/website/doctype/personal_data_download_request/personal_data_download_request.json
 #: frappe/workflow/doctype/workflow_action/workflow_action.json
 msgid "User"
-msgstr ""
+msgstr "Korisnik"
 
 #. Label of a Link field in DocType 'Access Log'
 #: frappe/core/doctype/access_log/access_log.json
@@ -27680,7 +27680,7 @@ msgstr ""
 
 #: frappe/utils/oauth.py:270
 msgid "User {0} is disabled"
-msgstr ""
+msgstr "Korisnik {0} je onemogućen"
 
 #: frappe/sessions.py:240
 msgid "User {0} is disabled. Please contact your System Manager."
@@ -27799,7 +27799,7 @@ msgstr ""
 #: frappe/website/doctype/web_form/web_form.js:197
 #: frappe/website/doctype/website_meta_tag/website_meta_tag.json
 msgid "Value"
-msgstr ""
+msgstr "Vrednost"
 
 #. Label of a Select field in DocType 'Dashboard Chart'
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -27812,7 +27812,7 @@ msgstr ""
 #: frappe/email/doctype/notification/notification.json
 #: frappe/social/doctype/energy_point_rule/energy_point_rule.json
 msgid "Value Change"
-msgstr ""
+msgstr "Promena vrednosti"
 
 #. Label of a Select field in DocType 'Notification'
 #: frappe/email/doctype/notification/notification.json
@@ -27885,7 +27885,7 @@ msgstr ""
 
 #: frappe/core/doctype/version/version_view.html:8
 msgid "Values Changed"
-msgstr ""
+msgstr "Promenjene vrednosti"
 
 #. Option for the 'Font' (Select) field in DocType 'Print Settings'
 #: frappe/printing/doctype/print_settings/print_settings.json
@@ -27947,7 +27947,7 @@ msgstr ""
 #. Label of a Select field in DocType 'Form Tour'
 #: frappe/desk/doctype/form_tour/form_tour.json
 msgid "View"
-msgstr ""
+msgstr "Prikaz"
 
 #: frappe/core/doctype/success_action/success_action.js:60
 #: frappe/public/js/frappe/form/success_action.js:89
@@ -28051,7 +28051,7 @@ msgstr ""
 #: frappe/core/doctype/doctype/doctype.json
 #: frappe/core/workspace/build/build.json
 msgid "Views"
-msgstr ""
+msgstr "Prikazi"
 
 #. Label of a Check field in DocType 'DocField'
 #: frappe/core/doctype/docfield/docfield.json
@@ -28092,12 +28092,12 @@ msgstr ""
 #. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: frappe/contacts/doctype/address/address.json
 msgid "Warehouse"
-msgstr ""
+msgstr "Skladište"
 
 #. Option for the 'Style' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "Warning"
-msgstr ""
+msgstr "Upozorenje"
 
 #: frappe/custom/doctype/customize_form/customize_form.js:217
 msgid "Warning: DATA LOSS IMMINENT! Proceeding will permanently delete following database columns from doctype {0}:"
@@ -28123,7 +28123,7 @@ msgstr ""
 #. Option for the 'Action' (Select) field in DocType 'Onboarding Step'
 #: frappe/desk/doctype/onboarding_step/onboarding_step.json
 msgid "Watch Video"
-msgstr ""
+msgstr "Pogledajte video"
 
 #: frappe/desk/doctype/workspace/workspace.js:38
 msgid "We do not allow editing of this document. Simply click the Edit button on the workspace page to make your workspace editable and customize it as you wish"
@@ -28296,7 +28296,7 @@ msgstr ""
 #: frappe/public/js/frappe/ui/toolbar/about.js:8
 #: frappe/website/workspace/website/website.json
 msgid "Website"
-msgstr ""
+msgstr "Veb-sajt"
 
 #. Name of a report
 #: frappe/website/report/website_analytics/website_analytics.json
@@ -28322,7 +28322,7 @@ msgstr ""
 #: frappe/website/doctype/website_slideshow/website_slideshow.json
 #: frappe/website/doctype/website_theme/website_theme.json
 msgid "Website Manager"
-msgstr ""
+msgstr "Menadžer za veb-sajt"
 
 #. Name of a DocType
 #: frappe/website/doctype/website_meta_tag/website_meta_tag.json
@@ -28346,7 +28346,7 @@ msgstr ""
 #: frappe/website/doctype/website_script/website_script.json
 #: frappe/website/workspace/website/website.json
 msgid "Website Script"
-msgstr ""
+msgstr "Skripta veb-sajta"
 
 #. Label of a Data field in DocType 'DocType'
 #: frappe/core/doctype/doctype/doctype.json
@@ -28363,7 +28363,7 @@ msgstr ""
 #: frappe/website/doctype/website_settings/website_settings.json
 #: frappe/website/workspace/website/website.json
 msgid "Website Settings"
-msgstr ""
+msgstr "Podešavanje veb-sajta"
 
 #. Label of a Link field in DocType 'Web Form'
 #. Label of a Link field in DocType 'Web Page'
@@ -28402,7 +28402,7 @@ msgstr ""
 #: frappe/website/doctype/website_theme/website_theme.json
 #: frappe/website/workspace/website/website.json
 msgid "Website Theme"
-msgstr ""
+msgstr "Tema veb-sajta"
 
 #. Name of a DocType
 #: frappe/website/doctype/website_theme_ignore_app/website_theme_ignore_app.json
@@ -28479,7 +28479,7 @@ msgstr ""
 #: frappe/social/doctype/energy_point_settings/energy_point_settings.json
 #: frappe/website/report/website_analytics/website_analytics.js:24
 msgid "Weekly"
-msgstr ""
+msgstr "Nedeljno"
 
 #. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
 #. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
@@ -28516,7 +28516,7 @@ msgstr ""
 
 #: frappe/core/doctype/user/user.py:418
 msgid "Welcome to {0}"
-msgstr ""
+msgstr "Dobro došli u {0}"
 
 #: frappe/public/js/frappe/ui/notifications/notifications.js:62
 msgid "What's New"
@@ -28631,13 +28631,13 @@ msgstr ""
 #: frappe/public/js/workflow_builder/store.js:129
 #: frappe/workflow/doctype/workflow/workflow.json
 msgid "Workflow"
-msgstr ""
+msgstr "Radni tok"
 
 #. Name of a DocType
 #: frappe/workflow/doctype/workflow_action/workflow_action.json
 #: frappe/workflow/doctype/workflow_action/workflow_action.py:477
 msgid "Workflow Action"
-msgstr ""
+msgstr "Radnja radnog toka"
 
 #. Name of a DocType
 #. Description of a DocType
@@ -28702,7 +28702,7 @@ msgstr ""
 #: frappe/workflow/doctype/workflow_action/workflow_action.json
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
 msgid "Workflow State"
-msgstr ""
+msgstr "Status radnog toka"
 
 #. Label of a Data field in DocType 'Workflow'
 #: frappe/workflow/doctype/workflow/workflow.json
@@ -28815,7 +28815,7 @@ msgstr ""
 
 #: frappe/desk/page/setup_wizard/setup_wizard.py:35
 msgid "Wrapping up"
-msgstr ""
+msgstr "Završavanje"
 
 #. Label of a Check field in DocType 'Custom DocPerm'
 #. Label of a Check field in DocType 'DocPerm'
@@ -28876,7 +28876,7 @@ msgstr ""
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
 #: frappe/website/doctype/company_history/company_history.json
 msgid "Year"
-msgstr ""
+msgstr "Godina"
 
 #. Option for the 'Frequency' (Select) field in DocType 'Auto Repeat'
 #. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
@@ -28894,7 +28894,7 @@ msgstr ""
 #: frappe/email/doctype/auto_email_report/auto_email_report.json
 #: frappe/public/js/frappe/utils/common.js:403
 msgid "Yearly"
-msgstr ""
+msgstr "Godišnje"
 
 #. Option for the 'Color' (Select) field in DocType 'DocType State'
 #. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
@@ -29269,7 +29269,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/list/list_view.js:503
 msgid "You haven't created a {0} yet"
-msgstr ""
+msgstr "Još uvek niste kerirali {0}"
 
 #: frappe/rate_limiter.py:164
 msgid "You hit the rate limit because of too many requests. Please try after sometime."
@@ -29561,7 +29561,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/utils/utils.js:406 frappe/utils/data.py:1402
 msgid "and"
-msgstr ""
+msgstr "i"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: frappe/workflow/doctype/workflow_state/workflow_state.json
@@ -30343,7 +30343,7 @@ msgstr ""
 #: frappe/public/js/frappe/utils/utils.js:403 frappe/www/login.html:87
 #: frappe/www/login.py:110
 msgid "or"
-msgstr ""
+msgstr "ili"
 
 #. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: frappe/desk/doctype/workspace/workspace.json
@@ -30885,7 +30885,7 @@ msgstr ""
 
 #: frappe/desk/doctype/event/event.js:87
 msgid "{0}"
-msgstr ""
+msgstr "{0}"
 
 #: frappe/public/js/frappe/ui/toolbar/search_utils.js:193
 msgid "{0} ${skip_list ? \"\" : type}"
@@ -31025,7 +31025,7 @@ msgstr ""
 
 #: frappe/utils/data.py:1556
 msgid "{0} and {1}"
-msgstr ""
+msgstr "{0} i {1}"
 
 #: frappe/public/js/frappe/utils/energy_point_utils.js:38
 msgid "{0} appreciated on {1}"
@@ -31288,7 +31288,7 @@ msgstr ""
 
 #: frappe/email/doctype/email_account/email_account.py:171
 msgid "{0} is mandatory"
-msgstr ""
+msgstr "{0} je obavezno"
 
 #: frappe/core/doctype/document_naming_rule/document_naming_rule.py:50
 msgid "{0} is not a field of doctype {1}"
@@ -31372,7 +31372,7 @@ msgstr ""
 #: frappe/printing/doctype/print_format/print_format.py:92
 #: frappe/utils/csvutils.py:131
 msgid "{0} is required"
-msgstr ""
+msgstr "{0} je obavezan"
 
 #: frappe/public/js/frappe/views/reports/report_view.js:1455
 msgid "{0} is set"

--- a/frappe/locale/tr.po
+++ b/frappe/locale/tr.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: developers@frappe.io\n"
 "POT-Creation-Date: 2025-03-20 13:58+0000\n"
-"PO-Revision-Date: 2025-04-11 16:17\n"
+"PO-Revision-Date: 2025-04-20 17:52\n"
 "Last-Translator: developers@frappe.io\n"
 "Language-Team: Turkish\n"
 "MIME-Version: 1.0\n"
@@ -20779,7 +20779,7 @@ msgstr "Sekmeyi Kaldır"
 
 #: frappe/core/doctype/file/file.py:154
 msgid "Removed {0}"
-msgstr "{0} Kaldırdı:"
+msgstr ""
 
 #: frappe/custom/doctype/custom_field/custom_field.js:137
 #: frappe/public/js/frappe/form/toolbar.js:253

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -1342,11 +1342,11 @@ class BaseDocument:
 	def cast(self, value, df):
 		return cast_fieldtype(df.fieldtype, value, show_warning=False)
 
-	def _extract_images_from_editor(self):
+	def _extract_images_from_text_editor(self):
 		from frappe.core.doctype.file.utils import extract_images_from_doc
 
 		if self.doctype != "DocType":
-			for df in self.meta.get("fields", {"fieldtype": ("in", ("Text Editor", "HTML Editor"))}):
+			for df in self.meta.get("fields", {"fieldtype": ("=", "Text Editor")}):
 				extract_images_from_doc(self, df.fieldname)
 
 

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -36,7 +36,7 @@ LOCATE_CAST_PATTERN = re.compile(r"locate\(([^,]+),\s*([`\"]?name[`\"]?)\s*\)", 
 FUNC_IFNULL_PATTERN = re.compile(r"(strpos|ifnull|coalesce)\(\s*[`\"]?name[`\"]?\s*,", flags=re.IGNORECASE)
 CAST_VARCHAR_PATTERN = re.compile(r"([`\"]?tab[\w`\" -]+\.[`\"]?name[`\"]?)(?!\w)", flags=re.IGNORECASE)
 ORDER_BY_PATTERN = re.compile(r"\ order\ by\ |\ asc|\ ASC|\ desc|\ DESC", flags=re.IGNORECASE)
-SUB_QUERY_PATTERN = re.compile("^.*[,();@].*")
+SUB_QUERY_PATTERN = re.compile("^.*[,();@].*", flags=re.DOTALL)
 IS_QUERY_PATTERN = re.compile(r"^(select|delete|update|drop|create)\s")
 IS_QUERY_PREDICATE_PATTERN = re.compile(r"\s*[0-9a-zA-z]*\s*( from | group by | order by | where | join )")
 FIELD_QUOTE_PATTERN = re.compile(r"[0-9a-zA-Z]+\s*'")

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -1217,6 +1217,10 @@ class DatabaseQuery:
 
 	def update_user_settings(self):
 		# update user settings if new search
+		if not self.save_user_settings_fields and not getattr(self, "user_settings", None):
+			# Nothing has changed or needs to be changed
+			return
+
 		user_settings = json.loads(get_user_settings(self.doctype))
 
 		if hasattr(self, "user_settings"):

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -936,7 +936,7 @@ class DatabaseQuery:
 					# because "like" uses backslash (\) for escaping
 					value = value.replace("\\", "\\\\").replace("%", "%%")
 
-			elif f.operator == "=" and df and df.fieldtype in ["Link", "Data"]:  # TODO: Refactor if possible
+			elif f.operator == "=" and df and df.fieldtype in ("Link", "Data", "Dynamic Link"):
 				value = cstr(f.value) or "''"
 				fallback = "''"
 

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -449,9 +449,11 @@ class DatabaseQuery:
 			lower_field = field.lower().strip()
 
 			if SUB_QUERY_PATTERN.match(field):
-				if lower_field[0] == "(":
-					subquery_token = lower_field[1:].lstrip().split(" ", 1)[0]
-					if subquery_token in blacklisted_keywords:
+				# Check for subquery anywhere in the field, not just at the beginning
+				if "(" in lower_field:
+					location = lower_field.index("(")
+					subquery_token = lower_field[location + 1 :].lstrip().split(" ", 1)[0]
+					if any(keyword in subquery_token for keyword in blacklisted_keywords):
 						_raise_exception()
 
 				function = lower_field.split("(", 1)[0].rstrip()

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -107,7 +107,7 @@ def delete_doc(
 			# Lock the doc without waiting
 			try:
 				frappe.db.get_value(doctype, name, for_update=True, wait=False)
-			except frappe.QueryTimeoutError:
+			except (frappe.QueryTimeoutError, frappe.QueryDeadlockError):
 				frappe.throw(
 					_(
 						"This document can not be deleted right now as it's being modified by another user. Please try again after some time."

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -202,7 +202,7 @@ class Document(BaseDocument):
 			children = (
 				frappe.db.get_values(
 					df.options,
-					{"parent": self.name, "parenttype": self.doctype, "parentfield": df.fieldname},
+					{"parent": str(self.name), "parenttype": self.doctype, "parentfield": df.fieldname},
 					"*",
 					as_dict=True,
 					order_by="idx asc",
@@ -487,7 +487,7 @@ class Document(BaseDocument):
 			tbl = frappe.qb.DocType(df.options)
 			qry = (
 				frappe.qb.from_(tbl)
-				.where(tbl.parent == self.name)
+				.where(tbl.parent == str(self.name))
 				.where(tbl.parenttype == self.doctype)
 				.where(tbl.parentfield == fieldname)
 				.delete()

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -530,7 +530,7 @@ class Document(BaseDocument):
 	def set_new_name(self, force=False, set_name=None, set_child_names=True):
 		"""Calls `frappe.naming.set_new_name` for parent and child docs."""
 
-		if self.flags.name_set and not force:
+		if (frappe.flags.api_name_set or self.flags.name_set) and not force:
 			return
 
 		autoname = self.meta.autoname or ""

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -630,7 +630,7 @@ class Document(BaseDocument):
 		self._fix_rating_value()
 		self._validate_code_fields()
 		self._sync_autoname_field()
-		self._extract_images_from_editor()
+		self._extract_images_from_text_editor()
 		self._sanitize_content()
 		self._save_passwords()
 		self.validate_workflow()
@@ -643,7 +643,7 @@ class Document(BaseDocument):
 			d._fix_rating_value()
 			d._validate_code_fields()
 			d._sync_autoname_field()
-			d._extract_images_from_editor()
+			d._extract_images_from_text_editor()
 			d._sanitize_content()
 			d._save_passwords()
 		if self.is_new():

--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -247,7 +247,7 @@ def load_doctype_module(doctype, module=None, prefix="", suffix=""):
 	module = module or get_doctype_module(doctype)
 	app = get_module_app(module)
 	key = (app, doctype, prefix, suffix)
-	module_name = get_module_name(doctype, module, prefix, suffix)
+	module_name = get_module_name(doctype, module, prefix, suffix, app)
 
 	if key not in doctype_python_modules:
 		try:

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -104,7 +104,6 @@ frappe.patches.v12_0.setup_tags
 frappe.patches.v12_0.update_auto_repeat_status_and_not_submittable
 frappe.patches.v12_0.create_notification_settings_for_user
 frappe.patches.v11_0.make_all_prepared_report_attachments_private #2019-11-26
-frappe.patches.v12_0.setup_email_linking
 frappe.patches.v12_0.change_existing_dashboard_chart_filters
 frappe.patches.v12_0.set_correct_assign_value_in_docs #2020-07-13
 execute:frappe.delete_doc('DocType', 'Test Runner') # 2022-05-19

--- a/frappe/public/js/billing.bundle.js
+++ b/frappe/public/js/billing.bundle.js
@@ -1,7 +1,6 @@
 let frappeCloudBaseEndpoint = "https://frappecloud.com";
 let isFCUser = false;
 
-
 $(document).ready(function () {
 	if (
 		frappe.boot.is_fc_site &&
@@ -40,7 +39,7 @@ function setErrorMessage(message) {
 
 function addManageBillingDropdown() {
 	$(".dropdown-navbar-user .dropdown-menu .dropdown-divider").before(
-		`<div class="dropdown-item login-to-fc" target="_blank">Manage Billing</div>`
+		`<button class="dropdown-item login-to-fc" target="_blank">Manage Billing</button>`
 	);
 }
 
@@ -113,11 +112,11 @@ function generateTrialSubscriptionBanner(trialEndDate) {
 							Your trial ends in ${trial_end_string}.
 						</span>
 						<span class="description">
-						${
-							isFCUser
-								? "Please upgrade for uninterrupted services"
-								: "Please contact your system administrator to upgrade your plan."
-						}
+							${
+								isFCUser
+									? "Please upgrade for uninterrupted services"
+									: "Please contact your system administrator to upgrade your plan."
+							}
 						</span>
 					</div>
 				</div>
@@ -125,7 +124,6 @@ function generateTrialSubscriptionBanner(trialEndDate) {
 					isFCUser
 						? `<button type="button"
 					class="upgrade-plan-button px-2 py-1"
-					onclick="window.location.href = '/billing'"
 				>
 					<svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
 						<path fill-rule="evenodd" clip-rule="evenodd" d="M6.2641 1C5.5758 1 4.97583 1.46845 4.80889 2.1362L3.57555 7.06953C3.33887 8.01625 4.05491 8.93333 5.03077 8.93333H7.50682L6.72168 14.4293C6.68838 14.6624 6.82229 14.8872 7.04319 14.9689C7.26408 15.0507 7.51204 14.9671 7.63849 14.7684L13.2161 6.00354C13.6398 5.33782 13.1616 4.46667 12.3725 4.46667H9.59038L10.3017 1.62127C10.3391 1.4719 10.3055 1.31365 10.2108 1.19229C10.116 1.07094 9.97063 1 9.81666 1H6.2641ZM5.77903 2.37873C5.83468 2.15615 6.03467 2 6.2641 2H9.17627L8.46492 4.8454C8.42758 4.99477 8.46114 5.15302 8.55589 5.27437C8.65064 5.39573 8.79602 5.46667 8.94999 5.46667H12.3725L8.0395 12.2757L8.5783 8.50404C8.5988 8.36056 8.55602 8.21523 8.46105 8.10573C8.36608 7.99623 8.22827 7.93333 8.08332 7.93333H5.03077C4.70548 7.93333 4.4668 7.62764 4.5457 7.31207L5.77903 2.37873Z" fill="currentColor"/>

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -66,7 +66,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		this.setup_awesomeplete();
 		this.bind_change_event();
 	}
-	
+
 	show_link_and_clear_buttons() {
 		if (this.$input.val() && this.get_options()) {
 			const doctype = this.get_options();
@@ -144,7 +144,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			frappe.utils.add_link_title(this.df.options, value, label);
 		}
 
-		return this.validate_and_set_in_model(value, e, true);
+		return this.validate_and_set_in_model(value, e);
 	}
 	parse(value) {
 		return strip_html(value);
@@ -683,14 +683,11 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 
 		// to avoid unnecessary request
 		if (value) {
-			let args = {}
-			this.set_custom_query(args)
 			return frappe
 				.xcall("frappe.client.validate_link", {
 					doctype: options,
 					docname: value,
 					fields: columns_to_fetch,
-					args: args
 				})
 				.then((response) => {
 					if (!this.docname || !columns_to_fetch.length) {

--- a/frappe/public/js/frappe/form/footer/footer.js
+++ b/frappe/public/js/frappe/form/footer/footer.js
@@ -45,6 +45,7 @@ frappe.ui.form.Footer = class FormFooter {
 							this.frm.comment_box.set_value("");
 							frappe.utils.play_sound("click");
 							this.frm.timeline.add_timeline_item(comment_item);
+							this.frm.get_docinfo().comments.push(comment);
 							this.frm.sidebar.refresh_comments_count &&
 								this.frm.sidebar.refresh_comments_count();
 						})

--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -608,18 +608,20 @@ class FormTimeline extends BaseTimeline {
 		let edit_box = this.make_editable(edit_wrapper);
 		let content_wrapper = comment_wrapper.find(".content");
 		let more_actions_wrapper = comment_wrapper.find(".more-actions");
-		if (
-			frappe.model.can_delete("Comment") &&
-			(frappe.session.user == doc.owner || frappe.user.has_role("System Manager"))
-		) {
-			const delete_option = $(`
-				<li>
-					<a class="dropdown-item">
-						${__("Delete")}
-					</a>
-				</li>
-			`).click(() => this.delete_comment(doc.name));
-			more_actions_wrapper.find(".dropdown-menu").append(delete_option);
+		const dropdown_menu = more_actions_wrapper.find(".dropdown-menu li");
+
+		if (frappe.session.user == doc.owner || frappe.user.has_role("System Manager")) {
+			if (frappe.model.can_delete("Comment")) {
+				const delete_option = $(`
+					<a class="dropdown-item">${__("Delete")}</a>
+				`).click(() => this.delete_comment(doc.name));
+				dropdown_menu.append(delete_option);
+			}
+
+			const un_publish_button = $(`
+				<a class="dropdown-item">${doc.published ? __("Unpublish") : __("Publish")}</a>
+			`).click(() => this.update_comment_publicity(doc.name, !doc.published));
+			dropdown_menu.append(un_publish_button);
 		}
 
 		let dismiss_button = $(`
@@ -726,6 +728,37 @@ class FormTimeline extends BaseTimeline {
 				})
 				.then(() => {
 					frappe.utils.play_sound("delete");
+				});
+		});
+	}
+
+	update_comment_publicity(comment_name, publish) {
+		let message;
+		if (publish) {
+			message = __(
+				"Would you like to publish this comment? This means it will become visible to website/portal users."
+			);
+		} else {
+			message = __(
+				"Would you like to unpublish this comment? This means it will no longer be visible to website/portal users."
+			);
+		}
+
+		frappe.confirm(message, () => {
+			return frappe
+				.xcall("frappe.desk.form.utils.update_comment_publicity", {
+					name: comment_name,
+					publish,
+				})
+				.then(() => {
+					frappe.utils.play_sound("click");
+
+					// update the comment info that is stored in the frontend, then refresh the timeline
+					const comment = this.frm
+						.get_docinfo()
+						.comments.find((comment) => comment.name === comment_name);
+					comment.published = publish;
+					this.refresh();
 				});
 		});
 	}

--- a/frappe/public/js/frappe/form/templates/timeline_message_box.html
+++ b/frappe/public/js/frappe/form/templates/timeline_message_box.html
@@ -31,10 +31,16 @@
 					{{ frappe.avatar(doc.owner, "avatar-medium") }}
 					<span class="ml-2" style="font-size: var(--text-base);">{{ doc.user_full_name || frappe.user.full_name(doc.owner) }}</span>
 					<span class="text-muted">{{ __("commented") }}</span>
-					<span> . </span>
-					<span class="margin-left text-muted">
+					<span> · </span>
+					<span class="text-muted">
 						{{ comment_when(doc.communication_date || doc.creation) }}
 					</span>
+					{% if (doc.published) { %}
+						<span> · </span>
+						<span class="text-muted" title="{{ __('Visible to website/portal users.') }}">
+							{{ __("Published") }}
+						</span>
+					{% } %}
 				</span>
 			{% } else { %}
 				<span class="margin-right">
@@ -42,7 +48,7 @@
 				</span>
 				<div>
 					{{ doc.user_full_name || frappe.user.full_name(doc.owner) }}
-					<span> . </span>
+					<span> · </span>
 					<span class="text-muted">
 						{{ comment_when(doc.communication_date || doc.creation) }}
 					</span>

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -278,6 +278,7 @@ frappe.views.BaseList = class BaseList {
 		if (this.page.disable_sidebar_toggle) {
 			return;
 		}
+
 		this.list_sidebar = new frappe.views.ListSidebar({
 			doctype: this.doctype,
 			stats: this.stats,
@@ -795,8 +796,9 @@ class FilterArea {
 			doctype_fields
 				.filter(
 					(df) =>
-						df.fieldname === title_field ||
-						(df.in_standard_filter && frappe.model.is_value_type(df.fieldtype))
+						(df.fieldname === title_field ||
+							(df.in_standard_filter && frappe.model.is_value_type(df.fieldtype))) &&
+						frappe.perm.has_perm(this.list_view.doctype, df.permlevel)
 				)
 				.map((df) => {
 					let options = df.options;

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -248,7 +248,9 @@ frappe.request.call = function (opts) {
 			frappe.msgprint({
 				title: __("Deadlock Occurred"),
 				indicator: "red",
-				message: __("Server was too busy to process this request. Please try again."),
+				message: __(
+					"Server failed to process this request because of a concurrent conflicting request. Please try again."
+				),
 			});
 		},
 	};

--- a/frappe/public/js/frappe/ui/group_by/group_by.html
+++ b/frappe/public/js/frappe/ui/group_by/group_by.html
@@ -10,11 +10,14 @@
 				<option value="" disabled selected>{{ __("Select Group By...") }}</option>
 				{% for (var parent_doctype in group_by_conditions) { %}
 					{% for (var val of group_by_conditions[parent_doctype]) { %}
+						{% field_name = val.label || val.fieldname %}
+						{% if(val.parent && doctype != val.parent) field_name += " ("+parent_doctype+")"  %}
 						<option
 							data-doctype="{{parent_doctype}}"
 							value="{{val.fieldname}}"
+							data-parent-doctype="{{doctype}}"
 						>
-							{{ __(val.label || val.fieldname, null, val.parent ) }}
+							{{ __(field_name, null, val.parent ) }}
 						</option>
 					{% } %}
 				{% } %}

--- a/frappe/public/js/frappe/ui/group_by/group_by.js
+++ b/frappe/public/js/frappe/ui/group_by/group_by.js
@@ -243,6 +243,15 @@ frappe.ui.GroupBy = class {
 	}
 
 	apply_group_by() {
+		if (
+			this.group_by_doctype &&
+			this.aggregate_on_doctype &&
+			this.group_by_doctype != this.aggregate_on_doctype
+		) {
+			frappe.msgprint(__("Parent-to-child or child-to-parent grouping is not allowed."));
+			return false;
+		}
+
 		this.group_by = "`tab" + this.group_by_doctype + "`.`" + this.group_by_field + "`";
 
 		if (this.aggregate_function === "count") {

--- a/frappe/public/js/frappe/views/map/map_view.js
+++ b/frappe/public/js/frappe/views/map/map_view.js
@@ -10,26 +10,13 @@ frappe.views.MapView = class MapView extends frappe.views.ListView {
 	}
 
 	setup_defaults() {
+		this.hide_sort_selector = true;
 		super.setup_defaults();
 		this.page_title = __("{0} Map", [this.page_title]);
 	}
 
-	setup_view() {}
-
-	on_filter_change() {
-		this.get_coords();
-	}
-
-	render() {
-		this.get_coords().then(() => {
-			this.render_map_view();
-		});
-		this.$paging_area.find(".level-left").append("<div></div>");
-	}
-
-	render_map_view() {
+	setup_view() {
 		this.map_id = frappe.dom.get_unique_id();
-
 		this.$result.html(`<div id="${this.map_id}" class="map-view-container"></div>`);
 
 		L.Icon.Default.imagePath = frappe.utils.map_defaults.image_path;
@@ -42,13 +29,37 @@ frappe.views.MapView = class MapView extends frappe.views.ListView {
 			this.map
 		);
 
+		this.bind_leaflet_locate_control();
 		L.control.scale().addTo(this.map);
+	}
+
+	render() {
+		this.get_coords().then(() => {
+			this.render_map_data();
+		});
+		this.$paging_area.find(".level-left").append("<div></div>");
+	}
+
+	render_map_data() {
+		// Clear existing markers
+		if (this.markerLayer) {
+			this.map.removeLayer(this.markerLayer);
+		}
+
 		if (this.coords.features && this.coords.features.length) {
-			this.coords.features.forEach((coords) =>
-				L.geoJSON(coords).bindPopup(coords.properties.name).addTo(this.map)
-			);
-			let lastCoords = this.coords.features[0].geometry.coordinates.reverse();
-			this.map.panTo(lastCoords, 8);
+			this.markerLayer = L.featureGroup();
+
+			this.coords.features.forEach((coords) => {
+				const marker = L.geoJSON(coords).bindPopup(
+					frappe.utils.get_form_link(this.doctype, coords.properties.name, true)
+				);
+				this.markerLayer.addLayer(marker);
+			});
+
+			this.markerLayer.addTo(this.map);
+
+			// Fit bounds to show all markers
+			this.map.fitBounds(this.markerLayer.getBounds());
 		}
 	}
 
@@ -82,10 +93,9 @@ frappe.views.MapView = class MapView extends frappe.views.ListView {
 			});
 	}
 
-	get required_libs() {
-		return [
-			"assets/frappe/js/lib/leaflet/leaflet.css",
-			"assets/frappe/js/lib/leaflet/leaflet.js",
-		];
+	bind_leaflet_locate_control() {
+		// To request location update and set location, sets current geolocation on load
+		this.locate_control = L.control.locate({ position: "topright" });
+		this.locate_control.addTo(this.map);
 	}
 };

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -638,13 +638,13 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			this.prepared_report_name = route_options.prepared_report_name;
 
 			const promises = filters_to_set.map((f) => {
-				return () => {
+				return async () => {
 					let value = route_options[f.df.fieldname];
 					if (typeof value === "string" && value[0] === "[") {
 						// multiselect array
 						value = JSON.parse(value);
 					}
-					f.set_value(value);
+					await f.set_value(value);
 				};
 			});
 			promises.push(() => {

--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -220,7 +220,14 @@ export default class NumberCardWidget extends Widget {
 		const default_country = frappe.sys_defaults.country;
 		const shortened_number = frappe.utils.shorten_number(this.number, default_country, 5);
 		let number_parts = shortened_number.split(" ");
-
+		// done to add multicurrency support in number card
+		if (this.card_doc.currency) {
+			this.formatted_number =
+				format_currency(number_parts[0], this.card_doc.currency) +
+				" " +
+				__(number_parts[1]);
+			return;
+		}
 		const symbol = number_parts[1] || "";
 		number_parts[0] = window.convert_old_to_new_number_format(number_parts[0]);
 		const formatted_number = frappe.format(number_parts[0], df, null, doc);

--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -159,7 +159,6 @@ select.form-control {
 		margin-bottom: var(--margin-sm);
 		border: 1px solid var(--border-color);
 		border-radius: var(--border-radius);
-		@include get_textstyle("sm", "regular");
 		word-wrap: break-word;
 		position: relative;
 		p:last-child {

--- a/frappe/share.py
+++ b/frappe/share.py
@@ -148,7 +148,7 @@ def _get_users(doc: "Document") -> list:
 			"owner",
 			"creation",
 		],
-		filters=dict(share_doctype=doc.doctype, share_name=doc.name),
+		filters=dict(share_doctype=doc.doctype, share_name=str(doc.name)),
 	)
 
 

--- a/frappe/tests/test_api.py
+++ b/frappe/tests/test_api.py
@@ -130,6 +130,10 @@ class FrappeAPITestCase(FrappeTestCase):
 	def delete(self, path, **kwargs) -> TestResponse:
 		return make_request(target=self.TEST_CLIENT.delete, args=(path,), kwargs=kwargs)
 
+	def tearDown(self) -> None:
+		frappe.db.rollback()
+		return super().tearDown()
+
 
 class TestResourceAPI(FrappeAPITestCase):
 	DOCTYPE = "ToDo"
@@ -146,6 +150,7 @@ class TestResourceAPI(FrappeAPITestCase):
 
 	@classmethod
 	def tearDownClass(cls):
+		frappe.db.commit()
 		for name in cls.GENERATED_DOCUMENTS:
 			frappe.delete_doc_if_exists(cls.DOCTYPE, name)
 		frappe.db.commit()

--- a/frappe/tests/test_api_v2.py
+++ b/frappe/tests/test_api_v2.py
@@ -33,6 +33,7 @@ class TestResourceAPIV2(FrappeAPITestCase):
 
 	@classmethod
 	def tearDownClass(cls):
+		frappe.db.commit()
 		for name in cls.GENERATED_DOCUMENTS:
 			frappe.delete_doc_if_exists(cls.DOCTYPE, name)
 		frappe.db.commit()

--- a/frappe/tests/test_auth.py
+++ b/frappe/tests/test_auth.py
@@ -26,6 +26,7 @@ def add_user(email, password, username=None, mobile_no=None):
 	user.add_roles("System Manager")
 	frappe.db.commit()
 
+
 class TestAuth(FrappeTestCase):
 	@classmethod
 	def setUpClass(cls):
@@ -46,10 +47,12 @@ class TestAuth(FrappeTestCase):
 
 	@classmethod
 	def tearDownClass(cls):
+		frappe.db.rollback()
 		frappe.delete_doc("User", cls.test_user_email, force=True)
 		frappe.local.request_ip = None
 		frappe.form_dict.email = None
 		frappe.local.response["http_status_code"] = None
+		frappe.db.commit()
 
 	def set_system_settings(self, k, v):
 		frappe.db.set_single_value("System Settings", k, v)

--- a/frappe/tests/test_frappe_client.py
+++ b/frappe/tests/test_frappe_client.py
@@ -105,7 +105,9 @@ class TestFrappeClient(FrappeTestCase):
 		self.assertEqual(
 			server.get_value("Website Settings", "title_prefix").get("title_prefix"), "test-prefix"
 		)
+		frappe.db.rollback()  # Clear snapshot isolation
 		frappe.db.set_single_value("Website Settings", "title_prefix", "")
+		frappe.db.commit()
 
 	def test_update_doc(self):
 		server = FrappeClient(get_url(), "Administrator", self.PASSWORD, verify=False)

--- a/frappe/tests/ui_test_helpers.py
+++ b/frappe/tests/ui_test_helpers.py
@@ -496,6 +496,9 @@ def setup_image_doctype():
 @whitelist_for_tests
 def setup_inbox():
 	frappe.db.delete("User Email")
+	doc = frappe.new_doc("Email Account")
+	doc.email_id = "email_linking@example.com"
+	doc.insert(ignore_permissions=True, ignore_if_duplicate=True)
 
 	user = frappe.get_doc("User", frappe.session.user)
 	user.append("user_emails", {"email_account": "Email Linking"})

--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -489,10 +489,11 @@ def search(text, start=0, limit=20, doctype=""):
 			continue
 
 		global_search = frappe.qb.Table("__global_search")
-		rank = Match(global_search.content).Against(word).as_("rank")
+		rank = Match(global_search.content).Against(word)
 		query = (
 			frappe.qb.from_(global_search)
-			.select(global_search.doctype, global_search.name, global_search.content, rank)
+			.select(global_search.doctype, global_search.name, global_search.content, rank.as_("rank"))
+			.where(rank)
 			.orderby("rank", order=frappe.qb.desc)
 			.limit(limit)
 		)

--- a/frappe/utils/install.py
+++ b/frappe/utils/install.py
@@ -111,27 +111,6 @@ def install_basic_docs():
 		{"doctype": "Workflow Action Master", "workflow_action_name": "Approve"},
 		{"doctype": "Workflow Action Master", "workflow_action_name": "Reject"},
 		{"doctype": "Workflow Action Master", "workflow_action_name": "Review"},
-		{
-			"doctype": "Email Domain",
-			"domain_name": "example.com",
-			"email_id": "account@example.com",
-			"password": "pass",
-			"email_server": "imap.example.com",
-			"use_imap": 1,
-			"smtp_server": "smtp.example.com",
-		},
-		{
-			"doctype": "Email Account",
-			"domain": "example.com",
-			"email_id": "notifications@example.com",
-			"default_outgoing": 1,
-		},
-		{
-			"doctype": "Email Account",
-			"domain": "example.com",
-			"email_id": "replies@example.com",
-			"default_incoming": 1,
-		},
 	]
 
 	for d in install_docs:

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -292,6 +292,7 @@ def send_private_file(path: str) -> Response:
 		path = "/protected/" + path
 		response = Response()
 		response.headers["X-Accel-Redirect"] = quote(frappe.utils.encode(path))
+		response.headers["Cache-Control"] = "private,max-age=3600,stale-while-revalidate=86400"
 
 	else:
 		filepath = frappe.utils.get_site_path(path)

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -691,7 +691,8 @@ VALID_UTILS = (
 	"formatdate",
 	"get_user_info_for_avatar",
 	"get_abbr",
-	"get_month"
+	"get_month",
+	"sha256_hash",
 )
 
 

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -42,7 +42,7 @@ class WebForm(WebsiteGenerator):
 		breadcrumbs: DF.Code | None
 		button_label: DF.Data | None
 		client_script: DF.Code | None
-		condition_json: DF.SmallText | None
+		condition: DF.Code | None
 		custom_css: DF.Code | None
 		doc_type: DF.Link
 		introduction_text: DF.TextEditor | None
@@ -156,7 +156,7 @@ def get_context(context):
 		# check permissions
 		if frappe.form_dict.name:
 			assert isinstance(frappe.form_dict.name, str | int)
-			
+
 			if frappe.session.user == "Guest":
 				frappe.throw(
 					_("You need to be logged in to access this {0}.").format(self.doc_type),
@@ -168,6 +168,7 @@ def get_context(context):
 				raise frappe.PageDoesNotExistError()
 
 			if not self.has_web_form_permission(self.doc_type, frappe.form_dict.name):
+				check_doctype_permission(self.doc_type)
 				frappe.throw(
 					_("You don't have the permissions to access this document"), frappe.PermissionError
 				)
@@ -269,6 +270,21 @@ def get_context(context):
 		messages = [
 			"Sr",
 			"Attach",
+			"Next",
+			"Previous",
+			"Discard?",
+			"Cancel",
+			"Discard:Button in web form",
+			"Edit:Button in web form",
+			"See previous responses:Button in web form",
+			"Edit your response:Button in web form",
+			"Are you sure you want to discard the changes?",
+			"Mandatory fields required::Error message in web form",
+			"Invalid values for fields::Error message in web form",
+			"Error:Title of error message in web form",
+			"Page {0} of {1}",
+			"Couldn't save, please check the data you have entered",
+			"Validation Error",
 			self.title,
 			self.introduction_text,
 			self.success_title,
@@ -283,6 +299,52 @@ def get_context(context):
 			messages.extend([field.label, field.description])
 			if field.fieldtype == "Select" and field.options:
 				messages.extend(field.options.split("\n"))
+
+		# When at least one field in self.web_form_fields has fieldtype "Table" then add "No data" to messages
+		if any(field.fieldtype == "Table" for field in self.web_form_fields):
+			messages.append("Move")
+			messages.append("Insert Above")
+			messages.append("Insert Below")
+			messages.append("Duplicate")
+			messages.append("Shortcuts")
+			messages.append("Ctrl + Up")
+			messages.append("Ctrl + Down")
+			messages.append("ESC")
+			messages.append("Editing Row")
+			messages.append("Add / Remove Columns")
+			messages.append("Fieldname")
+			messages.append("Column Width")
+			messages.append("Configure Columns")
+			messages.append("Select Fields")
+			messages.append("Select All")
+			messages.append("Update")
+			messages.append("Reset to default")
+			messages.append("No Data")
+			messages.append("Delete")
+			messages.append("Delete All")
+			messages.append("Add Row")
+			messages.append("Add Multiple")
+			messages.append("Download")
+			messages.append("of")
+			messages.append("Upload")
+			messages.append("Last")
+			messages.append("First")
+			messages.append("No.:Title of the 'row number' column")
+
+		# Phone Picker
+		if any(field.fieldtype == "Phone" for field in self.web_form_fields):
+			messages.append("Search for countries...")
+
+		# Dates
+		if any(field.fieldtype == "Date" for field in self.web_form_fields):
+			messages.append("Now")
+			messages.append("Today")
+			messages.append("Date {0} must be in format: {1}")
+			messages.append("{0} to {1}")
+
+		# Time
+		if any(field.fieldtype == "Time" for field in self.web_form_fields):
+			messages.append("Now")
 
 		messages.extend(col.get("label") if col else "" for col in self.list_columns)
 
@@ -351,15 +413,7 @@ def get_context(context):
 			context.reference_name = context.reference_doc.name
 
 			if self.show_attachments:
-				context.attachments = frappe.get_all(
-					"File",
-					filters={
-						"attached_to_name": context.reference_name,
-						"attached_to_doctype": context.reference_doctype,
-						"is_private": 0,
-					},
-					fields=["file_name", "file_url", "file_size"],
-				)
+				context.attachments = self.get_webform_attachments(context)
 
 			if self.allow_comments:
 				context.comment_list = get_comment_list(
@@ -439,6 +493,51 @@ def get_context(context):
 
 		else:
 			return False
+
+	def get_webform_attachments(self, context):
+		"""
+		Returns permitted attachments for the webform.
+		NOTE: At this point, `self.login_required` is True.
+		"""
+		from frappe.core.doctype.file.file import has_permission as has_file_permission
+
+		def _add_attachment(attachment):
+			"""Add attachment to the list."""
+			return {
+				"file_name": attachment.file_name,
+				"file_url": attachment.file_url,
+				"file_size": attachment.file_size,
+			}
+
+		attachments = frappe.get_all(
+			"File",
+			filters={
+				"attached_to_name": context.reference_name,
+				"attached_to_doctype": context.reference_doctype,
+			},
+			fields=[
+				"is_private",
+				"file_name",
+				"file_url",
+				"file_size",
+				"owner",
+				"attached_to_doctype",
+				"attached_to_name",
+			],
+		)
+
+		permitted_attachments = []
+		for attachment in attachments:
+			if not attachment.is_private:
+				# Public attachments are always permitted
+				permitted_attachments.append(_add_attachment(attachment))
+				continue
+
+			# Attachment is private. Check for file permission
+			if has_file_permission(attachment, "read"):
+				permitted_attachments.append(_add_attachment(attachment))
+
+		return permitted_attachments
 
 
 def get_web_form_module(doc):
@@ -595,13 +694,13 @@ def check_webform_perm(doctype, name):
 
 
 @frappe.whitelist(allow_guest=True)
-def get_web_form_filters(web_form_name):
+def get_web_form_filters(web_form_name: str):
 	web_form = frappe.get_doc("Web Form", web_form_name)
 	return [field for field in web_form.web_form_fields if field.show_in_filter]
 
 
 @frappe.whitelist(allow_guest=True)
-def get_form_data(doctype, docname=None, web_form_name=None):
+def get_form_data(doctype: str, docname: str | None = None, web_form_name: str | None = None):
 	web_form = frappe.get_doc("Web Form", web_form_name)
 
 	if web_form.login_required and frappe.session.user == "Guest":
@@ -687,6 +786,7 @@ def get_link_options(web_form_name, doctype, allow_read_on_all_link_options=Fals
 		if meta.translated_doctype:
 			# Translate the labels if "Translate Link Fields" is enabled
 			link_options = [{"value": row.value, "label": _(row.label)} for row in link_options]
+
 		return json.dumps(link_options, default=str)
 	else:
 		if meta.translated_doctype:

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -33,12 +33,11 @@ class Workflow(Document):
 	# end: auto-generated types
 	def validate(self):
 		self.set_active()
-		self.create_custom_field_for_workflow_state()
-		self.update_default_workflow_status()
 		self.validate_docstatus()
 
 	def on_update(self):
-		frappe.clear_cache(doctype=self.document_type)
+		self.create_custom_field_for_workflow_state()
+		self.update_default_workflow_status()
 
 	def create_custom_field_for_workflow_state(self):
 		frappe.clear_cache(doctype=self.document_type)

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -67,8 +67,15 @@ def get_context(context):
 			settings=settings,
 		)
 
+	# Include selected print format name in access log
+	print_format_name = getattr(print_format, "name", "Standard")
+
 	make_access_log(
-		doctype=frappe.form_dict.doctype, document=frappe.form_dict.name, file_type="PDF", method="Print"
+		doctype=frappe.form_dict.doctype,
+		document=frappe.form_dict.name,
+		file_type="PDF",
+		method="Print",
+		page=f"Print Format: {print_format_name}",
 	)
 
 	return {
@@ -81,7 +88,7 @@ def get_context(context):
 		"doctype": frappe.form_dict.doctype,
 		"name": frappe.form_dict.name,
 		"key": frappe.form_dict.get("key"),
-		"print_format": getattr(print_format, "name", None),
+		"print_format": print_format_name,
 		"letterhead": letterhead,
 		"no_letterhead": frappe.form_dict.no_letterhead,
 		"pdf_generator": frappe.form_dict.get("pdf_generator", "wkhtmltopdf"),

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
     "build": "node esbuild",
     "production": "node esbuild --production",
     "watch": "node esbuild --watch",
-    "coverage:report": "npx nyc report --reporter=clover",
-    "postinstall": "cd billing && yarn install"
+    "coverage:report": "npx nyc report --reporter=clover"
   },
   "repository": {
     "type": "git",
@@ -48,7 +47,7 @@
     "fast-deep-equal": "^2.0.1",
     "fast-glob": "^3.2.5",
     "frappe-charts": "^2.0.0-rc26",
-    "frappe-datatable": "1.17.16",
+    "frappe-datatable": "1.18.3",
     "frappe-gantt": "^0.6.0",
     "highlight.js": "^10.4.1",
     "html5-qrcode": "^2.3.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ dependencies = [
     "tomli~=2.0.1",
     "xlrd~=2.0.1",
     "zxcvbn~=4.4.28",
-    "markdownify~=0.11.6",
+    "markdownify~=0.14.1",
 
     # integration dependencies
     "boto3~=1.34.143",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1536,10 +1536,10 @@ frappe-charts@^2.0.0-rc26:
   resolved "https://registry.yarnpkg.com/frappe-charts/-/frappe-charts-2.0.0-rc26.tgz#9632d620b92f2043cebd192a8899119f5715524b"
   integrity sha512-0vyXcwcekIeYA6pxCHGcRdG8llC6hpGR91nkbwRGSnBYMKomX2AQtfgTlIKMrE9nmAkewJeZsTx1scni8Ry0iA==
 
-frappe-datatable@1.17.16:
-  version "1.17.16"
-  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.17.16.tgz#4e7bf3b50dad5bc048f95ccd7ca7da91e04844ab"
-  integrity sha512-BJgWFX8msHZcS1mw2xbuaY1YdH1dBXUIuREVmqH5z1p78GusPaDV8sbWskTS5yVBUklMrMq2VfBTUsJXjvl+wg==
+frappe-datatable@1.18.3:
+  version "1.18.3"
+  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.18.3.tgz#12291e997519fd99877845782cb304a770aca3e0"
+  integrity sha512-plcLPXTi6AkVYckUWR8stYBkmXvPfqJsG4wksmSU/ZYkvzjbzA/6cqSMCff7cwTvpjcjPFLKVbxM/njfB2cs+w==
   dependencies:
     hyperlist "^1.0.0-beta"
     lodash "^4.17.5"


### PR DESCRIPTION
### Tiltle :
Sync Frappe v15 Code Changes from May 2nd to May 6 th

### Scenario Covered
This PR includes code changes merged into [frappe/frappe](https://github.com/frappe/frappe) between May 2nd and May 6th. The following commits have been included:

### Bug Fixes

* **document:** don't try to overwrite name if a string is already set 
* don't create example email domains and email accounts 
* **link:** dont force set value in model 
* remove conflicts from package.json 
* resolve conflicts in yarn.lock 
* show the symbol if currency is present 
* **tests:** create `example.com` email_domain record for test 
* **ui_tests:** create email account 

### Features

* include print format name in Access Log during print 
### Performance Improvements

* add cache-control headers on private files 
* cast dynamic links while filtering 
* cast filters to string for assignments 
* cast todo queries for int PK
* Don't update list view settings on every query 
* Fix child table queries for int-PK parent 
* manually cast doc.name to string 

### Technical Details
Modules Affected: Core modules within the Frappe framework

### Linked Issue
None

### PR Reference
None