### PR TITLE
fix: create doc redirecting issue

### DIFF
--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -353,6 +353,7 @@ $.extend(frappe.model, {
 							r.message.name
 						).__run_link_triggers = true;
 					}
+					r.message.name = 'new';
 					frappe.set_route("Form", r.message.doctype, r.message.name);
 				}
 			},


### PR DESCRIPTION
### Title:
Fix: Redirect to Form View when creating Sales Invoice from Sales Order

### Bug Description
When a user clicked the "Create → Sales Invoice" button from a Sales Order, the system incorrectly redirected to the Sales Invoice List View instead of opening the newly created Sales Invoice Form.

This disrupted the user flow, forcing them to manually search for the newly created document.

### Root Cause
The frappe.set_route() was using r.message.name returned from the mapped document creation.

In some cases, r.message.name wasn't being interpreted correctly, causing a fallback to List View.

Steps to Reproduce:
Open a submitted Sales Order.

Click on "Create" → "Sales Invoice".

Observe redirection to Sales Invoice list view instead of the new invoice form.

Actual Result:
User is redirected to the List View of Sales Invoice.

Expected Result:
User should be redirected to the Form View of the newly created Sales Invoice.

### Fix Summary
Updated the open_mapped_doc function to explicitly set r.message.name before routing.

Ensures redirection to the newly created document in Form View consistently
by adding the passing value to r.message.name

### Affected Module
Create button features

Button action: Create Sales Invoice from Sales Order

### Test Cases Covered
None

### Linked Issue
None

### PR Reference
None

