### PR TITLE
fix: Sales Invoice creation from mapping not routing to form view

### DIFF
--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -290,7 +290,7 @@ $.extend(frappe.model, {
 			const is_blocked_field = no_copy_list.includes(key);
 			const is_no_copy = !from_amend && df && cint(df.no_copy) == 1;
 			const is_password = df && df.fieldtype === "Password";
-			
+
 			if (df && !is_internal_field && !is_blocked_field && !is_no_copy && !is_password) {
 				let value = doc[key] || [];
 				if (frappe.model.table_fields.includes(df.fieldtype)) {
@@ -353,7 +353,6 @@ $.extend(frappe.model, {
 							r.message.name
 						).__run_link_triggers = true;
 					}
-					r.message.name = 'new';
 					frappe.set_route("Form", r.message.doctype, r.message.name);
 				}
 			},

--- a/frappe/public/js/frappe/model/sync.js
+++ b/frappe/public/js/frappe/model/sync.js
@@ -70,10 +70,6 @@ Object.assign(frappe.model, {
 	},
 
 	add_to_locals: function (doc) {
-		if (!doc.name && doc.doctype == "Sales Invoice") {
-			return;
-		}
-		
 		if (!locals[doc.doctype]) locals[doc.doctype] = {};
 
 		if (!doc.name && doc.__islocal) {


### PR DESCRIPTION
### Bug Description
When creating a Sales Invoice via mapping (e.g., from a Sales Order using make_sales_invoice), the user was redirected to the list view instead of the newly created form. This broke the expected user experience and made it unclear whether the invoice was created or not.

### Root Cause
There was a hardcoded condition with improper return in sync.js due to which local name of target_doc wasn't getting created. 

if (!doc.name && doc.doctype == "Sales Invoice") {
	return;
}
This skipped syncing unsaved Sales Invoice documents (those with __islocal: 1 but no name). As a result:

The document was not added to locals.

Also in create_new.js route was set to redirect to new record.
frappe.set_route("Form", r.message.doctype, r.message.name) failed because r.message.name was undefined.

The user was redirected to the List View instead of the newly mapped form.

### Steps to Reproduce:

Open a Sales Order.

Click on "Create Sales Invoice".

Observe redirection to the list view instead of a new unsaved invoice form.

### Actual/Observed Result:
User is taken to the Sales Invoice List view. No form appears.

### Expected Result:
User should be redirected to the newly created unsaved Sales Invoice form (__islocal: 1).

### Fix Summary
Removed the following condition from sync.js:

if (!doc.name && doc.doctype == "Sales Invoice") {
	return;
}
This allows frappe.model.sync() to correctly generate a local name and sync the document as expected.

### Affected Module
Model



Verifying routing and document syncing for other mapped doctypes (e.g., Delivery Note)

Linked Issue
Fixes https://github.com/8848digital/erpnext/issues/2496

PR Reference
PR #155
PR #135