### PR TITLE
fix: Number card case sensitivity search issue

### DIFF
--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -218,7 +218,7 @@ def get_cards_for_user(doctype, txt, searchfield, start, page_len, filters):
 	numberCard = DocType("Number Card")
 
 	if txt:
-		search_conditions = [numberCard[field].like(f"%{txt}%") for field in searchfields]
+		search_conditions = [numberCard[field].ilike(f"%{txt}%") for field in searchfields]
 
 	condition_query = frappe.qb.get_query(
 		doctype,


### PR DESCRIPTION
### Title: 
Fix: Case-Insensitive Search for Workspace Number Cards

### Bug Description
Users were unable to find Number Cards in the Workspace unless the search input exactly matched the case of the card's name or label. For example, searching for "sales" did not return a card labeled "Sales Overview".

### Root Cause
The search logic used .like(), which performs case-sensitive matching in many database setups . As a result, lowercase inputs failed to match uppercase-labeled cards.

Steps to Reproduce
Create a Number Card labeled "Sales Overview".

Search for "sales" in the Workspace number card filter.

Observe that no matching cards appear.

Actual Result: Search failed to return results unless the case exactly matched.
Expected Result: Matching cards should appear regardless of case.

### Fix Summary
Replaced .like() with .ilike() in the get_cards_for_user() function to enable case-insensitive matching, resolving the issue across different input cases.

Replacing like() with ilike() fixed the issue.

### Affected Module
Workspace

Number Card search logic (get_cards_for_user function)

### Test Cases Covered
None

### Linked Issue
None

### PR Reference
None

