### PR TITLE
Sync Frappe v15 Code Changes from Aug 1st to 15th

### DIFF
--- a/esbuild/esbuild.js
+++ b/esbuild/esbuild.js
@@ -418,6 +418,11 @@ async function write_assets_json(metafile) {
 }
 
 async function update_assets_json_in_cache() {
+	// Redis won't be present during docker image build
+	if (process.env.FRAPPE_DOCKER_BUILD) {
+		return;
+	}
+
 	// update assets_json cache in redis, so that it can be read directly by python
 	let client = get_redis_subscriber("redis_cache");
 	// handle error event to avoid printing stack traces

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -60,7 +60,7 @@ from .utils.jinja import (
 )
 from .utils.lazy_loader import lazy_import
 
-__version__ = "15.76.0"
+__version__ = "15.77.0"
 __title__ = "Frappe Framework"
 
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -60,7 +60,7 @@ from .utils.jinja import (
 )
 from .utils.lazy_loader import lazy_import
 
-__version__ = "15.77.0"
+__version__ = "15.78.0"
 __title__ = "Frappe Framework"
 
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -60,7 +60,7 @@ from .utils.jinja import (
 )
 from .utils.lazy_loader import lazy_import
 
-__version__ = "15.75.0"
+__version__ = "15.76.0"
 __title__ = "Frappe Framework"
 
 

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -87,8 +87,8 @@ class AutoRepeat(Document):
 
 	def before_insert(self):
 		if not frappe.flags.in_test:
-			start_date = getdate(self.start_date)
-			today_date = getdate(today())
+			start_date = self.start_date
+			today_date = today()
 			if start_date <= today_date:
 				self.start_date = today_date
 
@@ -133,6 +133,8 @@ class AutoRepeat(Document):
 
 		if self.end_date:
 			self.validate_from_to_dates("start_date", "end_date")
+		if self.end_date == today():
+			frappe.throw(_("End Date cannot be today."))
 
 		if self.end_date == self.start_date:
 			frappe.throw(

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -208,7 +208,7 @@ def _restore(
 		click.secho("Failed to detect type of backup file", fg="red")
 		sys.exit(1)
 
-	if "cipher" in out.decode().split(":")[-1].strip():
+	if "AES" in out.decode().split(":")[-1].strip():
 		if encryption_key:
 			click.secho("Encrypted backup file detected. Decrypting using provided key.", fg="yellow")
 

--- a/frappe/contacts/doctype/address/address.json
+++ b/frappe/contacts/doctype/address/address.json
@@ -109,7 +109,8 @@
   {
    "fieldname": "phone",
    "fieldtype": "Data",
-   "label": "Phone"
+   "label": "Phone",
+   "options": "Phone"
   },
   {
    "fieldname": "fax",

--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -709,7 +709,7 @@
    "depends_on": "email_append_to",
    "fieldname": "recipient_account_field",
    "fieldtype": "Data",
-   "label": "Sender Email Account Field"
+   "label": "Recipient Account Field"
   }
  ],
  "grid_page_length": 50,

--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -709,7 +709,7 @@
    "depends_on": "email_append_to",
    "fieldname": "recipient_account_field",
    "fieldtype": "Data",
-   "label": "Recipient Account Field"
+   "label": "Sender Email Account Field"
   }
  ],
  "grid_page_length": 50,
@@ -793,7 +793,7 @@
    "link_fieldname": "reference_doctype"
   }
  ],
- "modified": "2025-09-23 06:48:13.555017",
+ "modified": "2025-07-19 12:23:16.296416",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",

--- a/frappe/core/doctype/installed_applications/installed_applications.py
+++ b/frappe/core/doctype/installed_applications/installed_applications.py
@@ -38,6 +38,10 @@ class InstalledApplications(Document):
 			):
 				has_setup_wizard = 1
 
+			setup_complete = app_wise_setup_details.get(app.get("app_name")) or 0
+			if app.get("app_name") == "india_compliance":
+				setup_complete = app_wise_setup_details.get("erpnext") or 0
+
 			self.append(
 				"installed_applications",
 				{
@@ -45,7 +49,7 @@ class InstalledApplications(Document):
 					"app_version": app.get("version") or "UNVERSIONED",
 					"git_branch": app.get("branch") or "UNVERSIONED",
 					"has_setup_wizard": has_setup_wizard,
-					"is_setup_complete": app_wise_setup_details.get(app.get("app_name")) or 0,
+					"is_setup_complete": setup_complete,
 				},
 			)
 

--- a/frappe/core/doctype/installed_applications/installed_applications.py
+++ b/frappe/core/doctype/installed_applications/installed_applications.py
@@ -41,6 +41,8 @@ class InstalledApplications(Document):
 			setup_complete = app_wise_setup_details.get(app.get("app_name")) or 0
 			if app.get("app_name") == "india_compliance":
 				setup_complete = app_wise_setup_details.get("erpnext") or 0
+			if app.get("app_name") == "insights":
+				setup_complete = app_wise_setup_details.get("frappe") or 0
 
 			self.append(
 				"installed_applications",

--- a/frappe/core/doctype/module_profile/module_profile.py
+++ b/frappe/core/doctype/module_profile/module_profile.py
@@ -57,11 +57,15 @@ class ModuleProfile(Document):
 
 		module_profile_modules = {module.module for module in self.block_modules}
 
-		for user, modules in user_modules.items():
+		for user_name, modules in user_modules.items():
 			if modules != module_profile_modules:
-				user = frappe.get_doc("User", user)
+				user = frappe.get_doc("User", user_name)
 				user.block_modules = []
 				for module in module_profile_modules:
 					user.append("block_modules", {"module": module})
+<<<<<<< HEAD
 			user.save()
 >>>>>>> f711e52fc9 (fix: sync user block_modules on update)
+=======
+				user.save()
+>>>>>>> 8d04ecba9e (ci: add unit tests)

--- a/frappe/core/doctype/module_profile/module_profile.py
+++ b/frappe/core/doctype/module_profile/module_profile.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2020, Frappe Technologies and contributors
 # License: MIT. See LICENSE
 
+from collections import defaultdict
+
+import frappe
 from frappe.model.document import Document
 
 
@@ -22,3 +25,43 @@ class ModuleProfile(Document):
 		from frappe.config import get_modules_from_all_apps
 
 		self.set_onload("all_modules", sorted(m.get("module_name") for m in get_modules_from_all_apps()))
+<<<<<<< HEAD
+=======
+
+	def get_permission_log_options(self, event=None):
+		return {"fields": ["block_modules"]}
+
+	def on_update(self):
+		self.clear_cache()
+		self.queue_action(
+			"update_all_users",
+			now=frappe.flags.in_test or frappe.flags.in_install,
+			enqueue_after_commit=True,
+		)
+
+	def update_all_users(self):
+		"""Changes in module_profile reflected across all its user"""
+		block_module = frappe.qb.DocType("Block Module")
+		user = frappe.qb.DocType("User")
+
+		all_current_modules = (
+			frappe.qb.from_(user)
+			.join(block_module)
+			.on(user.name == block_module.parent)
+			.where(user.module_profile == self.name)
+			.select(user.name, block_module.module)
+		).run()
+		user_modules = defaultdict(set)
+		for user, module in all_current_modules:
+			user_modules[user].add(module)
+
+		module_profile_modules = {module.module for module in self.block_modules}
+
+		for user, modules in user_modules.items():
+			if modules != module_profile_modules:
+				user = frappe.get_doc("User", user)
+				user.block_modules = []
+				for module in module_profile_modules:
+					user.append("block_modules", {"module": module})
+			user.save()
+>>>>>>> f711e52fc9 (fix: sync user block_modules on update)

--- a/frappe/core/doctype/module_profile/module_profile.py
+++ b/frappe/core/doctype/module_profile/module_profile.py
@@ -25,11 +25,6 @@ class ModuleProfile(Document):
 		from frappe.config import get_modules_from_all_apps
 
 		self.set_onload("all_modules", sorted(m.get("module_name") for m in get_modules_from_all_apps()))
-<<<<<<< HEAD
-=======
-
-	def get_permission_log_options(self, event=None):
-		return {"fields": ["block_modules"]}
 
 	def on_update(self):
 		self.clear_cache()
@@ -63,9 +58,4 @@ class ModuleProfile(Document):
 				user.block_modules = []
 				for module in module_profile_modules:
 					user.append("block_modules", {"module": module})
-<<<<<<< HEAD
-			user.save()
->>>>>>> f711e52fc9 (fix: sync user block_modules on update)
-=======
 				user.save()
->>>>>>> 8d04ecba9e (ci: add unit tests)

--- a/frappe/core/doctype/module_profile/test_module_profile.py
+++ b/frappe/core/doctype/module_profile/test_module_profile.py
@@ -4,17 +4,13 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 
-<<<<<<< HEAD
 class TestModuleProfile(FrappeTestCase):
-=======
-class TestModuleProfile(IntegrationTestCase):
 	def setUp(self):
 		frappe.delete_doc_if_exists("Module Profile", "_Test Module Profile", force=1)
 		frappe.delete_doc_if_exists("Module Profile", "_Test Module Profile 2", force=1)
 		frappe.delete_doc_if_exists("User", "test-module-user1@example.com", force=1)
 		frappe.delete_doc_if_exists("User", "test-module-user2@example.com", force=1)
 
->>>>>>> 8d04ecba9e (ci: add unit tests)
 	def test_make_new_module_profile(self):
 		frappe.get_doc(
 			{

--- a/frappe/core/doctype/module_profile/test_module_profile.py
+++ b/frappe/core/doctype/module_profile/test_module_profile.py
@@ -4,7 +4,18 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 
+<<<<<<< HEAD
 class TestModuleProfile(FrappeTestCase):
+=======
+class TestModuleProfile(IntegrationTestCase):
+	def setUp(self):
+		# Clean slate before each test
+		frappe.delete_doc_if_exists("Module Profile", "_Test Module Profile", force=1)
+		frappe.delete_doc_if_exists("Module Profile", "_Test Module Profile 2", force=1)
+		frappe.delete_doc_if_exists("User", "test-module-user1@example.com", force=1)
+		frappe.delete_doc_if_exists("User", "test-module-user2@example.com", force=1)
+
+>>>>>>> 8d04ecba9e (ci: add unit tests)
 	def test_make_new_module_profile(self):
 		if not frappe.db.get_value("Module Profile", "_Test Module Profile"):
 			frappe.get_doc(
@@ -27,3 +38,134 @@ class TestModuleProfile(FrappeTestCase):
 		new_user.save()
 
 		self.assertEqual(new_user.block_modules[0].module, "Accounts")
+
+	def test_multiple_block_modules(self):
+		"""Assign multiple blocked modules from profile to user"""
+		module_profile = frappe.get_doc(
+			{
+				"doctype": "Module Profile",
+				"module_profile_name": "_Test Module Profile",
+				"block_modules": [{"module": "Accounts"}, {"module": "CRM"}, {"module": "HR"}],
+			}
+		).insert()
+
+		user = frappe.get_doc(
+			{"doctype": "User", "email": "test-module-user1@example.com", "first_name": "Test User"}
+		).insert()
+
+		user.module_profile = module_profile.name
+		user.save()
+
+		self.assertSetEqual({bm.module for bm in user.block_modules}, {"Accounts", "CRM", "HR"})
+
+	def test_update_module_profile_propagates_to_users(self):
+		"""Updating block_modules in profile should update linked users"""
+		module_profile = frappe.get_doc(
+			{
+				"doctype": "Module Profile",
+				"module_profile_name": "_Test Module Profile",
+				"block_modules": [{"module": "Accounts"}],
+			}
+		).insert()
+
+		user = frappe.get_doc(
+			{"doctype": "User", "email": "test-module-user1@example.com", "first_name": "Test User"}
+		).insert()
+
+		user.module_profile = module_profile.name
+		user.save()
+
+		self.assertEqual({bm.module for bm in user.block_modules}, {"Accounts"})
+
+		# Update module profile
+
+		module_profile.append("block_modules", {"module": "Projects"})
+		module_profile.save()
+
+		user.reload()
+		self.assertSetEqual({bm.module for bm in user.block_modules}, {"Accounts", "Projects"})
+
+	def test_clear_block_modules(self):
+		"""Clearing block_modules in profile should also clear them for users"""
+		module_profile = frappe.get_doc(
+			{
+				"doctype": "Module Profile",
+				"module_profile_name": "_Test Module Profile",
+				"block_modules": [{"module": "Accounts"}],
+			}
+		).insert()
+
+		user = frappe.get_doc(
+			{"doctype": "User", "email": "test-module-user1@example.com", "first_name": "Test User"}
+		).insert()
+
+		user.module_profile = module_profile.name
+		user.save()
+		self.assertTrue(user.block_modules)
+
+		# Clear profile modules
+		module_profile.block_modules = []
+		module_profile.save()
+
+		user.reload()
+		self.assertEqual(user.block_modules, [])
+
+	def test_multiple_users_same_profile(self):
+		"""Updates should propagate to all users linked to the same profile"""
+		module_profile = frappe.get_doc(
+			{
+				"doctype": "Module Profile",
+				"module_profile_name": "_Test Module Profile",
+				"block_modules": [{"module": "Accounts"}],
+			}
+		).insert()
+
+		user1 = frappe.get_doc(
+			{"doctype": "User", "email": "test-module-user1@example.com", "first_name": "User One"}
+		).insert()
+		user2 = frappe.get_doc(
+			{"doctype": "User", "email": "test-module-user2@example.com", "first_name": "User Two"}
+		).insert()
+
+		for u in (user1, user2):
+			u.module_profile = module_profile.name
+			u.save()
+
+		# Update profile
+		module_profile.append("block_modules", {"module": "Projects"})
+		module_profile.save()
+
+		user1.reload()
+		user2.reload()
+		self.assertEqual([bm.module for bm in user1.block_modules], ["Accounts", "Projects"])
+		self.assertEqual([bm.module for bm in user2.block_modules], ["Accounts", "Projects"])
+
+	def test_switch_user_module_profile(self):
+		"""Switching user to a different profile updates their block_modules"""
+		profile1 = frappe.get_doc(
+			{
+				"doctype": "Module Profile",
+				"module_profile_name": "_Test Module Profile",
+				"block_modules": [{"module": "Accounts"}],
+			}
+		).insert()
+		profile2 = frappe.get_doc(
+			{
+				"doctype": "Module Profile",
+				"module_profile_name": "_Test Module Profile 2",
+				"block_modules": [{"module": "HR"}],
+			}
+		).insert()
+
+		user = frappe.get_doc(
+			{"doctype": "User", "email": "test-module-user1@example.com", "first_name": "Test User"}
+		).insert()
+
+		user.module_profile = profile1.name
+		user.save()
+		self.assertEqual([bm.module for bm in user.block_modules], ["Accounts"])
+
+		# Switch to another profile
+		user.module_profile = profile2.name
+		user.save()
+		self.assertEqual([bm.module for bm in user.block_modules], ["HR"])

--- a/frappe/core/doctype/module_profile/test_module_profile.py
+++ b/frappe/core/doctype/module_profile/test_module_profile.py
@@ -9,7 +9,6 @@ class TestModuleProfile(FrappeTestCase):
 =======
 class TestModuleProfile(IntegrationTestCase):
 	def setUp(self):
-		# Clean slate before each test
 		frappe.delete_doc_if_exists("Module Profile", "_Test Module Profile", force=1)
 		frappe.delete_doc_if_exists("Module Profile", "_Test Module Profile 2", force=1)
 		frappe.delete_doc_if_exists("User", "test-module-user1@example.com", force=1)
@@ -17,22 +16,17 @@ class TestModuleProfile(IntegrationTestCase):
 
 >>>>>>> 8d04ecba9e (ci: add unit tests)
 	def test_make_new_module_profile(self):
-		if not frappe.db.get_value("Module Profile", "_Test Module Profile"):
-			frappe.get_doc(
-				{
-					"doctype": "Module Profile",
-					"module_profile_name": "_Test Module Profile",
-					"block_modules": [{"module": "Accounts"}],
-				}
-			).insert()
+		frappe.get_doc(
+			{
+				"doctype": "Module Profile",
+				"module_profile_name": "_Test Module Profile",
+				"block_modules": [{"module": "Accounts"}],
+			}
+		).insert()
 
-		# add to user and check
-		if not frappe.db.get_value("User", "test-for-module_profile@example.com"):
-			new_user = frappe.get_doc(
-				{"doctype": "User", "email": "test-for-module_profile@example.com", "first_name": "Test User"}
-			).insert()
-		else:
-			new_user = frappe.get_doc("User", "test-for-module_profile@example.com")
+		new_user = frappe.get_doc(
+			{"doctype": "User", "email": "test-module-user1@example.com", "first_name": "Test User"}
+		).insert()
 
 		new_user.module_profile = "_Test Module Profile"
 		new_user.save()
@@ -77,8 +71,6 @@ class TestModuleProfile(IntegrationTestCase):
 
 		self.assertEqual({bm.module for bm in user.block_modules}, {"Accounts"})
 
-		# Update module profile
-
 		module_profile.append("block_modules", {"module": "Projects"})
 		module_profile.save()
 
@@ -103,7 +95,6 @@ class TestModuleProfile(IntegrationTestCase):
 		user.save()
 		self.assertTrue(user.block_modules)
 
-		# Clear profile modules
 		module_profile.block_modules = []
 		module_profile.save()
 
@@ -131,7 +122,6 @@ class TestModuleProfile(IntegrationTestCase):
 			u.module_profile = module_profile.name
 			u.save()
 
-		# Update profile
 		module_profile.append("block_modules", {"module": "Projects"})
 		module_profile.save()
 
@@ -165,7 +155,6 @@ class TestModuleProfile(IntegrationTestCase):
 		user.save()
 		self.assertEqual([bm.module for bm in user.block_modules], ["Accounts"])
 
-		# Switch to another profile
 		user.module_profile = profile2.name
 		user.save()
 		self.assertEqual([bm.module for bm in user.block_modules], ["HR"])

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -69,6 +69,7 @@ frappe.ui.form.on("User", {
 						let d = frm.add_child("block_modules");
 						d.module = v.module;
 					});
+					frm.module_editor.disable = 1;
 					frm.module_editor && frm.module_editor.show();
 				},
 			});
@@ -100,7 +101,11 @@ frappe.ui.form.on("User", {
 
 				if (frm.doc.user_type == "System User") {
 					var module_area = $("<div>").appendTo(frm.fields_dict.modules_html.wrapper);
-					frm.module_editor = new frappe.ModuleEditor(frm, module_area);
+					frm.module_editor = new frappe.ModuleEditor(
+						frm,
+						module_area,
+						frm.doc.module_profile && frm.doc.module_profile.length ? 1 : 0
+					);
 				}
 			} else {
 				frm.roles_editor.show();
@@ -245,6 +250,8 @@ frappe.ui.form.on("User", {
 				frm.roles_editor.show();
 			}
 
+			frm.module_editor.disable =
+				frm.doc.module_profile && frm.doc.module_profile.length ? 1 : 0;
 			frm.module_editor && frm.module_editor.show();
 
 			if (frappe.session.user == doc.name) {

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -104,7 +104,7 @@ frappe.ui.form.on("User", {
 					frm.module_editor = new frappe.ModuleEditor(
 						frm,
 						module_area,
-						frm.doc.module_profile && frm.doc.module_profile.length ? 1 : 0
+						frm.doc.module_profile ? 1 : 0
 					);
 				}
 			} else {
@@ -250,8 +250,7 @@ frappe.ui.form.on("User", {
 				frm.roles_editor.show();
 			}
 
-			frm.module_editor.disable =
-				frm.doc.module_profile && frm.doc.module_profile.length ? 1 : 0;
+			frm.module_editor.disable = frm.doc.module_profile ? 1 : 0;
 			frm.module_editor && frm.module_editor.show();
 
 			if (frappe.session.user == doc.name) {

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -438,7 +438,7 @@ function get_roles_for_editing_user() {
 function show_api_key_dialog(api_key, api_secret) {
 	const download_icon = `<i class="fa fa-download fa-w"></i>`;
 	const dialog = new frappe.ui.Dialog({
-		title: __("API Token"),
+		title: __("Key Details"),
 		fields: [
 			{
 				label: __("API Key"),
@@ -465,18 +465,20 @@ function show_api_key_dialog(api_key, api_secret) {
 					[api_key, api_secret],
 				],
 				"System Manager",
-				"api_token"
+				"key_details"
 			);
 		},
 	});
 
 	dialog.show();
-
 	dialog.show_message(__("Download details for future reference."), "yellow", 1);
-	dialog.get_close_btn().show(); // static: true, so close button is hidden by default
+
+	const close_btn = dialog.get_close_btn();
+
+	close_btn.show(); // static: true, so close button is hidden by default
 
 	// ask for confirmation before closing API details dialog
-	dialog.get_close_btn().on("click", function () {
+	close_btn.on("click", function () {
 		const confirm_dialog = frappe.confirm(
 			__(
 				"Are you sure you downloaded the key details? <br> <br> This is the last time we will show you the details."

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -454,6 +454,8 @@ function show_api_key_dialog(api_key, api_secret) {
 				default: "***************",
 			},
 		],
+		static: true,
+		size: "small",
 		primary_action_label: __("{0} Download", [frappe.utils.icon("down-arrow")]),
 		primary_action: function () {
 			frappe.tools.downloadify(
@@ -465,10 +467,10 @@ function show_api_key_dialog(api_key, api_secret) {
 				"api_token"
 			);
 		},
-		size: "small",
 	});
 
 	dialog.show();
 
 	dialog.show_message(__("Download details for future reference."), "yellow", 1);
+	dialog.get_close_btn().show(); // static: true, so close button is hidden by default
 }

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -466,10 +466,14 @@ function show_api_key_dialog(api_key, api_secret) {
 				"System Manager",
 				"key_details"
 			);
+
+			dialog.hide();
 		},
 		secondary_action_label: __("{0} Copy", [frappe.utils.icon("clipboard")]),
 		secondary_action: function () {
 			frappe.utils.copy_to_clipboard(JSON.stringify({ api_key, api_secret }, null, "\t"));
+
+			dialog.hide();
 		},
 	});
 

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -474,4 +474,18 @@ function show_api_key_dialog(api_key, api_secret) {
 
 	dialog.show_message(__("Download details for future reference."), "yellow", 1);
 	dialog.get_close_btn().show(); // static: true, so close button is hidden by default
+
+	// ask for confirmation before closing API details dialog
+	dialog.get_close_btn().on("click", function () {
+		const confirm_dialog = frappe.confirm(
+			__(
+				"Are you sure you downloaded the key details? <br> <br> This is the last time we will show you the details."
+			),
+			() => dialog.hide(),
+			() => dialog.show()
+		);
+
+		confirm_dialog.set_primary_action("Yes, Close");
+		confirm_dialog.set_secondary_action_label("No, Go Back");
+	});
 }

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -333,7 +333,7 @@ frappe.ui.form.on("User", {
 			},
 			callback: function (r) {
 				if (r.message) {
-					frappe.msgprint(__("Save API Secret: {0}", [r.message.api_secret]));
+					show_api_key_dialog(r.message.api_key, r.message.api_secret);
 					frm.reload_doc();
 				}
 			},
@@ -433,4 +433,40 @@ function get_roles_for_editing_user() {
 			.permissions.filter((perm) => perm.permlevel >= 1 && perm.write)
 			.map((perm) => perm.role) || ["System Manager"]
 	);
+}
+
+function show_api_key_dialog(api_key, api_secret) {
+	const dialog = new frappe.ui.Dialog({
+		title: __("API Token"),
+		fields: [
+			{
+				label: __("API Key"),
+				fieldname: "api_key",
+				fieldtype: "Data",
+				read_only: 1,
+				default: api_key,
+			},
+			{
+				label: __("API Secret"),
+				fieldname: "api_secret",
+				fieldtype: "Data",
+				read_only: 1,
+				default: api_secret,
+			},
+		],
+		primary_action_label: __("{0} Download", [frappe.utils.icon("down-arrow")]),
+		primary_action: function () {
+			frappe.tools.downloadify(
+				[
+					["api_key", "api_secret"],
+					[api_key, api_secret],
+				],
+				"System Manager",
+				"api_token"
+			);
+		},
+		size: "small",
+	});
+
+	dialog.show();
 }

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -451,7 +451,7 @@ function show_api_key_dialog(api_key, api_secret) {
 				fieldname: "api_secret",
 				fieldtype: "Data",
 				read_only: 1,
-				default: api_secret,
+				default: "******************",
 			},
 		],
 		primary_action_label: __("{0} Download", [frappe.utils.icon("down-arrow")]),

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -437,6 +437,7 @@ function get_roles_for_editing_user() {
 
 function show_api_key_dialog(api_key, api_secret) {
 	const download_icon = `<i class="fa fa-download fa-w"></i>`;
+
 	const dialog = new frappe.ui.Dialog({
 		title: __("Key Details"),
 		fields: [
@@ -468,10 +469,14 @@ function show_api_key_dialog(api_key, api_secret) {
 				"key_details"
 			);
 		},
+		secondary_action_label: __("{0} Copy", [frappe.utils.icon("clipboard")]),
+		secondary_action: function () {
+			frappe.utils.copy_to_clipboard(JSON.stringify({ api_key, api_secret }, null, "\t"));
+		},
 	});
 
 	dialog.show();
-	dialog.show_message(__("Download details for future reference."), "yellow", 1);
+	dialog.show_message(__("Download/Copy details for future reference."), "yellow", 1);
 
 	const close_btn = dialog.get_close_btn();
 
@@ -481,7 +486,7 @@ function show_api_key_dialog(api_key, api_secret) {
 	close_btn.on("click", function () {
 		const confirm_dialog = frappe.confirm(
 			__(
-				"Are you sure you downloaded the key details? <br> <br> This is the last time we will show you the details."
+				"Are you sure you downloaded/copied the key details? <br> <br> This is the last time we will show you the details."
 			),
 			() => dialog.hide(),
 			() => dialog.show()

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -451,7 +451,7 @@ function show_api_key_dialog(api_key, api_secret) {
 				fieldname: "api_secret",
 				fieldtype: "Data",
 				read_only: 1,
-				default: "******************",
+				default: "***************",
 			},
 		],
 		primary_action_label: __("{0} Download", [frappe.utils.icon("down-arrow")]),
@@ -469,4 +469,6 @@ function show_api_key_dialog(api_key, api_secret) {
 	});
 
 	dialog.show();
+
+	dialog.show_message(__("Download details for future reference."), "yellow", 1);
 }

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -436,8 +436,6 @@ function get_roles_for_editing_user() {
 }
 
 function show_api_key_dialog(api_key, api_secret) {
-	const download_icon = `<i class="fa fa-download fa-w"></i>`;
-
 	const dialog = new frappe.ui.Dialog({
 		title: __("Key Details"),
 		fields: [
@@ -458,7 +456,7 @@ function show_api_key_dialog(api_key, api_secret) {
 		],
 		static: true,
 		size: "small",
-		primary_action_label: __("{0} Download", [download_icon]),
+		primary_action_label: __("{0} Download", [`<i class="fa fa-download fa-w"></i>`]),
 		primary_action: function () {
 			frappe.tools.downloadify(
 				[

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -437,64 +437,49 @@ function get_roles_for_editing_user() {
 
 function show_api_key_dialog(api_key, api_secret) {
 	const dialog = new frappe.ui.Dialog({
-		title: __("Key Details"),
+		title: __("API Keys"),
 		fields: [
 			{
 				label: __("API Key"),
 				fieldname: "api_key",
-				fieldtype: "Data",
+				fieldtype: "Code",
 				read_only: 1,
 				default: api_key,
 			},
 			{
 				label: __("API Secret"),
 				fieldname: "api_secret",
-				fieldtype: "Data",
+				fieldtype: "Code",
 				read_only: 1,
-				default: "***************",
+				default: api_secret,
 			},
 		],
-		static: true,
 		size: "small",
-		primary_action_label: __("{0} Download", [`<i class="fa fa-download fa-w"></i>`]),
-		primary_action: function () {
+		primary_action_label: __("Download"),
+		primary_action: () => {
 			frappe.tools.downloadify(
 				[
 					["api_key", "api_secret"],
 					[api_key, api_secret],
 				],
 				"System Manager",
-				"key_details"
+				"frappe_api_keys"
 			);
 
 			dialog.hide();
 		},
-		secondary_action_label: __("{0} Copy", [frappe.utils.icon("clipboard")]),
-		secondary_action: function () {
-			frappe.utils.copy_to_clipboard(JSON.stringify({ api_key, api_secret }, null, "\t"));
-
+		secondary_action_label: __("Copy token to clipboard"),
+		secondary_action: () => {
+			const token = `${api_key}:${api_secret}`;
+			frappe.utils.copy_to_clipboard(token);
 			dialog.hide();
 		},
 	});
 
 	dialog.show();
-	dialog.show_message(__("Download/Copy details for future reference."), "yellow", 1);
-
-	const close_btn = dialog.get_close_btn();
-
-	close_btn.show(); // static: true, so close button is hidden by default
-
-	// ask for confirmation before closing API details dialog
-	close_btn.on("click", function () {
-		const confirm_dialog = frappe.confirm(
-			__(
-				"Are you sure you downloaded/copied the key details? <br> <br> This is the last time we will show you the details."
-			),
-			() => dialog.hide(),
-			() => dialog.show()
-		);
-
-		confirm_dialog.set_primary_action("Yes, Close");
-		confirm_dialog.set_secondary_action_label("No, Go Back");
-	});
+	dialog.show_message(
+		__("Store the API Secret securely, it won't be displayed again."),
+		"yellow",
+		1
+	);
 }

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -478,7 +478,7 @@ function show_api_key_dialog(api_key, api_secret) {
 
 	dialog.show();
 	dialog.show_message(
-		__("Store the API Secret securely, it won't be displayed again."),
+		__("Store the API secret securely. It won't be displayed again."),
 		"yellow",
 		1
 	);

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -436,6 +436,7 @@ function get_roles_for_editing_user() {
 }
 
 function show_api_key_dialog(api_key, api_secret) {
+	const download_icon = `<i class="fa fa-download fa-w"></i>`;
 	const dialog = new frappe.ui.Dialog({
 		title: __("API Token"),
 		fields: [
@@ -456,7 +457,7 @@ function show_api_key_dialog(api_key, api_secret) {
 		],
 		static: true,
 		size: "small",
-		primary_action_label: __("{0} Download", [frappe.utils.icon("down-arrow")]),
+		primary_action_label: __("{0} Download", [download_icon]),
 		primary_action: function () {
 			frappe.tools.downloadify(
 				[

--- a/frappe/core/doctype/user/user.json
+++ b/frappe/core/doctype/user/user.json
@@ -598,6 +598,7 @@
    "unique": 1
   },
   {
+   "description": "<a href=\"https://docs.frappe.io/framework/user/en/api/rest#1-token-based-authentication\" target=\"_blank\">\n  Click here to learn how to use token based Authentication\n</a>",
    "fieldname": "generate_keys",
    "fieldtype": "Button",
    "label": "Generate Keys",
@@ -874,7 +875,7 @@
   }
  ],
  "make_attachments_public": 1,
- "modified": "2025-03-17 11:29:39.254304",
+ "modified": "2025-05-21 14:57:24.333141",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User",

--- a/frappe/core/doctype/user/user.json
+++ b/frappe/core/doctype/user/user.json
@@ -598,7 +598,7 @@
    "unique": 1
   },
   {
-   "description": "<a href=\"https://docs.frappe.io/framework/user/en/api/rest#1-token-based-authentication\" target=\"_blank\">\n  Click here to learn how to use token based Authentication\n</a>",
+   "description": "<a href=\"https://docs.frappe.io/framework/user/en/api/rest#1-token-based-authentication\" target=\"_blank\">\n  Click here to learn about token-based authentication\n</a>",
    "fieldname": "generate_keys",
    "fieldtype": "Button",
    "label": "Generate Keys",

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1281,7 +1281,7 @@ def generate_keys(user: str):
 	user_details.api_secret = api_secret
 	user_details.save()
 
-	return {"api_secret": api_secret}
+	return {"api_key": user_details.api_key, "api_secret": api_secret}
 
 
 @frappe.whitelist()

--- a/frappe/core/doctype/version/version.py
+++ b/frappe/core/doctype/version/version.py
@@ -4,7 +4,7 @@
 import json
 
 import frappe
-from frappe.model import no_value_fields, table_fields
+from frappe.model import datetime_fields, no_value_fields, table_fields
 from frappe.model.document import Document
 from frappe.utils import cstr
 
@@ -119,6 +119,10 @@ def get_diff(old, new, for_child=False, compare_cancelled=False):
 		old_value, new_value = old.get(df.fieldname), new.get(df.fieldname)
 		if df.fieldtype in ("Link", "Dynamic Link"):
 			old_value, new_value = cstr(old_value), cstr(new_value)
+
+		if df.fieldtype in datetime_fields:
+			if old_value is None and new_value == "":
+				new_value = None
 
 		if not for_child and df.fieldtype in table_fields:
 			old_rows_by_name = {}

--- a/frappe/core/doctype/version/version_view.html
+++ b/frappe/core/doctype/version/version_view.html
@@ -4,6 +4,7 @@
 <p>{{ data.comment }}</p>
 {% endif %}
 
+{% const getEscapedValue = (v) => v === null ? "null" : frappe.utils.escape_html(v) %}
 {% if data.changed && data.changed.length %}
 <h4>{{ __("Values Changed") }}</h4>
 <table class="table table-bordered">
@@ -18,8 +19,8 @@
 		{% for item in data.changed %}
 		<tr>
 			<td>{{ frappe.meta.get_label(doc.ref_doctype, item[0]) }}</td>
-			<td class="diff-remove">{{ frappe.utils.escape_html(item[1]) }}</td>
-			<td class="diff-add">{{ frappe.utils.escape_html(item[2]) }}</td>
+			<td class="diff-remove">{{ getEscapedValue(item[1]) }}</td>
+			<td class="diff-add">{{ getEscapedValue(item[2]) }}</td>
 		</tr>
 		{% endfor %}
 	</tbody>
@@ -50,7 +51,7 @@
 							{% for row_key in item_keys %}
 							<tr>
 								<td class="small">{{ row_key }}</td>
-								<td class="small">{{ frappe.utils.escape_html(item[1][row_key]) }}</td>
+								<td class="small">{{ getEscapedValue(item[1][row_key]) }}</td>
 							</tr>
 							{% endfor %}
 						</tbody>
@@ -85,8 +86,8 @@
 				<td>{{ frappe.meta.get_label(doc.ref_doctype, table_info[0]) }}</td>
 				<td>{{ table_info[1] }}</td>
 				<td>{{ item[0] }}</td>
-				<td class="diff-remove">{{ frappe.utils.escape_html(item[1]) }}</td>
-				<td class="diff-add">{{ frappe.utils.escape_html(item[2]) }}</td>
+				<td class="diff-remove">{{ getEscapedValue(item[1]) }}</td>
+				<td class="diff-add">{{ getEscapedValue(item[2]) }}</td>
 			</tr>
 			{% endfor %}
 		{% endfor %}

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -144,12 +144,19 @@ class MariaDBConnectionUtil:
 		if frappe.conf.local_infile:
 			conn_settings["local_infile"] = frappe.conf.local_infile
 
-		if frappe.conf.db_ssl_ca and frappe.conf.db_ssl_cert and frappe.conf.db_ssl_key:
-			conn_settings["ssl"] = {
+		# Configure SSL settings
+		if frappe.conf.db_ssl_ca:
+			ssl_config = {
 				"ca": frappe.conf.db_ssl_ca,
-				"cert": frappe.conf.db_ssl_cert,
-				"key": frappe.conf.db_ssl_key,
+				"check_hostname": frappe.conf.db_ssl_check_hostname,
 			}
+
+			# Add client certificates for mutual SSL if available
+			if frappe.conf.db_ssl_cert and frappe.conf.db_ssl_key:
+				ssl_config.update({"cert": frappe.conf.db_ssl_cert, "key": frappe.conf.db_ssl_key})
+
+			conn_settings["ssl"] = ssl_config
+
 		return conn_settings
 
 

--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -74,6 +74,7 @@ def get_communication_doctype(doctype, txt, searchfield, start, page_len, filter
 	user_perms = frappe.utils.user.UserPermissions(frappe.session.user)
 	user_perms.build_permissions()
 	can_read = user_perms.can_read
+	from frappe import _
 	from frappe.modules import load_doctype_module
 
 	com_doctypes = []
@@ -91,4 +92,12 @@ def get_communication_doctype(doctype, txt, searchfield, start, page_len, filter
 			d[0] for d in frappe.db.get_values("DocType", {"issingle": 0, "istable": 0, "hide_toolbar": 0})
 		]
 
-	return [[dt] for dt in com_doctypes if txt.lower().replace("%", "") in dt.lower() and dt in can_read]
+	results = []
+	txt_lower = txt.lower().replace("%", "")
+
+	for dt in com_doctypes:
+		if dt in can_read:
+			if txt_lower in dt.lower() or txt_lower in _(dt).lower():
+				results.append([dt])
+
+	return results

--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -77,565 +77,566 @@
      "no_failed"
  ],
  "fields": [
-     {
-     "fieldname": "email_id",
-     "fieldtype": "Data",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "in_global_search": 1,
-     "in_list_view": 1,
-     "label": "Email Address",
-     "options": "Email",
-     "reqd": 1
-     },
-     {
-     "default": "0",
-     "depends_on": "eval: !doc.backend_app_flow",
-     "fieldname": "login_id_is_different",
-     "fieldtype": "Check",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Use different Email ID"
-     },
-     {
-     "depends_on": "login_id_is_different",
-     "fieldname": "login_id",
-     "fieldtype": "Data",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Alternative Email ID"
-     },
-     {
-     "depends_on": "eval: doc.auth_method === \"Basic\"",
-     "fieldname": "password",
-     "fieldtype": "Password",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Password"
-     },
-     {
-     "default": "0",
-     "depends_on": "eval: doc.auth_method === \"Basic\"",
-     "fieldname": "awaiting_password",
-     "fieldtype": "Check",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Awaiting password"
-     },
-     {
-     "default": "0",
-     "depends_on": "eval: doc.auth_method === \"Basic\"",
-     "fieldname": "ascii_encode_password",
-     "fieldtype": "Check",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Use ASCII encoding for password"
-     },
-     {
-     "description": "e.g. \"Support\", \"Sales\", \"Jerry Yang\"",
-     "fieldname": "email_account_name",
-     "fieldtype": "Data",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Email Account Name",
-     "unique": 1
-     },
-     {
-     "depends_on": "eval:!doc.service",
-     "fieldname": "domain",
-     "fieldtype": "Link",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "in_list_view": 1,
-     "in_standard_filter": 1,
-     "label": "Domain",
-     "options": "Email Domain"
-     },
-     {
-     "depends_on": "eval:!doc.domain",
-     "fieldname": "service",
-     "fieldtype": "Select",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Service",
-     "options": "\nGMail\nSendgrid\nSparkPost\nYahoo Mail\nOutlook.com\nYandex.Mail"
-     },
-     {
-     "fieldname": "mailbox_settings",
-     "fieldtype": "Section Break",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Incoming (POP/IMAP) Settings"
-     },
-     {
-     "default": "0",
-     "fieldname": "enable_incoming",
-     "fieldtype": "Check",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Enable Incoming"
-     },
-     {
-     "default": "0",
-     "depends_on": "eval: !doc.domain && doc.enable_incoming",
-     "fetch_from": "domain.use_imap",
-     "fieldname": "use_imap",
-     "fieldtype": "Check",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Use IMAP"
-     },
-     {
-     "depends_on": "eval:!doc.domain && doc.enable_incoming",
-     "description": "e.g. pop.gmail.com / imap.gmail.com",
-     "fetch_from": "domain.email_server",
-     "fieldname": "email_server",
-     "fieldtype": "Data",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Incoming Server"
-     },
-     {
-     "default": "0",
-     "depends_on": "eval:!doc.domain && doc.enable_incoming",
-     "fetch_from": "domain.use_ssl",
-     "fieldname": "use_ssl",
-     "fieldtype": "Check",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Use SSL"
-     },
-     {
-     "depends_on": "eval:!doc.domain && doc.enable_incoming",
-     "description": "Ignore attachments over this size",
-     "fetch_from": "domain.attachment_limit",
-     "fieldname": "attachment_limit",
-     "fieldtype": "Int",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Attachment Limit (MB)"
-     },
-     {
-     "depends_on": "eval: doc.enable_incoming && !doc.use_imap",
-     "description": "Append as communication against this DocType (must have fields: \"Sender\" and \"Subject\"). These fields can be defined in the email settings section of the appended doctype.",
-     "fieldname": "append_to",
-     "fieldtype": "Link",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "in_standard_filter": 1,
-     "label": "Append To",
-     "options": "DocType"
-     },
-     {
-     "default": "0",
-     "depends_on": "enable_incoming",
-     "description": "e.g. replies@yourcomany.com. All replies will come to this inbox.",
-     "fieldname": "default_incoming",
-     "fieldtype": "Check",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Default Incoming"
-     },
-     {
-     "default": "UNSEEN",
-     "depends_on": "eval: doc.enable_incoming && doc.use_imap",
-     "fieldname": "email_sync_option",
-     "fieldtype": "Select",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Email Sync Option",
-     "options": "ALL\nUNSEEN"
-     },
-     {
-     "default": "250",
-     "depends_on": "eval: doc.enable_incoming && doc.use_imap",
-     "description": "Total number of emails to sync in initial sync process ",
-     "fieldname": "initial_sync_count",
-     "fieldtype": "Select",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Initial Sync Count",
-     "options": "100\n250\n500"
-     },
-     {
-     "depends_on": "enable_incoming",
-     "fieldname": "section_break_13",
-     "fieldtype": "Column Break",
-     "hide_days": 1,
-     "hide_seconds": 1
-     },
-     {
-     "default": "0",
-     "fieldname": "notify_if_unreplied",
-     "fieldtype": "Check",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Notify if unreplied"
-     },
-     {
-     "default": "30",
-     "depends_on": "notify_if_unreplied",
-     "fieldname": "unreplied_for_mins",
-     "fieldtype": "Int",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Notify if unreplied for (in mins)"
-     },
-     {
-     "depends_on": "notify_if_unreplied",
-     "description": "Email Addresses",
-     "fieldname": "send_notification_to",
-     "fieldtype": "Small Text",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Send Notification to"
-     },
-     {
-     "fieldname": "outgoing_mail_settings",
-     "fieldtype": "Section Break",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Outgoing (SMTP) Settings"
-     },
-     {
-     "default": "0",
-     "description": "SMTP Settings for outgoing emails",
-     "fieldname": "enable_outgoing",
-     "fieldtype": "Check",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Enable Outgoing"
-     },
-     {
-     "depends_on": "eval:!doc.domain && doc.enable_outgoing",
-     "description": "e.g. smtp.gmail.com",
-     "fetch_from": "domain.smtp_server",
-     "fieldname": "smtp_server",
-     "fieldtype": "Data",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Outgoing Server"
-     },
-     {
-     "default": "0",
-     "depends_on": "eval:!doc.domain && doc.enable_outgoing",
-     "fetch_from": "domain.use_tls",
-     "fieldname": "use_tls",
-     "fieldtype": "Check",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Use TLS"
-     },
-     {
-     "depends_on": "eval:!doc.domain && doc.enable_outgoing",
-     "description": "If non standard port (e.g. 587). If on Google Cloud, try port 2525.",
-     "fetch_from": "domain.smtp_port",
-     "fieldname": "smtp_port",
-     "fieldtype": "Data",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Port"
-     },
-     {
-     "default": "0",
-     "depends_on": "enable_outgoing",
-     "description": "Notifications and bulk mails will be sent from this outgoing server.",
-     "fieldname": "default_outgoing",
-     "fieldtype": "Check",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Default Outgoing"
-     },
-     {
-     "default": "0",
-     "depends_on": "enable_outgoing",
-     "fieldname": "always_use_account_email_id_as_sender",
-     "fieldtype": "Check",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Always use this email address as sender address"
-     },
-     {
-     "default": "0",
-     "depends_on": "enable_outgoing",
-     "fieldname": "always_use_account_name_as_sender_name",
-     "fieldtype": "Check",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Always use this name as sender name"
-     },
-     {
-     "default": "1",
-     "fieldname": "send_unsubscribe_message",
-     "fieldtype": "Check",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Send unsubscribe message in email"
-     },
-     {
-     "default": "1",
-     "description": "Track if your email has been opened by the recipient.\n<br>\nNote: If you're sending to multiple recipients, even if 1 recipient reads the email, it'll be considered \"Opened\"",
-     "fieldname": "track_email_status",
-     "fieldtype": "Check",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Track Email Status"
-     },
-     {
-     "default": "0",
-     "fieldname": "no_smtp_authentication",
-     "fieldtype": "Check",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Disable SMTP server authentication"
-     },
-     {
-     "collapsible": 1,
-     "collapsible_depends_on": "add_signature",
-     "fieldname": "signature_section",
-     "fieldtype": "Section Break",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Signature"
-     },
-     {
-     "default": "0",
-     "fieldname": "add_signature",
-     "fieldtype": "Check",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Add Signature"
-     },
-     {
-     "depends_on": "add_signature",
-     "fieldname": "signature",
-     "fieldtype": "Text Editor",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Signature"
-     },
-     {
-     "collapsible": 1,
-     "collapsible_depends_on": "enable_auto_reply",
-     "fieldname": "auto_reply",
-     "fieldtype": "Section Break",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Auto Reply"
-     },
-     {
-     "default": "0",
-     "fieldname": "enable_auto_reply",
-     "fieldtype": "Check",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Enable Auto Reply"
-     },
-     {
-     "depends_on": "enable_auto_reply",
-     "description": "ProTip: Add <code>Reference: {{ reference_doctype }} {{ reference_name }}</code> to send document reference",
-     "fieldname": "auto_reply_message",
-     "fieldtype": "Text Editor",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Auto Reply Message"
-     },
-     {
-     "collapsible": 1,
-     "collapsible_depends_on": "eval:frappe.utils.html2text(doc.footer || '')!=''",
-     "fieldname": "set_footer",
-     "fieldtype": "Section Break",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Footer"
-     },
-     {
-     "fieldname": "footer",
-     "fieldtype": "Text Editor",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Footer Content"
-     },
-     {
-     "fieldname": "uidvalidity",
-     "fieldtype": "Data",
-     "hidden": 1,
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "UIDVALIDITY",
-     "no_copy": 1
-     },
-     {
-     "fieldname": "uidnext",
-     "fieldtype": "Int",
-     "hidden": 1,
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "UIDNEXT",
-     "no_copy": 1
-     },
-     {
-     "fieldname": "no_failed",
-     "fieldtype": "Int",
-     "hidden": 1,
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "no failed attempts",
-     "no_copy": 1,
-     "read_only": 1
-     },
-     {
-     "fieldname": "section_break_12",
-     "fieldtype": "Section Break",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Document Linking"
-     },
-     {
-     "default": "0",
-     "description": "For more information, <a class=\"text-muted\" href=\"https://erpnext.com/docs/user/manual/en/setting-up/email/linking-emails-to-document\">click here</a>.",
-     "fieldname": "enable_automatic_linking",
-     "fieldtype": "Check",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Enable Automatic Linking in Documents"
-     },
-     {
-     "depends_on": "eval:!doc.domain && doc.enable_incoming",
-     "description": "If non-standard port (e.g. POP3: 995/110, IMAP: 993/143)",
-     "fieldname": "incoming_port",
-     "fieldtype": "Data",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Port"
-     },
-     {
-     "default": "0",
-     "depends_on": "eval:!doc.domain && doc.enable_outgoing && doc.enable_incoming && doc.use_imap",
-     "fieldname": "append_emails_to_sent_folder",
-     "fieldtype": "Check",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Append Emails to Sent Folder"
-     },
-     {
-     "default": "0",
-     "depends_on": "eval:!doc.domain && doc.enable_outgoing",
-     "fieldname": "use_ssl_for_outgoing",
-     "fieldtype": "Check",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Use SSL"
-     },
-     {
-     "default": "1",
-     "fieldname": "create_contact",
-     "fieldtype": "Check",
-     "hide_days": 1,
-     "hide_seconds": 1,
-     "label": "Create Contacts from Incoming Emails"
-     },
-     {
-     "fieldname": "brand_logo",
-     "fieldtype": "Attach Image",
-     "label": "Brand Logo"
-     },
-     {
-     "fieldname": "authentication_column",
-     "fieldtype": "Section Break",
-     "label": "Authentication"
-     },
-     {
-     "fieldname": "column_break_10",
-     "fieldtype": "Column Break"
-     },
-     {
-     "fieldname": "column_break_18",
-     "fieldtype": "Column Break"
-     },
-     {
-     "fieldname": "column_break_38",
-     "fieldtype": "Column Break"
-     },
-     {
-     "fieldname": "column_break_3",
-     "fieldtype": "Column Break"
-     },
-     {
-     "fieldname": "account_section",
-     "fieldtype": "Section Break",
-     "label": "Account"
-     },
-     {
-     "depends_on": "eval: doc.use_imap && doc.enable_incoming",
-     "fieldname": "imap_folder",
-     "fieldtype": "Table",
-     "label": "IMAP Folder",
-     "options": "IMAP Folder"
-     },
-     {
-     "fieldname": "section_break_25",
-     "fieldtype": "Section Break",
-     "label": "IMAP Details"
-     },
-     {
-     "depends_on": "eval: doc.auth_method === \"OAuth\" && doc.connected_app && doc.connected_user && !doc.backend_app_flow",
-     "fieldname": "authorize_api_access",
-     "fieldtype": "Button",
-     "label": "Authorize API Access"
-     },
-     {
-     "default": "Basic",
-     "fieldname": "auth_method",
-     "fieldtype": "Select",
-     "label": "Method",
-     "options": "Basic\nOAuth"
-     },
-     {
-     "default": "0",
-     "depends_on": "eval:!doc.domain && doc.enable_incoming && doc.use_imap && !doc.use_ssl",
-     "fetch_from": "domain.use_starttls",
-     "fieldname": "use_starttls",
-     "fieldtype": "Check",
-     "label": "Use STARTTLS"
-     },
-     {
-     "depends_on": "eval: doc.auth_method === \"OAuth\"",
-     "fieldname": "connected_app",
-     "fieldtype": "Link",
-     "label": "Connected App",
-     "mandatory_depends_on": "eval: doc.auth_method === \"OAuth\"",
-     "options": "Connected App"
-     },
-     {
-     "depends_on": "eval: doc.auth_method === \"OAuth\" && !doc.backend_app_flow",
-     "fieldname": "connected_user",
-     "fieldtype": "Link",
-     "label": "Connected User",
-     "mandatory_depends_on": "eval: doc.auth_method === \"OAuth\" && !doc.backend_app_flow",
-     "options": "User"
-     },
-     {
-     "default": "0",
-     "depends_on": "eval: doc.auth_method === \"OAuth\"",
-     "fieldname": "backend_app_flow",
-     "fieldtype": "Check",
-     "label": "Authenticate as Service Principal"
-    },
-    {
-     "depends_on": "eval:!doc.domain && doc.enable_outgoing && doc.enable_incoming && doc.use_imap && doc.append_emails_to_sent_folder",
-     "fetch_from": "domain.sent_folder_name",
-     "fieldname": "sent_folder_name",
-     "fieldtype": "Data",
-     "label": "Sent Folder Name"
-    },
-    {
-     "description": "Use this, for example, if all sent emails should also be send to an archive.",
-     "fieldname": "always_bcc",
-     "fieldtype": "Data",
-     "label": "Always BCC Address",
-     "options": "Email"
-    }
+  {
+   "fieldname": "email_id",
+   "fieldtype": "Data",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "in_global_search": 1,
+   "in_list_view": 1,
+   "label": "Email Address",
+   "options": "Email",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: !doc.backend_app_flow",
+   "fieldname": "login_id_is_different",
+   "fieldtype": "Check",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Use different Email ID"
+  },
+  {
+   "depends_on": "login_id_is_different",
+   "fieldname": "login_id",
+   "fieldtype": "Data",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Alternative Email ID"
+  },
+  {
+   "depends_on": "eval: doc.auth_method === \"Basic\"",
+   "fieldname": "password",
+   "fieldtype": "Password",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Password"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.auth_method === \"Basic\"",
+   "fieldname": "awaiting_password",
+   "fieldtype": "Check",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Awaiting password"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.auth_method === \"Basic\"",
+   "fieldname": "ascii_encode_password",
+   "fieldtype": "Check",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Use ASCII encoding for password"
+  },
+  {
+   "description": "e.g. \"Support\", \"Sales\", \"Jerry Yang\"",
+   "fieldname": "email_account_name",
+   "fieldtype": "Data",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Email Account Name",
+   "unique": 1
+  },
+  {
+   "depends_on": "eval:!doc.service",
+   "fieldname": "domain",
+   "fieldtype": "Link",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Domain",
+   "options": "Email Domain"
+  },
+  {
+   "depends_on": "eval:!doc.domain",
+   "fieldname": "service",
+   "fieldtype": "Select",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Service",
+   "options": "\nGMail\nSendgrid\nSparkPost\nYahoo Mail\nOutlook.com\nYandex.Mail"
+  },
+  {
+   "fieldname": "mailbox_settings",
+   "fieldtype": "Section Break",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Incoming (POP/IMAP) Settings"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_incoming",
+   "fieldtype": "Check",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Enable Incoming"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: !doc.domain && doc.enable_incoming",
+   "fetch_from": "domain.use_imap",
+   "fieldname": "use_imap",
+   "fieldtype": "Check",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Use IMAP"
+  },
+  {
+   "depends_on": "eval:!doc.domain && doc.enable_incoming",
+   "description": "e.g. pop.gmail.com / imap.gmail.com",
+   "fetch_from": "domain.email_server",
+   "fieldname": "email_server",
+   "fieldtype": "Data",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Incoming Server"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:!doc.domain && doc.enable_incoming",
+   "fetch_from": "domain.use_ssl",
+   "fieldname": "use_ssl",
+   "fieldtype": "Check",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Use SSL"
+  },
+  {
+   "depends_on": "eval:!doc.domain && doc.enable_incoming",
+   "description": "Ignore attachments over this size",
+   "fetch_from": "domain.attachment_limit",
+   "fieldname": "attachment_limit",
+   "fieldtype": "Int",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Attachment Limit (MB)"
+  },
+  {
+   "depends_on": "eval: doc.enable_incoming && !doc.use_imap",
+   "description": "Append as communication against this DocType (must have fields: \"Sender\" and \"Subject\"). These fields can be defined in the email settings section of the appended doctype.",
+   "fieldname": "append_to",
+   "fieldtype": "Link",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "in_standard_filter": 1,
+   "label": "Append To",
+   "options": "DocType"
+  },
+  {
+   "default": "0",
+   "depends_on": "enable_incoming",
+   "description": "e.g. replies@yourcomany.com. All replies will come to this inbox.",
+   "fieldname": "default_incoming",
+   "fieldtype": "Check",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Default Incoming"
+  },
+  {
+   "default": "UNSEEN",
+   "depends_on": "eval: doc.enable_incoming && doc.use_imap",
+   "fieldname": "email_sync_option",
+   "fieldtype": "Select",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Email Sync Option",
+   "options": "ALL\nUNSEEN"
+  },
+  {
+   "default": "250",
+   "depends_on": "eval: doc.enable_incoming && doc.use_imap",
+   "description": "Total number of emails to sync in initial sync process ",
+   "fieldname": "initial_sync_count",
+   "fieldtype": "Select",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Initial Sync Count",
+   "options": "100\n250\n500"
+  },
+  {
+   "depends_on": "enable_incoming",
+   "fieldname": "section_break_13",
+   "fieldtype": "Column Break",
+   "hide_days": 1,
+   "hide_seconds": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "notify_if_unreplied",
+   "fieldtype": "Check",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Notify if unreplied"
+  },
+  {
+   "default": "30",
+   "depends_on": "notify_if_unreplied",
+   "fieldname": "unreplied_for_mins",
+   "fieldtype": "Int",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Notify if unreplied for (in mins)"
+  },
+  {
+   "depends_on": "notify_if_unreplied",
+   "description": "Email Addresses",
+   "fieldname": "send_notification_to",
+   "fieldtype": "Small Text",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Send Notification to"
+  },
+  {
+   "fieldname": "outgoing_mail_settings",
+   "fieldtype": "Section Break",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Outgoing (SMTP) Settings"
+  },
+  {
+   "default": "0",
+   "description": "SMTP Settings for outgoing emails",
+   "fieldname": "enable_outgoing",
+   "fieldtype": "Check",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Enable Outgoing"
+  },
+  {
+   "depends_on": "eval:!doc.domain && doc.enable_outgoing",
+   "description": "e.g. smtp.gmail.com",
+   "fetch_from": "domain.smtp_server",
+   "fieldname": "smtp_server",
+   "fieldtype": "Data",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Outgoing Server"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:!doc.domain && doc.enable_outgoing",
+   "fetch_from": "domain.use_tls",
+   "fieldname": "use_tls",
+   "fieldtype": "Check",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Use TLS"
+  },
+  {
+   "depends_on": "eval:!doc.domain && doc.enable_outgoing",
+   "description": "If non standard port (e.g. 587). If on Google Cloud, try port 2525.",
+   "fetch_from": "domain.smtp_port",
+   "fieldname": "smtp_port",
+   "fieldtype": "Data",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Port"
+  },
+  {
+   "default": "0",
+   "depends_on": "enable_outgoing",
+   "description": "Notifications and bulk mails will be sent from this outgoing server.",
+   "fieldname": "default_outgoing",
+   "fieldtype": "Check",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Default Outgoing"
+  },
+  {
+   "default": "0",
+   "depends_on": "enable_outgoing",
+   "fieldname": "always_use_account_email_id_as_sender",
+   "fieldtype": "Check",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Always use this email address as sender address"
+  },
+  {
+   "default": "0",
+   "depends_on": "enable_outgoing",
+   "fieldname": "always_use_account_name_as_sender_name",
+   "fieldtype": "Check",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Always use this name as sender name"
+  },
+  {
+   "default": "1",
+   "fieldname": "send_unsubscribe_message",
+   "fieldtype": "Check",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Send unsubscribe message in email"
+  },
+  {
+   "default": "1",
+   "description": "Track if your email has been opened by the recipient.\n<br>\nNote: If you're sending to multiple recipients, even if 1 recipient reads the email, it'll be considered \"Opened\"",
+   "fieldname": "track_email_status",
+   "fieldtype": "Check",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Track Email Status"
+  },
+  {
+   "default": "0",
+   "fieldname": "no_smtp_authentication",
+   "fieldtype": "Check",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Disable SMTP server authentication"
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "add_signature",
+   "fieldname": "signature_section",
+   "fieldtype": "Section Break",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Signature"
+  },
+  {
+   "default": "0",
+   "fieldname": "add_signature",
+   "fieldtype": "Check",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Add Signature"
+  },
+  {
+   "depends_on": "add_signature",
+   "fieldname": "signature",
+   "fieldtype": "Text Editor",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Signature"
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "enable_auto_reply",
+   "fieldname": "auto_reply",
+   "fieldtype": "Section Break",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Auto Reply"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_auto_reply",
+   "fieldtype": "Check",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Enable Auto Reply"
+  },
+  {
+   "depends_on": "enable_auto_reply",
+   "description": "ProTip: Add <code>Reference: {{ reference_doctype }} {{ reference_name }}</code> to send document reference",
+   "fieldname": "auto_reply_message",
+   "fieldtype": "Text Editor",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Auto Reply Message"
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "eval:frappe.utils.html2text(doc.footer || '')!=''",
+   "fieldname": "set_footer",
+   "fieldtype": "Section Break",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Footer"
+  },
+  {
+   "fieldname": "footer",
+   "fieldtype": "Text Editor",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Footer Content"
+  },
+  {
+   "fieldname": "uidvalidity",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "UIDVALIDITY",
+   "no_copy": 1
+  },
+  {
+   "fieldname": "uidnext",
+   "fieldtype": "Int",
+   "hidden": 1,
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "UIDNEXT",
+   "no_copy": 1
+  },
+  {
+   "fieldname": "no_failed",
+   "fieldtype": "Int",
+   "hidden": 1,
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "no failed attempts",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_12",
+   "fieldtype": "Section Break",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Document Linking"
+  },
+  {
+   "default": "0",
+   "description": "For more information, <a class=\"text-muted\" href=\"https://docs.frappe.io/erpnext/user/manual/en/linking-emails-to-document\">click here</a>.",
+   "fieldname": "enable_automatic_linking",
+   "fieldtype": "Check",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Enable Automatic Linking in Documents"
+  },
+  {
+   "depends_on": "eval:!doc.domain && doc.enable_incoming",
+   "description": "If non-standard port (e.g. POP3: 995/110, IMAP: 993/143)",
+   "fieldname": "incoming_port",
+   "fieldtype": "Data",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Port"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:!doc.domain && doc.enable_outgoing && doc.enable_incoming && doc.use_imap",
+   "fieldname": "append_emails_to_sent_folder",
+   "fieldtype": "Check",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Append Emails to Sent Folder"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:!doc.domain && doc.enable_outgoing",
+   "fieldname": "use_ssl_for_outgoing",
+   "fieldtype": "Check",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Use SSL"
+  },
+  {
+   "default": "1",
+   "fieldname": "create_contact",
+   "fieldtype": "Check",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Create Contacts from Incoming Emails"
+  },
+  {
+   "fieldname": "brand_logo",
+   "fieldtype": "Attach Image",
+   "label": "Brand Logo"
+  },
+  {
+   "fieldname": "authentication_column",
+   "fieldtype": "Section Break",
+   "label": "Authentication"
+  },
+  {
+   "fieldname": "column_break_10",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_18",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_38",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_3",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "account_section",
+   "fieldtype": "Section Break",
+   "label": "Account"
+  },
+  {
+   "depends_on": "eval: doc.use_imap && doc.enable_incoming",
+   "fieldname": "imap_folder",
+   "fieldtype": "Table",
+   "label": "IMAP Folder",
+   "options": "IMAP Folder"
+  },
+  {
+   "fieldname": "section_break_25",
+   "fieldtype": "Section Break",
+   "label": "IMAP Details"
+  },
+  {
+   "depends_on": "eval: doc.auth_method === \"OAuth\" && doc.connected_app && doc.connected_user && !doc.backend_app_flow",
+   "fieldname": "authorize_api_access",
+   "fieldtype": "Button",
+   "label": "Authorize API Access"
+  },
+  {
+   "default": "Basic",
+   "fieldname": "auth_method",
+   "fieldtype": "Select",
+   "label": "Method",
+   "options": "Basic\nOAuth"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:!doc.domain && doc.enable_incoming && doc.use_imap && !doc.use_ssl",
+   "fetch_from": "domain.use_starttls",
+   "fieldname": "use_starttls",
+   "fieldtype": "Check",
+   "label": "Use STARTTLS"
+  },
+  {
+   "depends_on": "eval: doc.auth_method === \"OAuth\"",
+   "fieldname": "connected_app",
+   "fieldtype": "Link",
+   "label": "Connected App",
+   "mandatory_depends_on": "eval: doc.auth_method === \"OAuth\"",
+   "options": "Connected App"
+  },
+  {
+   "depends_on": "eval: doc.auth_method === \"OAuth\" && !doc.backend_app_flow",
+   "fieldname": "connected_user",
+   "fieldtype": "Link",
+   "label": "Connected User",
+   "mandatory_depends_on": "eval: doc.auth_method === \"OAuth\" && !doc.backend_app_flow",
+   "options": "User"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.auth_method === \"OAuth\"",
+   "fieldname": "backend_app_flow",
+   "fieldtype": "Check",
+   "label": "Authenticate as Service Principal"
+  },
+  {
+   "depends_on": "eval:!doc.domain && doc.enable_outgoing && doc.enable_incoming && doc.use_imap && doc.append_emails_to_sent_folder",
+   "fetch_from": "domain.sent_folder_name",
+   "fieldname": "sent_folder_name",
+   "fieldtype": "Data",
+   "label": "Sent Folder Name"
+  },
+  {
+   "description": "Use this, for example, if all sent emails should also be send to an archive.",
+   "fieldname": "always_bcc",
+   "fieldtype": "Data",
+   "label": "Always BCC Address",
+   "options": "Email"
+  }
  ],
  "icon": "fa fa-inbox",
  "index_web_pages_for_search": 1,

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -11,6 +11,7 @@ import frappe
 import frappe.sessions
 import frappe.utils
 from frappe import _, is_whitelisted, ping
+from frappe.core.doctype.file.utils import find_file_by_url
 from frappe.core.doctype.server_script.server_script_utils import get_server_script_map
 from frappe.monitor import add_data_to_monitor
 from frappe.permissions import check_doctype_permission
@@ -276,8 +277,8 @@ def download_file(file_url: str):
 	Endpoints : download_file, frappe.core.doctype.file.file.download_file
 	URL Params : file_name = /path/to/file relative to site path
 	"""
-	file: "File" = frappe.get_doc("File", {"file_url": file_url})
-	if not file.is_downloadable():
+	file = find_file_by_url(file_url)
+	if not file:
 		raise frappe.PermissionError
 
 	frappe.local.response.filename = os.path.basename(file_url)

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -336,6 +336,7 @@ def install_app(name, verbose=False, set_as_patched=True, force=False):
 	for after_sync in app_hooks.after_sync or []:
 		frappe.get_attr(after_sync)()  #
 
+	frappe.clear_cache()
 	frappe.flags.in_install = False
 
 
@@ -418,6 +419,7 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False)
 		remove_from_installed_apps(app_name)
 		frappe.get_single("Installed Applications").update_versions()
 		frappe.db.commit()
+		frappe.clear_cache()
 
 	for after_uninstall in app_hooks.after_uninstall or []:
 		frappe.get_attr(after_uninstall)()
@@ -427,6 +429,9 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False)
 
 	click.secho(f"Uninstalled App {app_name} from Site {site}", fg="green")
 	frappe.flags.in_uninstall = False
+
+	if not dry_run:
+		frappe.clear_cache()
 
 
 def _delete_modules(modules: list[str], dry_run: bool) -> list[str]:

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -350,6 +350,7 @@ def add_to_installed_apps(app_name, rebuild_website=True):
 			post_install(rebuild_website)
 
 	frappe.get_single("Installed Applications").update_versions()
+	frappe.db.commit()
 
 
 def remove_from_installed_apps(app_name):

--- a/frappe/integrations/doctype/connected_app/connected_app.py
+++ b/frappe/integrations/doctype/connected_app/connected_app.py
@@ -9,6 +9,7 @@ from requests_oauthlib import OAuth2Session
 
 import frappe
 from frappe import _
+from frappe.integrations.utils import make_get_request
 from frappe.model.document import Document
 
 if any((os.getenv("CI"), frappe.conf.developer_mode, frappe.conf.allow_tests)):
@@ -45,6 +46,12 @@ class ConnectedApp(Document):
 	"""Connect to a remote oAuth Server. Retrieve and store user's access token
 	in a Token Cache.
 	"""
+
+	@frappe.whitelist()
+	def get_openid_configuration(self):
+		if not self.openid_configuration:
+			frappe.throw(_("Please enter OpenID Configuration URL"))
+		return make_get_request(self.openid_configuration)
 
 	def validate(self):
 		base_url = frappe.utils.get_url()

--- a/frappe/integrations/doctype/google_settings/google_settings.js
+++ b/frappe/integrations/doctype/google_settings/google_settings.js
@@ -5,7 +5,7 @@ frappe.ui.form.on("Google Settings", {
 	refresh: function (frm) {
 		frm.dashboard.set_headline(
 			__("For more information, {0}.", [
-				`<a href='https://erpnext.com/docs/user/manual/en/erpnext_integration/google_settings'>${__(
+				`<a href='https://erpnext.com/docs/user/manual/en/google_settings'>${__(
 					"Click here"
 				)}</a>`,
 			])

--- a/frappe/integrations/doctype/social_login_key/social_login_key.py
+++ b/frappe/integrations/doctype/social_login_key/social_login_key.py
@@ -88,6 +88,17 @@ class SocialLoginKey(Document):
 			frappe.throw(
 				_("Please enter Client Secret before social login is enabled"), exc=ClientSecretNotSetError
 			)
+		if self.auth_url_data:
+			try:
+				json.loads(self.auth_url_data)
+			except json.JSONDecodeError:
+				frappe.throw(_("Auth URL data should be valid JSON"))
+
+		if self.api_endpoint_args:
+			try:
+				json.loads(self.api_endpoint_args)
+			except json.JSONDecodeError:
+				frappe.throw(_("API Endpoint Args should be valid JSON"))
 
 	def set_icon(self):
 		icon_map = {

--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -5,6 +5,8 @@ import contextlib
 import functools
 import json
 import os
+import threading
+import time
 from textwrap import dedent
 
 import frappe
@@ -89,6 +91,7 @@ class SiteMigration:
 		"""Run operations that should be run post schema updation processes
 		This should be executed irrespective of outcome
 		"""
+		self.db_monitor.stop()
 		frappe.translate.clear_cache()
 		clear_website_cache()
 		clear_notifications()
@@ -178,6 +181,8 @@ class SiteMigration:
 			frappe.init(site=site)
 			frappe.connect()
 
+		self.db_monitor = DBQueryProgressMonitor()
+
 		if not self.required_services_running():
 			raise SystemExit(1)
 
@@ -190,3 +195,65 @@ class SiteMigration:
 			finally:
 				self.tearDown()
 				frappe.destroy()
+
+
+class DBQueryProgressMonitor(threading.Thread):
+	POLL_DURATION = 10
+
+	def __init__(self) -> None:
+		super().__init__()
+		self.site = frappe.local.site
+		self.daemon = True
+		self._running = threading.Event()
+		if frappe.db.db_type == "mariadb":
+			self.conn_id = frappe.db.sql("select connection_id()")[0][0]
+			self.start()
+
+	def run(self):
+		if self._running.is_set():
+			return
+		self._running.set()
+
+		frappe.init(self.site)
+		frappe.connect()
+
+		while self._running.is_set():
+			time.sleep(self.POLL_DURATION)
+			queries = frappe.db.sql(
+				"SELECT * FROM information_schema.PROCESSLIST WHERE ID = %s",
+				self.conn_id,
+				as_dict=True,
+			)
+
+			if not queries:
+				continue
+
+			query = frappe._dict(queries[0])
+			time_taken = query.TIME
+			if not time_taken or time_taken < 5:
+				continue
+
+			msg = []
+			command = query.COMMAND or ""
+			msg.append(f"Command: {command}")
+			msg.append(f"Time: {time_taken}s")
+			msg.append(f"State: {query.STATE or 'N/A'}")
+			if query.PROGRESS:
+				msg.append(f"Progress: {query.PROGRESS}%")
+
+			if command and command == "Query":
+				sql_query = query.INFO or ""
+				sql_query = sql_query.replace("\r", "").replace("\n", " ").replace("\t", " ")
+				if len(sql_query) > 100:
+					sql_query = sql_query[:40] + " ... " + sql_query[-20:]
+				msg.append(f"Query: {sql_query}")
+
+			msg = "\r" + " | ".join(msg)
+			if self._running.is_set():
+				print(msg, end="", flush=True)
+
+		frappe.destroy()
+
+	def stop(self):
+		print("")  # Clear current line
+		self._running.clear()

--- a/frappe/model/create_new.py
+++ b/frappe/model/create_new.py
@@ -146,8 +146,8 @@ def set_dynamic_default_values(doc, parent_doc, parentfield):
 			elif df.fieldtype == "Datetime" and df.default.lower() == "now":
 				doc[df.fieldname] = now_datetime()
 
-		if df.fieldtype == "Time":
-			doc[df.fieldname] = nowtime()
+			elif df.fieldtype == "Time" and df.default.lower() == "now":
+				doc[df.fieldname] = nowtime()
 
 	if parent_doc:
 		doc["parent"] = parent_doc.name

--- a/frappe/model/create_new.py
+++ b/frappe/model/create_new.py
@@ -146,8 +146,8 @@ def set_dynamic_default_values(doc, parent_doc, parentfield):
 			elif df.fieldtype == "Datetime" and df.default.lower() == "now":
 				doc[df.fieldname] = now_datetime()
 
-			elif df.fieldtype == "Time" and df.default.lower() == "now":
-				doc[df.fieldname] = nowtime()
+		if df.fieldtype == "Time":
+			doc[df.fieldname] = nowtime()
 
 	if parent_doc:
 		doc["parent"] = parent_doc.name

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -265,6 +265,14 @@ frappe.Application = class Application {
 			if (frappe.boot.print_css) {
 				frappe.dom.set_style(frappe.boot.print_css, "print-style");
 			}
+
+			let current_app = localStorage.current_app;
+			if (current_app) {
+				frappe.boot.setup_complete =
+					frappe.boot.setup_wizard_not_required_apps?.includes(current_app) ||
+					frappe.boot.setup_wizard_completed_apps?.includes(current_app);
+			}
+
 			frappe.user.name = frappe.boot.user.name;
 			frappe.router.setup();
 		} else {

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -266,13 +266,7 @@ frappe.Application = class Application {
 				frappe.dom.set_style(frappe.boot.print_css, "print-style");
 			}
 
-			let current_app = localStorage.current_app;
-			if (current_app) {
-				frappe.boot.setup_complete =
-					frappe.boot.setup_wizard_not_required_apps?.includes(current_app) ||
-					frappe.boot.setup_wizard_completed_apps?.includes(current_app);
-			}
-
+			frappe.boot.setup_complete = frappe.boot.sysdefaults["setup_complete"];
 			frappe.user.name = frappe.boot.user.name;
 			frappe.router.setup();
 		} else {

--- a/frappe/public/js/frappe/form/column.js
+++ b/frappe/public/js/frappe/form/column.js
@@ -22,7 +22,7 @@ export default class Column {
 		if (this.df.description) {
 			$(`
 				<p class="col-sm-12 form-column-description">
-					${__(this.df.description)}
+					${__(this.df.description, null, this.df.parent)}
 				</p>
 			`).prependTo(this.wrapper);
 		}

--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -69,7 +69,6 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 		if (this.df.options == "URL") {
 			this.setup_url_field();
 		}
-
 		if (this.df.options == "Barcode") {
 			this.setup_barcode_field();
 		}
@@ -147,6 +146,9 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 		this.$scan_btn.toggle(true);
 
 		const me = this;
+		$(document).on("frappe.ui.Dialog:shown", function () {
+			me.$scan_btn.toggle(true);
+		});
 		this.$scan_btn.on("click", "a", () => {
 			new frappe.ui.Scanner({
 				dialog: true,

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -17,7 +17,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 				<a class="btn-clear" style="display: inline-block;" title="${__("Clear Link")}">
 					${frappe.utils.icon("close", "xs", "es-icon")}
 				</a>
-				<a class="btn-open" style="display: inline-block;" title="${__("Open Link")}">
+				<a class="btn-open" tabIndex='-1' style="display: inline-block;" title="${__("Open Link")}">
 					${frappe.utils.icon("arrow-right", "xs")}
 				</a>
 			</span>

--- a/frappe/public/js/frappe/form/controls/table.js
+++ b/frappe/public/js/frappe/form/controls/table.js
@@ -15,7 +15,22 @@ frappe.ui.form.ControlTable = class ControlTable extends frappe.ui.form.Control 
 		if (this.frm) {
 			this.frm.grids[this.frm.grids.length] = this;
 		}
-
+		const me = this;
+		this.$wrapper.on("keydown", (e) => {
+			if (e.which == 9) {
+				if (e.shiftKey) {
+					let row_idx = me.set_current_row(e.target);
+					if (row_idx) {
+						this.grid.grid_rows[row_idx - 1].toggle_editable_row(true);
+					}
+				} else {
+					if (this.grid.grid_rows.length > 0)
+						this.grid.grid_rows[this.grid.grid_rows.length - 1].toggle_editable_row(
+							true
+						);
+				}
+			}
+		});
 		this.$wrapper.on("paste", ":text", (e) => {
 			const table_field = this.df.fieldname;
 			const grid = this.grid;
@@ -153,5 +168,14 @@ frappe.ui.form.ControlTable = class ControlTable extends frappe.ui.form.Control 
 	}
 	check_all_rows() {
 		this.$wrapper.find(".grid-row-check")[0].click();
+	}
+	set_current_row(target) {
+		let current_row = null;
+		for (let i = 0; i < this.grid.grid_rows.length; i++) {
+			if (this.grid.grid_rows[i].wrapper.get(0).contains(target)) {
+				current_row = i + 1;
+			}
+		}
+		return current_row;
 	}
 };

--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -553,6 +553,7 @@ class FormTimeline extends BaseTimeline {
 			last_email: communication_doc,
 			subject: communication_doc && communication_doc.subject,
 			reply_all: reply_all,
+			sender: communication_doc?.sender,
 		};
 
 		const email_accounts = frappe.boot.email_accounts

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -62,7 +62,7 @@ export default class Grid {
 	make() {
 		let template = `
 			<div class="grid-field">
-				<label class="control-label">${__(this.df.label || "")}</label>
+				<label class="control-label">${__(this.df.label || "", null, this.df.parent)}</label>
 				<span class="help"></span>
 				<p class="text-muted small grid-description"></p>
 				<div class="grid-custom-buttons"></div>

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -352,6 +352,7 @@ export default class Grid {
 			frm: this.frm,
 			grid: this,
 			configure_columns: true,
+			header_row: true,
 		});
 
 		this.header_search = new GridRow({
@@ -909,7 +910,7 @@ export default class Grid {
 
 		setTimeout(() => {
 			this.grid_rows[idx].row
-				.find('input[type="Text"],textarea,select')
+				.find('input[type="checkbox"],input[type="Text"],textarea,select')
 				.filter(":visible:first")
 				.focus();
 		}, 100);

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -255,6 +255,10 @@ export default class GridRow {
 				? this.doc.idx
 				: __("No.", null, "Title of the 'row number' column");
 
+			if (this.header_row) {
+				this.row_check_html = $(this.row_check_html).attr("tabindex", -1).get(0).outerHTML;
+			}
+
 			this.row_check = $(
 				`<div class="row-check sortable-handle col">
 					${this.row_check_html}
@@ -335,7 +339,7 @@ export default class GridRow {
 		if (this.doc && !this.grid.df.in_place_edit) {
 			// remove row
 			if (!this.open_form_button) {
-				this.open_form_button = $('<div class="col"></div>').appendTo(this.row);
+				this.open_form_button = $('<button class="col"></button>').appendTo(this.row);
 
 				if (!this.configure_columns) {
 					const edit_msg = __("Edit", "", "Edit grid row");
@@ -349,6 +353,14 @@ export default class GridRow {
 							me.toggle_view();
 							return false;
 						});
+					$(this.open_form_button)
+						.parent()
+						.on("keydown", function (ev) {
+							if (ev.key == "Enter") {
+								me.toggle_view();
+								return false;
+							}
+						});
 
 					this.open_form_button.tooltip({ delay: { show: 600, hide: 100 } });
 				}
@@ -357,6 +369,10 @@ export default class GridRow {
 					// narrow
 					this.open_form_button.css({ "margin-right": "-2px" });
 				}
+				// focus open form button after escape
+				$(document).on("escape", function () {
+					me.open_form_button.parent().focus();
+				});
 			}
 		}
 	}
@@ -1173,7 +1189,6 @@ export default class GridRow {
 		this.on_grid_fields_dict[df.fieldname] = field;
 		this.on_grid_fields.push(field);
 	}
-
 	set_arrow_keys(field) {
 		var me = this;
 		let ignore_fieldtypes = ["Text", "Small Text", "Code", "Text Editor", "HTML Editor"];
@@ -1216,28 +1231,7 @@ export default class GridRow {
 				};
 
 				// TAB
-				if (e.which === TAB && !e.shiftKey) {
-					var last_column = me.wrapper.find(":input:enabled:last").get(0);
-					var is_last_column = $(this).attr("data-last-input") || last_column === this;
-
-					if (is_last_column) {
-						// last row
-						if (me.doc.idx === values.length) {
-							setTimeout(function () {
-								me.grid.add_new_row(null, null, true);
-								me.grid.grid_rows[
-									me.grid.grid_rows.length - 1
-								].toggle_editable_row();
-								me.grid.set_focus_on_row();
-							}, 100);
-						} else {
-							// last column before last row
-							me.grid.grid_rows[me.doc.idx].toggle_editable_row();
-							me.grid.set_focus_on_row(me.doc.idx);
-							return false;
-						}
-					}
-				} else if (e.which === UP_ARROW) {
+				if (e.which === UP_ARROW) {
 					if (me.doc.idx > 1) {
 						var prev = me.grid.grid_rows[me.doc.idx - 2];
 						if (move_up_down(prev)) {
@@ -1334,7 +1328,6 @@ export default class GridRow {
 			this.hide_form();
 		}
 		callback && callback();
-
 		return this;
 	}
 	show_form() {
@@ -1347,6 +1340,7 @@ export default class GridRow {
 				row: this,
 			});
 		}
+		this.grid_form.wrapper.css("display", "block");
 		this.grid_form.render();
 		this.row.toggle(false);
 		// this.form_panel.toggle(true);
@@ -1391,7 +1385,11 @@ export default class GridRow {
 		}
 		this.refresh();
 		if (cur_frm) cur_frm.cur_grid = null;
+		if (this.grid_form) {
+			this.grid_form.wrapper.css("display", "none");
+		}
 		this.wrapper.removeClass("grid-row-open");
+		this.open_form_button.parent().focus();
 	}
 	open_prev() {
 		if (!this.doc) return;

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -36,7 +36,6 @@ frappe.ui.form.Layout = class Layout {
 			this.setup_tabbed_layout();
 		}
 
-		this.setup_tab_events();
 		this.frm && this.setup_tooltip_events();
 		this.render();
 	}

--- a/frappe/public/js/frappe/form/section.js
+++ b/frappe/public/js/frappe/form/section.js
@@ -78,8 +78,14 @@ export default class Section {
 			this.collapse_link = this.head.on("click", () => {
 				this.collapse();
 			});
+			const me = this;
+			this.collapse_link.enterKey(function () {
+				me.collapse();
+			});
 			this.set_icon();
 			this.indicator.show();
+			this.head.attr("tabindex", 0);
+			this.indicator.attr("tabindex", 0);
 		}
 	}
 

--- a/frappe/public/js/frappe/form/tab.js
+++ b/frappe/public/js/frappe/form/tab.js
@@ -16,14 +16,14 @@ export default class Tab {
 		const id = `${frappe.scrub(this.doctype, "-")}-${this.df.fieldname}`;
 		this.tab_link = $(`
 			<li class="nav-item">
-				<a class="nav-link ${this.df.active ? "active" : ""}" id="${id}-tab"
+				<button class="nav-link ${this.df.active ? "active" : ""}" id="${id}-tab"
 					data-toggle="tab"
 					data-fieldname="${this.df.fieldname}"
 					href="#${id}"
 					role="tab"
 					aria-controls="${id}">
-						${__(this.label)}
-				</a>
+					${__(this.label)}
+				</button>
 			</li>
 		`).appendTo(this.tab_link_container);
 

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -217,7 +217,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 				let label = __("New Name");
 				if (me.frm.meta.autoname && me.frm.meta.autoname.startsWith("field:")) {
 					let fieldname = me.frm.meta.autoname.split(":")[1];
-					label = __("New {0}", [me.frm.get_docfield(fieldname).label]);
+					label = __("New {0}", [__(me.frm.get_docfield(fieldname).label)]);
 					is_title_field_same_as_autoname = fieldname === title_field;
 				}
 

--- a/frappe/public/js/frappe/module_editor.js
+++ b/frappe/public/js/frappe/module_editor.js
@@ -1,7 +1,8 @@
 frappe.ModuleEditor = class ModuleEditor {
-	constructor(frm, wrapper) {
+	constructor(frm, wrapper, disable) {
 		this.frm = frm;
 		this.wrapper = wrapper;
+		this.disable = disable;
 		const block_modules = this.frm.doc.block_modules.map((row) => row.module);
 		this.multicheck = frappe.ui.form.make_control({
 			parent: wrapper,
@@ -27,12 +28,18 @@ frappe.ModuleEditor = class ModuleEditor {
 			render_input: true,
 		});
 	}
+	set_enable_disable() {
+		$(this.wrapper)
+			.find('input[type="checkbox"]')
+			.attr("disabled", this.disable ? true : false);
+	}
 
 	show() {
 		const block_modules = this.frm.doc.block_modules.map((row) => row.module);
 		const all_modules = this.frm.doc.__onload.all_modules;
 		this.multicheck.selected_options = all_modules.filter((m) => !block_modules.includes(m));
 		this.multicheck.refresh_input();
+		this.set_enable_disable();
 	}
 
 	set_modules_in_table() {

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -637,17 +637,17 @@ frappe.request.report_error = function (xhr, request_opts) {
 };
 
 frappe.request.cleanup_request_opts = function (request_opts) {
-	var doc = (request_opts.args || {}).doc;
+	let doc = (request_opts.args || {}).doc;
 	if (doc) {
 		doc = JSON.parse(doc);
-		$.each(Object.keys(doc), function (i, key) {
-			if (key.indexOf("password") !== -1 && doc[key]) {
-				// mask the password
-				doc[key] = "*****";
-			}
-		});
+		frappe.utils.mask_passwords(doc);
 		request_opts.args.doc = JSON.stringify(doc);
 	}
+
+	if (request_opts.args) {
+		frappe.utils.mask_passwords(request_opts.args);
+	}
+
 	return request_opts;
 };
 

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -143,12 +143,15 @@ frappe.router = {
 		if (!frappe.app) return;
 
 		let sub_path = this.get_sub_path();
-		let current_app = localStorage.current_app;
 
+<<<<<<< HEAD
 		if (
 			frappe.boot.setup_complete ||
 			(current_app && frappe.boot.setup_wizard_not_required_apps?.includes(current_app))
 		) {
+=======
+		if (frappe.boot.setup_complete) {
+>>>>>>> b4686d83e6 (fix: update `setup_complete` based on current app)
 			!frappe.re_route["setup-wizard"] && (frappe.re_route["setup-wizard"] = "app");
 		} else if (!sub_path.startsWith("setup-wizard")) {
 			frappe.re_route["setup-wizard"] && delete frappe.re_route["setup-wizard"];

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -144,14 +144,7 @@ frappe.router = {
 
 		let sub_path = this.get_sub_path();
 
-<<<<<<< HEAD
-		if (
-			frappe.boot.setup_complete ||
-			(current_app && frappe.boot.setup_wizard_not_required_apps?.includes(current_app))
-		) {
-=======
 		if (frappe.boot.setup_complete) {
->>>>>>> b4686d83e6 (fix: update `setup_complete` based on current app)
 			!frappe.re_route["setup-wizard"] && (frappe.re_route["setup-wizard"] = "app");
 		} else if (!sub_path.startsWith("setup-wizard")) {
 			frappe.re_route["setup-wizard"] && delete frappe.re_route["setup-wizard"];

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -144,7 +144,11 @@ frappe.router = {
 
 		let sub_path = this.get_sub_path();
 
-		if (frappe.boot.setup_complete) {
+		if (
+			frappe.boot.setup_complete ||
+			(current_app && frappe.boot.setup_wizard_not_required_apps?.includes(current_app)) ||
+			(current_app && frappe.boot.setup_wizard_completed_apps?.includes(current_app))
+		) {
 			!frappe.re_route["setup-wizard"] && (frappe.re_route["setup-wizard"] = "app");
 		} else if (!sub_path.startsWith("setup-wizard")) {
 			frappe.re_route["setup-wizard"] && delete frappe.re_route["setup-wizard"];

--- a/frappe/public/js/frappe/ui/keyboard.js
+++ b/frappe/public/js/frappe/ui/keyboard.js
@@ -322,6 +322,7 @@ frappe.ui.keyCode = {
 function handle_escape_key() {
 	close_grid_and_dialog();
 	document.activeElement?.blur();
+	$(document).trigger("escape");
 }
 
 function close_grid_and_dialog() {
@@ -339,3 +340,14 @@ function close_grid_and_dialog() {
 		return false;
 	}
 }
+
+$.fn.enterKey = function (fnc) {
+	return this.each(function () {
+		$(this).keypress(function (ev) {
+			var keycode = ev.keyCode ? ev.keyCode : ev.which;
+			if (keycode == "13") {
+				fnc.call(this, ev);
+			}
+		});
+	});
+};

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1775,26 +1775,6 @@ Object.assign(frappe.utils, {
 			__("Generate Tracking URL")
 		);
 	},
-<<<<<<< HEAD
-=======
-	/**
-	 * Checks if a value is empty.
-	 *
-	 * Returns false for: "hello", 0, 1, 3.1415, {"a": 1}, [1, 2, 3]
-	 * Returns true for: "", null, undefined, {}, []
-	 *
-	 * @param {*} value - The value to check.
-	 * @returns {boolean} - Returns `true` if the value is empty, `false` otherwise.
-	 */
-	is_empty(value) {
-		if (!value && value !== 0) return true;
-
-		if (typeof value === "object")
-			return (Array.isArray(value) ? value : Object.keys(value)).length === 0;
-
-		return false;
-	},
-
 	/**
 	 * Masks passwords in an object by replacing the values of keys containing
 	 * "password" or "passphrase" with "*****".
@@ -1809,5 +1789,4 @@ Object.assign(frappe.utils, {
 			}
 		}
 	},
->>>>>>> f90c7b6e09 (fix: mask passwords (#33635))
 });

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1775,4 +1775,39 @@ Object.assign(frappe.utils, {
 			__("Generate Tracking URL")
 		);
 	},
+<<<<<<< HEAD
+=======
+	/**
+	 * Checks if a value is empty.
+	 *
+	 * Returns false for: "hello", 0, 1, 3.1415, {"a": 1}, [1, 2, 3]
+	 * Returns true for: "", null, undefined, {}, []
+	 *
+	 * @param {*} value - The value to check.
+	 * @returns {boolean} - Returns `true` if the value is empty, `false` otherwise.
+	 */
+	is_empty(value) {
+		if (!value && value !== 0) return true;
+
+		if (typeof value === "object")
+			return (Array.isArray(value) ? value : Object.keys(value)).length === 0;
+
+		return false;
+	},
+
+	/**
+	 * Masks passwords in an object by replacing the values of keys containing
+	 * "password" or "passphrase" with "*****".
+	 *
+	 * @param {Object} obj - The object to mask passwords in.
+	 */
+	mask_passwords(obj) {
+		const KEYWORDS_TO_MASK = ["password", "passphrase"];
+		for (const key of Object.keys(obj)) {
+			if (KEYWORDS_TO_MASK.some((keyword) => key.includes(keyword)) && obj[key]) {
+				obj[key] = "*****";
+			}
+		}
+	},
+>>>>>>> f90c7b6e09 (fix: mask passwords (#33635))
 });

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -332,8 +332,11 @@ frappe.views.CommunicationComposer = class {
 			if (this.last_email.sender == this.sender) {
 				this.recipients = this.last_email.recipients;
 			}
-			this.cc = this.last_email.cc;
-			this.bcc = this.last_email.bcc;
+
+			if (this.reply_all) {
+				this.cc = this.last_email.cc;
+				this.bcc = this.last_email.bcc;
+			}
 		}
 
 		if (!this.forward && !this.recipients) {

--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -82,14 +82,17 @@ export default class NumberCardWidget extends Widget {
 			type: is_document_type ? "doctype" : "report",
 			is_query_report: !is_document_type,
 		});
-
+		const filters = this.get_filters();
 		if (is_document_type) {
-			const filters = JSON.parse(this.card_doc.filters_json);
 			frappe.route_options = filters.reduce((acc, filter) => {
 				return Object.assign(acc, {
 					[`${filter[0]}.${filter[1]}`]: [filter[2], filter[3]],
 				});
 			}, {});
+		} else {
+			if (filters && Object.keys(filters).length) {
+				frappe.route_options = filters;
+			}
 		}
 
 		frappe.set_route(route);

--- a/frappe/public/scss/common/buttons.scss
+++ b/frappe/public/scss/common/buttons.scss
@@ -82,6 +82,9 @@
 		background-color: var(--btn-default-hover-bg);
 		color: var(--text-color);
 	}
+	&:focus {
+		box-shadow: var(--focus-default) !important;
+	}
 }
 
 .btn.btn-default {

--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -105,6 +105,10 @@ select.form-control {
 		width: 100%;
 	}
 
+	ul {
+		min-width: 300px;
+	}
+
 	li {
 		padding: var(--padding-sm);
 	}

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -96,6 +96,9 @@
 .grid-body .data-row {
 	@include get_textstyle("sm", "regular");
 	color: var(--text-muted);
+	button.col:focus {
+		outline: 1px solid #c9c9c9;
+	}
 }
 
 .grid-empty,

--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -54,6 +54,12 @@
 			margin-left: 10px;
 			position: relative;
 			padding: 0px;
+			&:focus {
+				outline: 1px solid #c9c9c9;
+			}
+		}
+		&:focus {
+			outline: 1px solid #c9c9c9;
 		}
 	}
 
@@ -430,11 +436,16 @@
 				color: var(--text-muted);
 				padding: 10px 0;
 				margin: 0 var(--margin-md);
-
+				background-color: var(--card-bg);
+				border: 0;
 				&.active {
 					font-weight: 600;
 					border-bottom: 1px solid var(--primary);
 					color: var(--text-color);
+				}
+				&:focus {
+					outline: none;
+					font-weight: 600;
 				}
 			}
 		}

--- a/frappe/templates/emails/file_backup_notification.html
+++ b/frappe/templates/emails/file_backup_notification.html
@@ -1,6 +1,6 @@
 Hello,
 
 <br>
-<p> {{ _("Please use following links to download file backup.") </p>
-<p> {{ _("Public Files Backup:") <a href='{{ backup_path_files }}'>{{ backup_path_files }}</a> </p>
-<p> {{ _("Private Files Backup:") <a href='{{ backup_path_private_files }}'>{{ backup_path_private_files }}</a> </p>
+<p> {{ _("Please use following links to download file backup.") }} </p>
+<p> {{ _("Public Files Backup:") }} <a href='{{ backup_path_files }}'>{{ backup_path_files }}</a> </p>
+<p> {{ _("Private Files Backup:") }} <a href='{{ backup_path_private_files }}'>{{ backup_path_private_files }}</a> </p>

--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -265,6 +265,19 @@ class NestedSet(Document):
 		if self.meta.get("nsm_parent_field"):
 			self.nsm_parent_field = self.meta.nsm_parent_field
 
+	def after_insert(self):
+		if (
+			frappe.flags.in_import
+			or frappe.flags.in_patch
+			or frappe.flags.in_migrate
+			or frappe.flags.in_install
+		):
+			return
+
+		# Clear user permissions cache, otherwise user can't access the new document
+		if frappe.db.exists("User Permission", {"user": frappe.session.user, "allow": self.doctype}):
+			frappe.cache.hdel("user_permissions", frappe.session.user)
+
 	def on_update(self):
 		update_nsm(self)
 		self.validate_ledger()

--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -25,8 +25,7 @@ def get_excel_date_format():
 	time_format = frappe.get_system_settings("time_format")
 
 	# Excel-compatible format
-	date_format = date_format.upper().replace("YYYY", "yyyy").replace("DD", "dd").replace("MM", "mm")
-	time_format = time_format.upper().replace("HH", "hh").replace("MM", "mm").replace("SS", "ss")
+	date_format = date_format.replace("mm", "MM")
 
 	return date_format, time_format
 

--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+import datetime
 import re
 from io import BytesIO
 
 import openpyxl
 import xlrd
 from openpyxl import load_workbook
+from openpyxl.cell import WriteOnlyCell
 from openpyxl.styles import Font
 from openpyxl.utils import get_column_letter
 from openpyxl.workbook.child import INVALID_TITLE_REGEX
@@ -16,6 +18,11 @@ from frappe.utils.html_utils import unescape_html
 ILLEGAL_CHARACTERS_RE = re.compile(
 	r"[\000-\010]|[\013-\014]|[\016-\037]|\uFEFF|\uFFFE|\uFFFF|[\uD800-\uDFFF]"
 )
+
+
+def get_excel_date_format():
+	frappe_format = frappe.get_system_settings("date_format") or "yyyy-mm-dd"
+	return frappe_format.upper().replace("YYYY", "yyyy").replace("DD", "dd").replace("MM", "mm")
 
 
 # return xlsx file object
@@ -34,6 +41,8 @@ def make_xlsx(data, sheet_name, wb=None, column_widths=None):
 	row1 = ws.row_dimensions[1]
 	row1.font = Font(name="Calibri", bold=True)
 
+	date_format = get_excel_date_format()
+
 	for row in data:
 		clean_row = []
 		for item in row:
@@ -46,7 +55,15 @@ def make_xlsx(data, sheet_name, wb=None, column_widths=None):
 				# Remove illegal characters from the string
 				value = ILLEGAL_CHARACTERS_RE.sub("", value)
 
-			clean_row.append(value)
+			if isinstance(value, datetime.date | datetime.datetime):
+				if isinstance(value, datetime.datetime):
+					date_format += " HH:MM:SS"
+
+				cell = WriteOnlyCell(ws, value=value)
+				cell.number_format = date_format
+				clean_row.append(cell)
+			else:
+				clean_row.append(value)
 
 		ws.append(clean_row)
 

--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -21,8 +21,14 @@ ILLEGAL_CHARACTERS_RE = re.compile(
 
 
 def get_excel_date_format():
-	frappe_format = frappe.get_system_settings("date_format") or "yyyy-mm-dd"
-	return frappe_format.upper().replace("YYYY", "yyyy").replace("DD", "dd").replace("MM", "mm")
+	date_format = frappe.get_system_settings("date_format")
+	time_format = frappe.get_system_settings("time_format")
+
+	# Excel-compatible format
+	date_format = date_format.upper().replace("YYYY", "yyyy").replace("DD", "dd").replace("MM", "mm")
+	time_format = time_format.upper().replace("HH", "hh").replace("MM", "mm").replace("SS", "ss")
+
+	return date_format, time_format
 
 
 # return xlsx file object
@@ -41,7 +47,7 @@ def make_xlsx(data, sheet_name, wb=None, column_widths=None):
 	row1 = ws.row_dimensions[1]
 	row1.font = Font(name="Calibri", bold=True)
 
-	date_format = get_excel_date_format()
+	date_format, time_format = get_excel_date_format()
 
 	for row in data:
 		clean_row = []
@@ -56,11 +62,12 @@ def make_xlsx(data, sheet_name, wb=None, column_widths=None):
 				value = ILLEGAL_CHARACTERS_RE.sub("", value)
 
 			if isinstance(value, datetime.date | datetime.datetime):
+				number_format = date_format
 				if isinstance(value, datetime.datetime):
-					date_format += " HH:MM:SS"
+					number_format = f"{date_format} {time_format}"
 
 				cell = WriteOnlyCell(ws, value=value)
-				cell.number_format = date_format
+				cell.number_format = number_format
 				clean_row.append(cell)
 			else:
 				clean_row.append(value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     # We depend on internal attributes,
     # do NOT add loose requirements on PyMySQL versions.
     "PyMySQL==1.1.1",
-    "pypdf~=3.17.0",
+    "pypdf~=6.0.0",
     "PyPika==0.48.9",
     "PyQRCode~=1.2.1",
     "PyYAML~=6.0.2",


### PR DESCRIPTION
### Title:

Sync Frappe v15 Code Changes from Aug 1st to 15th

### Scenario Covered:
fix: rename_modal_translation (#28937) (#28952)
 
fix: dont set assets_json during build (#33051) (#33519)
fix: remove default value from time field (#33515)
fix: clear all cache after uninstalling apps (#33524)
Revert "fix: remove default value from time field (backport #33515)" (#33526)
 
refactor: Add desciption how to use Token based Authentication
fix: api_key and api_secret in generate_keys API
refactor: Implement dialog to display and download API key and secret
fix: Mask API secret in dialog for security
refactor: Minor changes
refactor: Not hiding dialog of API token when click outside
refactor: use proper download icon
refactor: add confirmation dialog before closing API details dialog
refactor: update dialog title
fix: Include copy functionality for API key details
chore: Remove redundant variable declaration
fix: Hide dialog after copying/downloading API key details
chore: UI cleanup
 
fix: improve warning message copy
fix: improve copy for token based auth docs link
fix(Login): don't prevent login if encryption key is invalid (backport #28401) (#33545)
fix: jinja template had missing }} (#33541) (#33542)
chore(release): Bumped to Version 15.76.0
 
fix: Commit changes to installed apps (#33550) (#33552)
fix: don't carry forward cc/bcc if not reply all
fix: allow download via API, if at least one file copy is downloadable (backport #33560) (#33565)'
 
fix: set sender in compose mail if from timeline (#33562) (#33569)
 
fix: show null as string if value is null (#33577) (#33582)
fix(ui): MultiSelect Field to have same min-width as link field (#33580) (#33581)
fix: documentation link for email linking to doc (#33578) (#33583)
 
chore: resolve merge conflict
chore: rename label
 
refactor: fetch openID config in backend (#33586) (#33599)
fix: version diff for empty datetime fields (#33605) (#33608)
 
feat: Allow local translation as input for doctype (backport #33585) (#33602)
fix: show barcode icon in dialog
fix: keyboard navigation via tab on forms (backport #33609) (#33615)
chore(release): Bumped to Version 15.77.0
 
fix(restore): check for AES instead of cipher to detect encrypted backup
fix(nestedset): clear user permissions cache when a new doc is create, if applicable
 
fix: validate social login key JSON fields (#33622) (#33642)
 
feat: format date and datetime fields on export
refactor: fetch time format dynamic
refactor: only replace month for compatibility

