### PR TITLE
Sync Frappe v15 Code Changes from Oct to Nov

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         exclude: ".*json$|.*txt$|.*csv|.*md|.*svg"
       - id: check-yaml
       - id: no-commit-to-branch
-        args: ['--branch','develop','--branch','pre-prod','--branch','pre-prod-develop','--branch','version-15']
+        args: ['--branch', 'version-15-hotfix']
       - id: check-merge-conflict
       - id: check-ast
       - id: check-json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 exclude: 'node_modules|.git'
 default_stages: [pre-commit]
+default_install_hook_types: [pre-commit, commit-msg]
 fail_fast: false
 
 
@@ -71,6 +72,13 @@ repos:
                 frappe/templates/includes/.*|
                 frappe/public/js/lib/.*
             )$
+
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.22.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ['conventional-changelog-conventionalcommits']
 
 ci:
     autoupdate_schedule: weekly

--- a/babel_extractors.csv
+++ b/babel_extractors.csv
@@ -1,6 +1,7 @@
 **/hooks.py,frappe.gettext.extractors.navbar.extract
 **/doctype/*/*.json,frappe.gettext.extractors.doctype.extract
 **/workspace/*/*.json,frappe.gettext.extractors.workspace.extract
+**/web_form/*/*.json,frappe.gettext.extractors.web_form.extract
 **/onboarding_step/*/*.json,frappe.gettext.extractors.onboarding_step.extract
 **/module_onboarding/*/*.json,frappe.gettext.extractors.module_onboarding.extract
 **/report/*/*.json,frappe.gettext.extractors.report.extract

--- a/cypress/integration/form.js
+++ b/cypress/integration/form.js
@@ -87,15 +87,16 @@ context("Form", () => {
 		cy.visit("/app/contact/new");
 		cy.get('.frappe-control[data-fieldname="email_ids"]').as("table");
 		cy.get("@table").find("button.grid-add-row").click();
-		cy.get("@table").find("button.grid-add-row").click();
 		cy.get("@table").find('[data-idx="1"]').as("row1");
-		cy.get("@table").find('[data-idx="2"]').as("row2");
+
 		cy.get("@row1").click();
 		cy.get("@row1").find("input.input-with-feedback.form-control").as("email_input1");
 
 		cy.get("@email_input1").type(website_input, { waitForAnimations: false });
 		cy.fill_field("company_name", "Test Company");
 
+		cy.get("@table").find("button.grid-add-row").click();
+		cy.get("@table").find('[data-idx="2"]').as("row2");
 		cy.get("@row2").click();
 		cy.get("@row2").find("input.input-with-feedback.form-control").as("email_input2");
 		cy.get("@email_input2").type(valid_email, { waitForAnimations: false });

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -60,7 +60,7 @@ from .utils.jinja import (
 )
 from .utils.lazy_loader import lazy_import
 
-__version__ = "15.87.0"
+__version__ = "15.88.0"
 __title__ = "Frappe Framework"
 
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -60,7 +60,7 @@ from .utils.jinja import (
 )
 from .utils.lazy_loader import lazy_import
 
-__version__ = "15.85.0"
+__version__ = "15.86.0"
 __title__ = "Frappe Framework"
 
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -60,7 +60,7 @@ from .utils.jinja import (
 )
 from .utils.lazy_loader import lazy_import
 
-__version__ = "15.86.0"
+__version__ = "15.87.0"
 __title__ = "Frappe Framework"
 
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -60,7 +60,7 @@ from .utils.jinja import (
 )
 from .utils.lazy_loader import lazy_import
 
-__version__ = "15.84.0"
+__version__ = "15.85.0"
 __title__ = "Frappe Framework"
 
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1591,8 +1591,8 @@ def get_installed_apps(*, _ensure_on_bench: bool = False) -> list[str]:
 
 
 def get_doc_hooks():
-	"""Returns hooked methods for given doc. It will expand the dict tuple if required."""
-	if not hasattr(local, "doc_events_hooks"):
+	"""Return hooked methods for given doc. Expand the dict tuple if required."""
+	if not getattr(local, "doc_events_hooks", None):
 		hooks = get_hooks("doc_events", {})
 		out = {}
 		for key, value in hooks.items():

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -60,7 +60,7 @@ from .utils.jinja import (
 )
 from .utils.lazy_loader import lazy_import
 
-__version__ = "15.88.1"
+__version__ = "15.88.2"
 __title__ = "Frappe Framework"
 
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -60,7 +60,7 @@ from .utils.jinja import (
 )
 from .utils.lazy_loader import lazy_import
 
-__version__ = "15.88.0"
+__version__ = "15.88.1"
 __title__ = "Frappe Framework"
 
 

--- a/frappe/api/v1.py
+++ b/frappe/api/v1.py
@@ -4,12 +4,16 @@ from werkzeug.routing import Rule
 
 import frappe
 from frappe import _
+from frappe.utils import attach_expanded_links
 from frappe.utils.data import sbool
 
 
 def document_list(doctype: str):
 	if frappe.form_dict.get("fields"):
 		frappe.form_dict["fields"] = json.loads(frappe.form_dict["fields"])
+
+	if frappe.form_dict.get("expand"):
+		frappe.form_dict["expand"] = json.loads(frappe.form_dict["expand"])
 
 	# set limit of records for frappe.get_list
 	frappe.form_dict.setdefault(
@@ -75,7 +79,35 @@ def read_doc(doctype: str, name: str):
 	if not doc.has_permission("read"):
 		raise frappe.PermissionError
 	doc.apply_fieldlevel_read_permissions()
-	return doc
+	doc_dict = doc.as_dict()
+	if sbool(frappe.form_dict.get("expand_links")):
+		get_values_for_link_and_dynamic_link_fields(doc_dict)
+		get_values_for_table_and_multiselect_fields(doc_dict)
+
+	return doc_dict
+
+
+def get_values_for_link_and_dynamic_link_fields(doc_dict):
+	meta = frappe.get_meta(doc_dict.doctype)
+	link_fields = meta.get_link_fields() + meta.get_dynamic_link_fields()
+
+	for field in link_fields:
+		if not (doc_fieldvalue := getattr(doc_dict, field.fieldname, None)):
+			continue
+
+		doctype = field.options if field.fieldtype == "Link" else doc_dict.get(field.options)
+
+		link_doc = frappe.get_doc(doctype, doc_fieldvalue)
+		doc_dict.update({field.fieldname: link_doc})
+
+
+def get_values_for_table_and_multiselect_fields(doc_dict):
+	meta = frappe.get_meta(doc_dict.doctype)
+	table_fields = meta.get_table_fields()
+
+	for field in table_fields:
+		table_link_fieldnames = [f.fieldname for f in frappe.get_meta(field.options).get_link_fields()]
+		attach_expanded_links(field.options, doc_dict.get(field.fieldname), table_link_fieldnames)
 
 
 def execute_doc_method(doctype: str, name: str, method: str | None = None):

--- a/frappe/api/v1.py
+++ b/frappe/api/v1.py
@@ -79,12 +79,13 @@ def read_doc(doctype: str, name: str):
 	if not doc.has_permission("read"):
 		raise frappe.PermissionError
 	doc.apply_fieldlevel_read_permissions()
-	doc_dict = doc.as_dict()
 	if sbool(frappe.form_dict.get("expand_links")):
+		doc_dict = doc.as_dict()
 		get_values_for_link_and_dynamic_link_fields(doc_dict)
 		get_values_for_table_and_multiselect_fields(doc_dict)
+		return doc_dict
 
-	return doc_dict
+	return doc
 
 
 def get_values_for_link_and_dynamic_link_fields(doc_dict):

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.js
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.js
@@ -85,14 +85,17 @@ frappe.ui.form.on("Auto Repeat", {
 	},
 
 	preview_message: function (frm) {
+		if (frm.is_dirty()) {
+			frappe.msgprint(__("Please save the form before previewing the message"));
+			return;
+		}
+
 		if (frm.doc.message) {
 			frappe.call({
 				method: "frappe.automation.doctype.auto_repeat.auto_repeat.generate_message_preview",
+				type: "POST",
 				args: {
-					reference_dt: frm.doc.reference_doctype,
-					reference_doc: frm.doc.reference_document,
-					subject: frm.doc.subject,
-					message: frm.doc.message,
+					name: frm.doc.name,
 				},
 				callback: function (r) {
 					if (r.message) {

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -565,14 +565,15 @@ def update_reference(docname: str, reference: str):
 	return "success"  # backward compatbility
 
 
-@frappe.whitelist()
-def generate_message_preview(reference_dt, reference_doc, message=None, subject=None):
+@frappe.whitelist(methods=["POST"])
+def generate_message_preview(name: str):
 	frappe.has_permission("Auto Repeat", "write", throw=True)
-	doc = frappe.get_doc(reference_dt, reference_doc)
+	auto_repeat = frappe.get_doc("Auto Repeat", str(name))
+	doc = frappe.get_doc(auto_repeat.reference_doctype, auto_repeat.reference_document)
 	doc.check_permission()
 	subject_preview = _("Please add a subject to your email")
-	msg_preview = frappe.render_template(message, {"doc": doc})
-	if subject:
-		subject_preview = frappe.render_template(subject, {"doc": doc})
+	msg_preview = frappe.render_template(auto_repeat.message, {"doc": doc})
+	if auto_repeat.subject:
+		subject_preview = frappe.render_template(auto_repeat.subject, {"doc": doc})
 
 	return {"message": msg_preview, "subject": subject_preview}

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -11,7 +11,7 @@ from frappe import _
 from frappe.desk.reportview import validate_args
 from frappe.model.db_query import check_parent_permission
 from frappe.model.utils import is_virtual_doctype
-from frappe.utils import get_safe_filters
+from frappe.utils import attach_expanded_links, get_safe_filters
 from frappe.utils.deprecations import deprecated
 
 if TYPE_CHECKING:
@@ -37,6 +37,7 @@ def get_list(
 	debug: bool = False,
 	as_dict: bool = True,
 	or_filters=None,
+	expand=None,
 ):
 	"""Returns a list of records by filters, fields, ordering and limit
 
@@ -64,7 +65,17 @@ def get_list(
 	)
 
 	validate_args(args)
-	return frappe.get_list(**args)
+	_list = frappe.get_list(**args)
+
+	if not expand:
+		return _list
+
+	if fields and not fields[0] == "*":
+		expand = [f for f in expand if f in fields]
+
+	attach_expanded_links(doctype, _list, expand)
+
+	return _list
 
 
 @frappe.whitelist()

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -200,8 +200,28 @@ def _restore(
 	with_public_files=None,
 	with_private_files=None,
 ):
+	from pathlib import Path
+
 	from frappe.installer import extract_files
 	from frappe.utils.backups import decrypt_backup, get_or_generate_backup_encryption_key
+
+	# Check for the backup file in the backup directory, as well as the main bench directory
+	dirs = (f"{site}/private/backups", "..")
+
+	# Try to resolve path to the file if we can't find it directly
+	if not Path(sql_file_path).exists():
+		click.secho(
+			f"File {sql_file_path} not found. Trying to check in alternative directories.", fg="yellow"
+		)
+		for dir in dirs:
+			potential_path = Path(dir) / Path(sql_file_path)
+			if potential_path.exists():
+				sql_file_path = str(potential_path.resolve())
+				click.secho(f"File {sql_file_path} found.", fg="green")
+				break
+		else:
+			click.secho(f"File {sql_file_path} not found.", fg="red")
+			sys.exit(1)
 
 	err, out = frappe.utils.execute_in_shell(f"file {sql_file_path}", check_exit_code=True)
 	if err:
@@ -286,24 +306,6 @@ def restore_backup(
 	from pathlib import Path
 
 	from frappe.installer import _new_site, is_downgrade, is_partial, validate_database_sql
-
-	# Check for the backup file in the backup directory, as well as the main bench directory
-	dirs = (f"{site}/private/backups", "..")
-
-	# Try to resolve path to the file if we can't find it directly
-	if not Path(sql_file_path).exists():
-		click.secho(
-			f"File {sql_file_path} not found. Trying to check in alternative directories.", fg="yellow"
-		)
-		for dir in dirs:
-			potential_path = Path(dir) / Path(sql_file_path)
-			if potential_path.exists():
-				sql_file_path = str(potential_path.resolve())
-				click.secho(f"File {sql_file_path} found.", fg="green")
-				break
-		else:
-			click.secho(f"File {sql_file_path} not found.", fg="red")
-			sys.exit(1)
 
 	if is_partial(sql_file_path):
 		click.secho(

--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -57,9 +57,8 @@ class Address(Document):
 		self.flags.linked = False
 
 	def autoname(self):
-		if not self.address_title:
-			if self.links:
-				self.address_title = self.links[0].link_name
+		if not self.address_title and self.links:
+			self.address_title = self.links[0].link_title or self.links[0].link_name
 
 		if self.address_title:
 			self.name = cstr(self.address_title).strip() + "-" + cstr(_(self.address_type)).strip()

--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -416,6 +416,13 @@ class Communication(Document, CommunicationEmailMixin):
 
 	# Timeline Links
 	def set_timeline_links(self):
+		# Skip timeline links if a "Sent" communication already exists
+		# else will create duplicate timeline entries
+		if self.sent_or_received == "Received" and self.find_one_by_filters(
+			message_id=self.message_id, sent_or_received="Sent"
+		):
+			return
+
 		contacts = []
 		create_contact_enabled = self.email_account and frappe.db.get_value(
 			"Email Account", self.email_account, "create_contact"

--- a/frappe/core/doctype/doctype/doctype_list.js
+++ b/frappe/core/doctype/doctype/doctype_list.js
@@ -11,6 +11,7 @@ frappe.listview_settings["DocType"] = {
 				fieldname: "name",
 				fieldtype: "Data",
 				reqd: 1,
+				length: 61,
 			},
 			{ fieldtype: "Column Break" },
 			{

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -418,9 +418,6 @@ class File(Document):
 		else:
 			self.file_name = re.sub(r"/", "", self.file_name)
 
-		# Escape HTML characters in file name
-		self.file_name = escape_html(self.file_name)
-
 	def generate_content_hash(self):
 		if self.content_hash or not self.file_url or self.is_remote_file:
 			return

--- a/frappe/core/doctype/file/file_list.js
+++ b/frappe/core/doctype/file/file_list.js
@@ -1,0 +1,7 @@
+frappe.listview_settings["File"] = {
+	formatters: {
+		file_name: function (value) {
+			return frappe.utils.escape_html(value || "");
+		},
+	},
+};

--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -55,6 +55,7 @@
   "two_factor_method",
   "lifespan_qrcode_image",
   "otp_issuer_name",
+  "otp_sms_template",
   "password_tab",
   "password_settings",
   "logout_on_password_reset",
@@ -364,6 +365,13 @@
    "fieldname": "otp_issuer_name",
    "fieldtype": "Data",
    "label": "OTP Issuer Name"
+  },
+  {
+   "depends_on": "eval:doc.enable_two_factor_auth==1 && doc.two_factor_method==\"SMS\"",
+   "description": "OTP placeholder should be defined as <code>{{ otp }}</code> ",
+   "fieldname": "otp_sms_template",
+   "fieldtype": "Small Text",
+   "label": "OTP SMS Template"
   },
   {
    "fieldname": "email",
@@ -739,7 +747,7 @@
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2025-09-03 10:52:38.096662",
+ "modified": "2025-11-04 16:47:54.230874",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -118,16 +118,19 @@ class SystemSettings(Document):
 			if len(parts) != 2 or not (cint(parts[0]) or cint(parts[1])):
 				frappe.throw(_("Session Expiry must be in format {0}").format("hh:mm"))
 
-		if self.enable_two_factor_auth:
-			if self.two_factor_method == "SMS":
-				if not frappe.db.get_single_value("SMS Settings", "sms_gateway_url"):
-					frappe.throw(
-						_("Please setup SMS before setting it as an authentication method, via SMS Settings")
-					)
-			toggle_two_factor_auth(True, roles=["All"])
-		else:
-			self.bypass_2fa_for_retricted_ip_users = 0
-			self.bypass_restrict_ip_check_if_2fa_enabled = 0
+		if self.has_value_changed("enable_two_factor_auth"):
+			if self.enable_two_factor_auth:
+				if self.two_factor_method == "SMS":
+					if not frappe.db.get_single_value("SMS Settings", "sms_gateway_url"):
+						frappe.throw(
+							_(
+								"Please setup SMS before setting it as an authentication method, via SMS Settings"
+							)
+						)
+				toggle_two_factor_auth(True, roles=["All"])
+			else:
+				self.bypass_2fa_for_retricted_ip_users = 0
+				self.bypass_restrict_ip_check_if_2fa_enabled = 0
 
 		frappe.flags.update_last_reset_password_date = False
 		if self.force_user_to_reset_password and not cint(

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -87,6 +87,7 @@ class SystemSettings(Document):
 			"#,###",
 		]
 		otp_issuer_name: DF.Data | None
+		otp_sms_template: DF.SmallText | None
 		password_reset_limit: DF.Int
 		rate_limit_email_link_login: DF.Int
 		reset_password_link_expiry_duration: DF.Duration | None
@@ -141,6 +142,7 @@ class SystemSettings(Document):
 		self.validate_user_pass_login()
 		self.validate_backup_limit()
 		self.validate_file_extensions()
+		self.validate_otp_sms_template()
 
 		if not self.link_field_results_limit:
 			self.link_field_results_limit = 10
@@ -150,6 +152,17 @@ class SystemSettings(Document):
 			label = _(self.meta.get_label("link_field_results_limit"))
 			frappe.msgprint(
 				_("{0} can not be more than {1}").format(label, 50), alert=True, indicator="yellow"
+			)
+
+	def validate_otp_sms_template(self):
+		if not self.enable_two_factor_auth or self.two_factor_method != "SMS" or not self.otp_sms_template:
+			return
+
+		if "{{otp}}" not in self.otp_sms_template.replace(" ", ""):
+			frappe.throw(
+				_("OTP SMS Template must contain <code>{0}</code> placeholder to insert the OTP.").format(
+					"{{otp}}"
+				)
 			)
 
 	def validate_user_pass_login(self):

--- a/frappe/custom/doctype/custom_field/custom_field.json
+++ b/frappe/custom/doctype/custom_field/custom_field.json
@@ -85,6 +85,7 @@
    "fieldtype": "Data",
    "in_filter": 1,
    "label": "Label",
+   "length": 255,
    "no_copy": 1,
    "oldfieldname": "label",
    "oldfieldtype": "Data"
@@ -466,11 +467,12 @@
    "label": "Placeholder"
   }
  ],
+ "grid_page_length": 50,
  "icon": "fa fa-glass",
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-09-28 20:19:35.935720",
+ "modified": "2025-10-10 11:10:23.862393",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Custom Field",
@@ -499,6 +501,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "dt,label,fieldtype,options",
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -339,6 +339,8 @@ def get_definition(fieldtype, precision=None, length=None):
 
 		if length:
 			if coltype == "varchar":
+				if length < 64:
+					length = 64
 				size = length
 			elif coltype == "int" and length < 11:
 				# allow setting custom length for int if length provided is less than 11
@@ -364,5 +366,9 @@ def add_column(doctype, column_name, fieldtype, precision=None, length=None, def
 		query += " not null"
 	if default:
 		query += f" default '{default}'"
-
-	frappe.db.sql(query)
+	try:
+		frappe.db.sql(query)
+	except Exception as err:
+		# 1118 is error code for the row size limit exceeded error
+		if hasattr(err, "args") and err.args[0] == 1118:
+			frappe.db.rollback()

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -339,6 +339,7 @@ def get_definition(fieldtype, precision=None, length=None):
 
 		if length:
 			if coltype == "varchar":
+				# Reference: https://mariadb.com/docs/server/server-usage/storage-engines/innodb/innodb-row-formats/troubleshooting-row-size-too-large-errors-with-innodb
 				if length < 64:
 					length = 64
 				size = length
@@ -366,9 +367,5 @@ def add_column(doctype, column_name, fieldtype, precision=None, length=None, def
 		query += " not null"
 	if default:
 		query += f" default '{default}'"
-	try:
-		frappe.db.sql(query)
-	except Exception as err:
-		# 1118 is error code for the row size limit exceeded error
-		if hasattr(err, "args") and err.args[0] == 1118:
-			frappe.db.rollback()
+
+	frappe.db.sql(query)

--- a/frappe/desk/doctype/module_onboarding/module_onboarding.py
+++ b/frappe/desk/doctype/module_onboarding/module_onboarding.py
@@ -53,10 +53,14 @@ class ModuleOnboarding(Document):
 		is_complete = [bool(step.is_complete or step.is_skipped) for step in steps]
 		if all(is_complete):
 			self.is_complete = True
-			self.save(ignore_permissions=True)
+			frappe.enqueue(self.mark_as_completed, enqueue_after_commit=True)
 			return True
 
 		return False
+
+	def mark_as_completed(self):
+		self.is_complete = True
+		self.save(ignore_permissions=True)
 
 	@frappe.whitelist()
 	def reset_progress(self):

--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -95,7 +95,7 @@ def get_communication_doctype(doctype, txt, searchfield, start, page_len, filter
 	results = []
 	txt_lower = txt.lower().replace("%", "")
 
-	for dt in com_doctypes:
+	for dt in list(set(com_doctypes)):
 		if dt in can_read:
 			if txt_lower in dt.lower() or txt_lower in _(dt).lower():
 				results.append([dt])

--- a/frappe/email/doctype/auto_email_report/auto_email_report.js
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.js
@@ -155,9 +155,13 @@ frappe.ui.form.on("Auto Email Report", {
 					.appendTo(row);
 			});
 
+			// remove mandatory but hidden filters from dialog
+			const dialog_filter_fields = report_filters.filter(
+				(f) => !(f.hidden == 1 && f.reqd == 1)
+			);
 			table.on("click", function () {
-				var dialog = new frappe.ui.Dialog({
-					fields: report_filters,
+				dialog = new frappe.ui.Dialog({
+					fields: dialog_filter_fields,
 					primary_action: function () {
 						var values = this.get_values();
 						if (values) {

--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -122,7 +122,9 @@ class AutoEmailReport(Document):
 		filters = frappe.parse_json(self.filters) if self.filters else {}
 		filter_meta = frappe.parse_json(self.filter_meta) if self.filter_meta else {}
 		throw_list = [
-			meta["label"] for meta in filter_meta if meta.get("reqd") and not filters.get(meta["fieldname"])
+			meta["label"]
+			for meta in filter_meta
+			if (meta.get("reqd") and (not meta.get("hidden"))) and not filters.get(meta["fieldname"])
 		]
 		if throw_list:
 			frappe.throw(

--- a/frappe/email/doctype/email_account/test_email_account.py
+++ b/frappe/email/doctype/email_account/test_email_account.py
@@ -524,7 +524,7 @@ class TestInboundMail(FrappeTestCase):
 		mail_content = self.get_test_mail(fname="incoming-1.raw")
 		message_id = Email(mail_content).message_id
 		# Create new communication record in DB
-		communication = self.new_communication(message_id=message_id)
+		communication = self.new_communication(message_id=message_id, sent_or_received="Received")
 
 		email_account = frappe.get_doc("Email Account", "_Test Email Account 1")
 		inbound_mail = InboundMail(mail_content, email_account, 12345, 1)

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -710,7 +710,9 @@ class InboundMail(Email):
 		if not self.message_id:
 			return
 
-		return Communication.find_one_by_filters(message_id=self.message_id, order_by="creation DESC")
+		return Communication.find_one_by_filters(
+			message_id=self.message_id, sent_or_received="Received", order_by="creation DESC"
+		)
 
 	def is_sender_same_as_receiver(self):
 		return self.from_email == self.email_account.email_id
@@ -756,7 +758,9 @@ class InboundMail(Email):
 		if not self.is_reply():
 			return ""
 
-		communication = Communication.find_one_by_filters(message_id=self.in_reply_to)
+		communication = Communication.find_one_by_filters(
+			message_id=self.in_reply_to, order_by="creation DESC"
+		)
 		if not communication:
 			if self.parent_email_queue() and self.parent_email_queue().communication:
 				communication = Communication.find(self.parent_email_queue().communication, ignore_error=True)

--- a/frappe/geo/country_info.json
+++ b/frappe/geo/country_info.json
@@ -2988,6 +2988,19 @@
   ],
   "isd": "+260"
  },
+ "Kosovo": {
+  "code": "xk",
+  "currency": "EUR",
+  "currency_fraction": "Cent",
+  "currency_fraction_units": 100,
+  "currency_name": "Euro",
+  "currency_symbol": "€",
+  "number_format": "#,###.##",
+  "timezones": [
+    "Europe/Belgrade"
+  ],
+  "isd": "+383"
+ },
  "Zimbabwe": {
   "code": "zw",
   "currency": "ZWL",

--- a/frappe/gettext/extractors/web_form.py
+++ b/frappe/gettext/extractors/web_form.py
@@ -1,0 +1,73 @@
+import json
+
+
+def extract(fileobj, *args, **kwargs):
+	"""
+	Extract messages from Web Form JSON files. To be used to babel extractor
+	:param fileobj: the file-like object the messages should be extracted from
+	:rtype: `iterator`
+	"""
+	data = json.load(fileobj)
+
+	if isinstance(data, list):
+		return
+
+	if data.get("doctype") != "Web Form":
+		return
+
+	web_form_name = data.get("name")
+
+	# Extract main web form fields
+	if title := data.get("title"):
+		yield None, "_", title, [f"Title of the {web_form_name} Web Form"]
+
+	if introduction_text := data.get("introduction_text"):
+		yield None, "_", introduction_text, [f"Introduction text of the {web_form_name} Web Form"]
+
+	if success_message := data.get("success_message"):
+		yield None, "_", success_message, [f"Success message of the {web_form_name} Web Form"]
+
+	if success_title := data.get("success_title"):
+		yield None, "_", success_title, [f"Success title of the {web_form_name} Web Form"]
+
+	if list_title := data.get("list_title"):
+		yield None, "_", list_title, [f"List title of the {web_form_name} Web Form"]
+
+	if button_label := data.get("button_label"):
+		yield None, "_", button_label, [f"Button label of the {web_form_name} Web Form"]
+
+	if meta_title := data.get("meta_title"):
+		yield None, "_", meta_title, [f"Meta title of the {web_form_name} Web Form"]
+
+	if meta_description := data.get("meta_description"):
+		yield None, "_", meta_description, [f"Meta description of the {web_form_name} Web Form"]
+
+	# Extract web form fields
+	for field in data.get("web_form_fields", []):
+		if label := field.get("label"):
+			yield None, "_", label, [f"Label of a field in the {web_form_name} Web Form"]
+
+		if description := field.get("description"):
+			yield None, "_", description, [f"Description of a field in the {web_form_name} Web Form"]
+
+		# Extract options for Select fields
+		if field.get("fieldtype") == "Select" and (options := field.get("options")):
+			skip_options = (
+				web_form_name == "edit-profile" and field.get("fieldname") == "time_zone"
+			)  # Dumb workaround for avoiding a flood of strings from this field
+			if isinstance(options, str) and not skip_options:
+				# Handle both single values and newline-separated values
+				option_list = options.split("\n") if "\n" in options else [options]
+				for option in option_list:
+					if option.strip():
+						yield (
+							None,
+							"_",
+							option.strip(),
+							[f"Option in a Select field in the {web_form_name} Web Form"],
+						)
+
+	# Extract list columns
+	for column in data.get("list_columns", []):
+		if isinstance(column, dict) and (label := column.get("label")):
+			yield None, "_", label, [f"Label of a list column in the {web_form_name} Web Form"]

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -361,6 +361,7 @@ def remove_from_installed_apps(app_name):
 			"DefaultValue", {"defkey": "installed_apps"}, "defvalue", json.dumps(installed_apps)
 		)
 		_clear_cache("__global")
+		frappe.local.doc_events_hooks = None
 		frappe.get_single("Installed Applications").update_versions()
 		frappe.db.commit()
 		if frappe.flags.in_install:

--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.py
@@ -278,13 +278,14 @@ class LDAPSettings(Document):
 		elif self.ldap_directory_server.lower() == "openldap":
 			ldap_object_class = "posixgroup"
 			ldap_group_members_attribute = "memberuid"
-			user_search_str = getattr(user, self.ldap_username_field).value
+			user_search_str = escape_filter_chars(getattr(user, self.ldap_username_field).value)
 
 		elif self.ldap_directory_server.lower() == "custom":
 			ldap_object_class = self.ldap_group_objectclass
 			ldap_group_members_attribute = self.ldap_group_member_attribute
 			ldap_custom_group_search = self.ldap_custom_group_search or "{0}"
-			user_search_str = ldap_custom_group_search.format(getattr(user, self.ldap_username_field).value)
+			user_value = escape_filter_chars(getattr(user, self.ldap_username_field).value)
+			user_search_str = ldap_custom_group_search.format(user_value)
 
 		else:
 			# NOTE: depreciate this else path
@@ -308,6 +309,7 @@ class LDAPSettings(Document):
 		if not self.enabled:
 			frappe.throw(_("LDAP is not enabled."))
 
+		username = escape_filter_chars(username)
 		user_filter = self.ldap_search_string.format(username)
 		ldap_attributes = self.get_ldap_attributes()
 		conn = self.connect_to_ldap(self.base_dn, self.get_password(raise_exception=False))
@@ -335,7 +337,8 @@ class LDAPSettings(Document):
 		except LDAPInvalidCredentialsResult:
 			frappe.throw(_("Invalid username or password"))
 
-	def reset_password(self, user, password, logout_sessions=False):
+	def reset_password(self, user: str, password: str, logout_sessions: int = 0):
+		user = escape_filter_chars(user)
 		search_filter = f"({self.ldap_email_field}={user})"
 
 		conn = self.connect_to_ldap(self.base_dn, self.get_password(raise_exception=False), read_only=False)
@@ -420,7 +423,7 @@ def login():
 
 
 @frappe.whitelist()
-def reset_password(user, password, logout):
+def reset_password(user: str, password: str, logout: int):
 	ldap: LDAPSettings = frappe.get_doc("LDAP Settings")
 	if not ldap.enabled:
 		frappe.throw(_("LDAP is not enabled."))

--- a/frappe/locale/main.pot
+++ b/frappe/locale/main.pot
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Frappe Framework VERSION\n"
 "Report-Msgid-Bugs-To: developers@frappe.io\n"
-"POT-Creation-Date: 2025-06-27 08:47+0000\n"
-"PO-Revision-Date: 2025-06-27 08:47+0000\n"
+"POT-Creation-Date: 2025-10-02 10:57+0000\n"
+"PO-Revision-Date: 2025-10-02 10:57+0000\n"
 "Last-Translator: developers@frappe.io\n"
 "Language-Team: developers@frappe.io\n"
 "MIME-Version: 1.0\n"
@@ -80,15 +80,19 @@ msgstr ""
 msgid "'In List View' is not allowed for field {0} of type {1}"
 msgstr ""
 
-#: frappe/custom/doctype/customize_form/customize_form.py:360
+#: frappe/custom/doctype/customize_form/customize_form.py:367
 msgid "'In List View' not allowed for type {0} in row {1}"
 msgstr ""
 
-#: frappe/automation/doctype/auto_repeat/auto_repeat.py:156
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:159
 msgid "'Recipients' not specified"
 msgstr ""
 
-#: frappe/utils/__init__.py:242
+#: frappe/utils/__init__.py:257
+msgid "'{0}' is not a valid IBAN"
+msgstr ""
+
+#: frappe/utils/__init__.py:247
 msgid "'{0}' is not a valid URL"
 msgstr ""
 
@@ -120,7 +124,7 @@ msgstr ""
 msgid "0 is highest"
 msgstr ""
 
-#: frappe/public/js/frappe/form/grid_row.js:838
+#: frappe/public/js/frappe/form/grid_row.js:860
 msgid "1 = True & 0 = False"
 msgstr ""
 
@@ -139,7 +143,7 @@ msgstr ""
 msgid "1 Google Calendar Event synced."
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:887
+#: frappe/public/js/frappe/views/reports/query_report.js:888
 msgid "1 Report"
 msgstr ""
 
@@ -147,7 +151,7 @@ msgstr ""
 msgid "1 comment"
 msgstr ""
 
-#: frappe/tests/test_utils.py:670
+#: frappe/tests/test_utils.py:797
 msgid "1 day ago"
 msgstr ""
 
@@ -156,17 +160,17 @@ msgid "1 hour"
 msgstr ""
 
 #: frappe/public/js/frappe/utils/pretty_date.js:52
-#: frappe/tests/test_utils.py:668
+#: frappe/tests/test_utils.py:795
 msgid "1 hour ago"
 msgstr ""
 
 #: frappe/public/js/frappe/utils/pretty_date.js:48
-#: frappe/tests/test_utils.py:666
+#: frappe/tests/test_utils.py:793
 msgid "1 minute ago"
 msgstr ""
 
 #: frappe/public/js/frappe/utils/pretty_date.js:66
-#: frappe/tests/test_utils.py:674
+#: frappe/tests/test_utils.py:801
 msgid "1 month ago"
 msgstr ""
 
@@ -178,37 +182,37 @@ msgstr ""
 msgid "1 record will be exported"
 msgstr ""
 
-#: frappe/tests/test_utils.py:665
+#: frappe/tests/test_utils.py:792
 msgid "1 second ago"
 msgstr ""
 
 #: frappe/public/js/frappe/utils/pretty_date.js:62
-#: frappe/tests/test_utils.py:672
+#: frappe/tests/test_utils.py:799
 msgid "1 week ago"
 msgstr ""
 
 #: frappe/public/js/frappe/utils/pretty_date.js:70
-#: frappe/tests/test_utils.py:676
+#: frappe/tests/test_utils.py:803
 msgid "1 year ago"
 msgstr ""
 
-#: frappe/tests/test_utils.py:669
+#: frappe/tests/test_utils.py:796
 msgid "2 hours ago"
 msgstr ""
 
-#: frappe/tests/test_utils.py:675
+#: frappe/tests/test_utils.py:802
 msgid "2 months ago"
 msgstr ""
 
-#: frappe/tests/test_utils.py:673
+#: frappe/tests/test_utils.py:800
 msgid "2 weeks ago"
 msgstr ""
 
-#: frappe/tests/test_utils.py:677
+#: frappe/tests/test_utils.py:804
 msgid "2 years ago"
 msgstr ""
 
-#: frappe/tests/test_utils.py:667
+#: frappe/tests/test_utils.py:794
 msgid "3 minutes ago"
 msgstr ""
 
@@ -224,7 +228,7 @@ msgstr ""
 msgid "5 Records"
 msgstr ""
 
-#: frappe/tests/test_utils.py:671
+#: frappe/tests/test_utils.py:798
 msgid "5 days ago"
 msgstr ""
 
@@ -244,6 +248,14 @@ msgstr ""
 msgid "<="
 msgstr ""
 
+#. Description of the 'Generate Keys' (Button) field in DocType 'User'
+#: frappe/core/doctype/user/user.json
+msgid ""
+"<a href=\"https://docs.frappe.io/framework/user/en/api/rest#1-token-based-authentication\" target=\"_blank\">\n"
+"  Click here to learn about token-based authentication\n"
+"</a>"
+msgstr ""
+
 #: frappe/public/js/frappe/widgets/widget_dialog.js:582
 msgid "<b>{0}</b> is not a valid URL"
 msgstr ""
@@ -251,6 +263,16 @@ msgstr ""
 #. Content of the 'Help' (HTML) field in DocType 'Property Setter'
 #: frappe/custom/doctype/property_setter/property_setter.json
 msgid "<div class=\"alert\">Please don't update it as it can mess up your form. Use the Customize Form View and Custom Fields to set properties!</div>"
+msgstr ""
+
+#. Introduction text of the request-data Web Form
+#: frappe/website/web_form/request_data/request_data.json
+msgid "<div class=\"ql-editor read-mode\"><p>Request a file containing your personally identifiable information (PII) that is saved on our system. The file will be in JSON format and is sent to you by email. If you would like to have your PII deleted from our system, please make a <a href=\"/request-to-delete-data\" rel=\"noopener noreferrer\">request to delete data</a>.</p></div>"
+msgstr ""
+
+#. Introduction text of the request-to-delete-data Web Form
+#: frappe/website/web_form/request_to_delete_data/request_to_delete_data.json
+msgid "<div class=\"ql-editor read-mode\"><p>Send a request to delete your account and personally identifiable information (PII) that is stored on our system. You will receive an email to verify your request. Once the request is verified we will take care of deleting your PII. If you just want to check what PII we have stored, you can <a href=\"/request-data\" rel=\"noopener noreferrer\">request your data</a>.</p></div>"
 msgstr ""
 
 #. Content of the 'Help HTML' (HTML) field in DocType 'Document Naming
@@ -621,8 +643,13 @@ msgstr ""
 msgid "A DocType (Document Type) is used to insert forms in ERPNext. Forms such as Customer, Orders, and Invoices are Doctypes in the backend. You can also create new DocTypes to create new forms in ERPNext as per your business needs."
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1013
+#: frappe/core/doctype/doctype/doctype.py:1015
 msgid "A DocType's name should start with a letter and can only consist of letters, numbers, spaces, underscores and hyphens"
+msgstr ""
+
+#. Success message of the request-data Web Form
+#: frappe/website/web_form/request_data/request_data.json
+msgid "A download link with your data will be sent to the email address associated with your account."
 msgstr ""
 
 #: frappe/website/doctype/blog_post/blog_post.py:93
@@ -633,7 +660,7 @@ msgstr ""
 msgid "A field with the name {0} already exists in {1}"
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:255
+#: frappe/core/doctype/file/file.py:260
 msgid "A file with same name {} already exists"
 msgstr ""
 
@@ -646,7 +673,7 @@ msgstr ""
 msgid "A new account has been created for you at {0}"
 msgstr ""
 
-#: frappe/automation/doctype/auto_repeat/auto_repeat.py:400
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:403
 msgid "A recurring {0} {1} has been created for you via Auto Repeat {2}."
 msgstr ""
 
@@ -740,11 +767,15 @@ msgstr ""
 msgid "API Endpoint Args"
 msgstr ""
 
+#: frappe/integrations/doctype/social_login_key/social_login_key.py:101
+msgid "API Endpoint Args should be valid JSON"
+msgstr ""
+
 #. Label of a Data field in DocType 'User'
 #. Label of a Data field in DocType 'Google Settings'
 #. Label of a Section Break field in DocType 'Google Settings'
 #. Label of a Data field in DocType 'Push Notification Settings'
-#: frappe/core/doctype/user/user.json
+#: frappe/core/doctype/user/user.js:441 frappe/core/doctype/user/user.json
 #: frappe/integrations/doctype/google_settings/google_settings.json
 #: frappe/integrations/doctype/push_notification_settings/push_notification_settings.json
 msgid "API Key"
@@ -761,6 +792,15 @@ msgstr ""
 msgid "API Key cannot be regenerated"
 msgstr ""
 
+#: frappe/core/doctype/user/user.js:438
+msgid "API Keys"
+msgstr ""
+
+#. Label of a Section Break field in DocType 'System Settings'
+#: frappe/core/doctype/system_settings/system_settings.json
+msgid "API Logging"
+msgstr ""
+
 #. Label of a Data field in DocType 'Server Script'
 #: frappe/core/doctype/server_script/server_script.json
 msgid "API Method"
@@ -768,7 +808,7 @@ msgstr ""
 
 #. Label of a Password field in DocType 'User'
 #. Label of a Password field in DocType 'Push Notification Settings'
-#: frappe/core/doctype/user/user.json
+#: frappe/core/doctype/user/user.js:448 frappe/core/doctype/user/user.json
 #: frappe/integrations/doctype/push_notification_settings/push_notification_settings.json
 msgid "API Secret"
 msgstr ""
@@ -814,6 +854,20 @@ msgstr ""
 msgid "About {0} seconds remaining"
 msgstr ""
 
+#: frappe/templates/emails/user_invitation.html:16
+msgid "Accept Invitation"
+msgstr ""
+
+#. Option for the 'Status' (Select) field in DocType 'User Invitation'
+#: frappe/core/doctype/user_invitation/user_invitation.json
+msgid "Accepted"
+msgstr ""
+
+#. Label of a Datetime field in DocType 'User Invitation'
+#: frappe/core/doctype/user_invitation/user_invitation.json
+msgid "Accepted At"
+msgstr ""
+
 #. Label of a Section Break field in DocType 'Web Form'
 #: frappe/website/doctype/web_form/web_form.json
 msgid "Access Control"
@@ -849,7 +903,7 @@ msgstr ""
 msgid "Access Token URL"
 msgstr ""
 
-#: frappe/auth.py:482
+#: frappe/auth.py:485
 msgid "Access not allowed from this IP Address"
 msgstr ""
 
@@ -912,7 +966,7 @@ msgstr ""
 msgid "Action Complete"
 msgstr ""
 
-#: frappe/model/document.py:1720
+#: frappe/model/document.py:1724
 msgid "Action Failed"
 msgstr ""
 
@@ -962,10 +1016,10 @@ msgstr ""
 #: frappe/custom/doctype/customize_form/customize_form.js:283
 #: frappe/custom/doctype/customize_form/customize_form.json
 #: frappe/public/js/frappe/ui/page.html:56
-#: frappe/public/js/frappe/views/reports/query_report.js:190
-#: frappe/public/js/frappe/views/reports/query_report.js:203
-#: frappe/public/js/frappe/views/reports/query_report.js:213
-#: frappe/public/js/frappe/views/reports/query_report.js:774
+#: frappe/public/js/frappe/views/reports/query_report.js:191
+#: frappe/public/js/frappe/views/reports/query_report.js:204
+#: frappe/public/js/frappe/views/reports/query_report.js:214
+#: frappe/public/js/frappe/views/reports/query_report.js:775
 msgid "Actions"
 msgstr ""
 
@@ -1022,13 +1076,13 @@ msgstr ""
 
 #: frappe/core/page/permission_manager/permission_manager.js:482
 #: frappe/email/doctype/email_group/email_group.js:60
-#: frappe/public/js/frappe/form/grid_row.js:478
+#: frappe/public/js/frappe/form/grid_row.js:495
 #: frappe/public/js/frappe/form/sidebar/assign_to.js:100
 #: frappe/public/js/frappe/form/templates/set_sharing.html:68
 #: frappe/public/js/frappe/list/bulk_operations.js:437
 #: frappe/public/js/frappe/views/dashboard/dashboard_view.js:441
-#: frappe/public/js/frappe/views/reports/query_report.js:265
-#: frappe/public/js/frappe/views/reports/query_report.js:293
+#: frappe/public/js/frappe/views/reports/query_report.js:266
+#: frappe/public/js/frappe/views/reports/query_report.js:294
 #: frappe/public/js/frappe/widgets/widget_dialog.js:30
 msgid "Add"
 msgstr ""
@@ -1038,7 +1092,7 @@ msgctxt "Primary action in list view"
 msgid "Add"
 msgstr ""
 
-#: frappe/public/js/frappe/form/grid_row.js:434
+#: frappe/public/js/frappe/form/grid_row.js:451
 msgid "Add / Remove Columns"
 msgstr ""
 
@@ -1050,7 +1104,7 @@ msgstr ""
 msgid "Add A New Rule"
 msgstr ""
 
-#: frappe/public/js/frappe/views/communication.js:586
+#: frappe/public/js/frappe/views/communication.js:589
 #: frappe/public/js/frappe/views/interaction.js:159
 msgid "Add Attachment"
 msgstr ""
@@ -1079,7 +1133,7 @@ msgstr ""
 msgid "Add Card to Dashboard"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:209
+#: frappe/public/js/frappe/views/reports/query_report.js:210
 msgid "Add Chart to Dashboard"
 msgstr ""
 
@@ -1088,10 +1142,10 @@ msgid "Add Child"
 msgstr ""
 
 #: frappe/public/js/frappe/views/kanban/kanban_board.html:4
-#: frappe/public/js/frappe/views/reports/query_report.js:1701
-#: frappe/public/js/frappe/views/reports/query_report.js:1704
-#: frappe/public/js/frappe/views/reports/report_view.js:356
-#: frappe/public/js/frappe/views/reports/report_view.js:381
+#: frappe/public/js/frappe/views/reports/query_report.js:1738
+#: frappe/public/js/frappe/views/reports/query_report.js:1741
+#: frappe/public/js/frappe/views/reports/report_view.js:361
+#: frappe/public/js/frappe/views/reports/report_view.js:386
 #: frappe/public/js/print_format_builder/Field.vue:112
 msgid "Add Column"
 msgstr ""
@@ -1125,7 +1179,7 @@ msgid "Add Gray Background"
 msgstr ""
 
 #: frappe/public/js/frappe/ui/group_by/group_by.js:230
-#: frappe/public/js/frappe/ui/group_by/group_by.js:427
+#: frappe/public/js/frappe/ui/group_by/group_by.js:430
 msgid "Add Group"
 msgstr ""
 
@@ -1154,7 +1208,7 @@ msgstr ""
 msgid "Add Review"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:758
+#: frappe/core/doctype/user/user.py:769
 msgid "Add Roles"
 msgstr ""
 
@@ -1192,7 +1246,7 @@ msgctxt "Button in list view actions menu"
 msgid "Add Tags"
 msgstr ""
 
-#: frappe/public/js/frappe/views/communication.js:418
+#: frappe/public/js/frappe/views/communication.js:421
 msgid "Add Template"
 msgstr ""
 
@@ -1299,7 +1353,7 @@ msgid "Add tab"
 msgstr ""
 
 #: frappe/public/js/frappe/utils/dashboard_utils.js:263
-#: frappe/public/js/frappe/views/reports/query_report.js:251
+#: frappe/public/js/frappe/views/reports/query_report.js:252
 msgid "Add to Dashboard"
 msgstr ""
 
@@ -1325,7 +1379,7 @@ msgstr ""
 msgid "Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO"
 msgstr ""
 
-#: frappe/core/doctype/log_settings/log_settings.py:82
+#: frappe/core/doctype/log_settings/log_settings.py:81
 msgid "Added default log doctypes: {}"
 msgstr ""
 
@@ -1349,6 +1403,7 @@ msgstr ""
 #. Label of a Small Text field in DocType 'Website Settings'
 #: frappe/contacts/doctype/address/address.json
 #: frappe/contacts/doctype/contact/contact.json
+#: frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py:46
 #: frappe/website/doctype/contact_us_settings/contact_us_settings.json
 #: frappe/website/doctype/website_settings/website_settings.json
 msgid "Address"
@@ -1357,6 +1412,7 @@ msgstr ""
 #. Label of a Data field in DocType 'Address'
 #. Label of a Data field in DocType 'Contact Us Settings'
 #: frappe/contacts/doctype/address/address.json
+#: frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py:37
 #: frappe/website/doctype/contact_us_settings/contact_us_settings.json
 msgid "Address Line 1"
 msgstr ""
@@ -1364,6 +1420,7 @@ msgstr ""
 #. Label of a Data field in DocType 'Address'
 #. Label of a Data field in DocType 'Contact Us Settings'
 #: frappe/contacts/doctype/address/address.json
+#: frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py:38
 #: frappe/website/doctype/contact_us_settings/contact_us_settings.json
 msgid "Address Line 2"
 msgstr ""
@@ -1440,11 +1497,11 @@ msgstr ""
 msgid "Administrator"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:1158
+#: frappe/core/doctype/user/user.py:1171
 msgid "Administrator Logged In"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:1152
+#: frappe/core/doctype/user/user.py:1165
 msgid "Administrator accessed {0} on {1} via IP Address {2}."
 msgstr ""
 
@@ -1773,7 +1830,7 @@ msgid "Allow Print for Cancelled"
 msgstr ""
 
 #. Label of a Check field in DocType 'Print Settings'
-#: frappe/automation/doctype/auto_repeat/auto_repeat.py:407
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:410
 #: frappe/printing/doctype/print_settings/print_settings.json
 msgid "Allow Print for Draft"
 msgstr ""
@@ -1925,7 +1982,7 @@ msgstr ""
 msgid "Allowing DocType, DocType. Be careful!"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:969
+#: frappe/core/doctype/user/user.py:980
 msgid "Already Registered"
 msgstr ""
 
@@ -1933,11 +1990,11 @@ msgstr ""
 msgid "Already in the following Users ToDo list:{0}"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:903
+#: frappe/public/js/frappe/views/reports/report_view.js:908
 msgid "Also adding the dependent currency field {0}"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:916
+#: frappe/public/js/frappe/views/reports/report_view.js:921
 msgid "Also adding the status dependency field {0}"
 msgstr ""
 
@@ -2017,6 +2074,11 @@ msgstr ""
 
 #: frappe/core/doctype/document_naming_settings/document_naming_settings.py:207
 msgid "Amendment naming rules updated."
+msgstr ""
+
+#. Success message of the request-to-delete-data Web Form
+#: frappe/website/web_form/request_to_delete_data/request_to_delete_data.json
+msgid "An email to verify your request has been sent to your email address. Please verify your request to complete the process."
 msgstr ""
 
 #: frappe/public/js/frappe/ui/toolbar/toolbar.js:312
@@ -2125,11 +2187,13 @@ msgid "App Logo"
 msgstr ""
 
 #. Label of a Select field in DocType 'Module Def'
+#. Label of a Select field in DocType 'User Invitation'
 #. Label of a Data field in DocType 'Changelog Feed'
 #. Label of a Data field in DocType 'OAuth Client'
 #. Label of a Data field in DocType 'Website Settings'
 #: frappe/core/doctype/installed_applications/installed_applications.js:27
 #: frappe/core/doctype/module_def/module_def.json
+#: frappe/core/doctype/user_invitation/user_invitation.json
 #: frappe/desk/doctype/changelog_feed/changelog_feed.json
 #: frappe/integrations/doctype/oauth_client/oauth_client.json
 #: frappe/website/doctype/website_settings/website_settings.json
@@ -2141,7 +2205,7 @@ msgstr ""
 msgid "App Secret Key"
 msgstr ""
 
-#: frappe/modules/utils.py:280
+#: frappe/modules/utils.py:281
 msgid "App not found for module: {0}"
 msgstr ""
 
@@ -2197,6 +2261,10 @@ msgstr ""
 #. Label of a Data field in DocType 'Installed Application'
 #: frappe/core/doctype/installed_application/installed_application.json
 msgid "Application Version"
+msgstr ""
+
+#: frappe/core/doctype/user_invitation/user_invitation.py:195
+msgid "Application is not installed"
 msgstr ""
 
 #. Label of a Select field in DocType 'Property Setter'
@@ -2307,6 +2375,10 @@ msgstr ""
 msgid "Archived Columns"
 msgstr ""
 
+#: frappe/core/doctype/user_invitation/user_invitation.js:18
+msgid "Are you sure you want to cancel the invitation?"
+msgstr ""
+
 #: frappe/public/js/frappe/form/grid.js:281
 msgid "Are you sure you want to delete all rows?"
 msgstr ""
@@ -2335,11 +2407,15 @@ msgctxt "Confirmation dialog message"
 msgid "Are you sure you want to delete the tab? All the sections along with fields in the tab will be moved to the previous tab."
 msgstr ""
 
-#: frappe/public/js/frappe/web_form/web_form.js:185
+#: frappe/public/js/frappe/web_form/web_form.js:203
+msgid "Are you sure you want to delete this record?"
+msgstr ""
+
+#: frappe/public/js/frappe/web_form/web_form.js:191
 msgid "Are you sure you want to discard the changes?"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:901
+#: frappe/public/js/frappe/views/reports/query_report.js:902
 msgid "Are you sure you want to generate a new report?"
 msgstr ""
 
@@ -2347,7 +2423,7 @@ msgstr ""
 msgid "Are you sure you want to merge {0} with {1}?"
 msgstr ""
 
-#: frappe/public/js/frappe/views/kanban/kanban_view.js:107
+#: frappe/public/js/frappe/views/kanban/kanban_view.js:117
 msgid "Are you sure you want to proceed?"
 msgstr ""
 
@@ -2411,7 +2487,7 @@ msgstr ""
 msgid "Assign Condition"
 msgstr ""
 
-#: frappe/public/js/frappe/form/sidebar/assign_to.js:189
+#: frappe/public/js/frappe/form/sidebar/assign_to.js:182
 msgid "Assign To"
 msgstr ""
 
@@ -2420,7 +2496,7 @@ msgctxt "Button in list view actions menu"
 msgid "Assign To"
 msgstr ""
 
-#: frappe/public/js/frappe/form/sidebar/assign_to.js:180
+#: frappe/public/js/frappe/form/sidebar/assign_to.js:192
 msgid "Assign To User Group"
 msgstr ""
 
@@ -2466,7 +2542,7 @@ msgstr ""
 msgid "Assigned By Full Name"
 msgstr ""
 
-#: frappe/model/meta.py:55
+#: frappe/model/meta.py:56
 #: frappe/public/js/frappe/form/templates/form_sidebar.html:48
 #: frappe/public/js/frappe/list/list_sidebar_group_by.js:71
 #: frappe/public/js/frappe/model/meta.js:207
@@ -2549,7 +2625,7 @@ msgstr ""
 msgid "Assignments"
 msgstr ""
 
-#: frappe/public/js/frappe/form/grid_row.js:667
+#: frappe/public/js/frappe/form/grid_row.js:684
 msgid "At least one column is required to show in the grid."
 msgstr ""
 
@@ -2629,7 +2705,7 @@ msgstr ""
 msgid "Attached To Name"
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:140
+#: frappe/core/doctype/file/file.py:145
 msgid "Attached To Name must be a string or an integer"
 msgstr ""
 
@@ -2649,7 +2725,7 @@ msgstr ""
 msgid "Attachment Limit (MB)"
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:322
+#: frappe/core/doctype/file/file.py:327
 #: frappe/public/js/frappe/form/sidebar/attachments.js:36
 msgid "Attachment Limit Reached"
 msgstr ""
@@ -2673,15 +2749,15 @@ msgstr ""
 #: frappe/email/doctype/newsletter/newsletter.json
 #: frappe/email/doctype/newsletter/templates/newsletter.html:47
 #: frappe/public/js/frappe/form/templates/form_sidebar.html:65
-#: frappe/website/doctype/web_form/templates/web_form.html:103
+#: frappe/website/doctype/web_form/templates/web_form.html:110
 msgid "Attachments"
 msgstr ""
 
-#: frappe/public/js/frappe/form/print_utils.js:91
+#: frappe/public/js/frappe/form/print_utils.js:119
 msgid "Attempting Connection to QZ Tray..."
 msgstr ""
 
-#: frappe/public/js/frappe/form/print_utils.js:107
+#: frappe/public/js/frappe/form/print_utils.js:135
 msgid "Attempting to launch QZ Tray..."
 msgstr ""
 
@@ -2703,6 +2779,10 @@ msgstr ""
 #. Label of a Code field in DocType 'Social Login Key'
 #: frappe/integrations/doctype/social_login_key/social_login_key.json
 msgid "Auth URL Data"
+msgstr ""
+
+#: frappe/integrations/doctype/social_login_key/social_login_key.py:95
+msgid "Auth URL data should be valid JSON"
 msgstr ""
 
 #. Label of a Check field in DocType 'Email Account'
@@ -2826,11 +2906,11 @@ msgstr ""
 msgid "Auto Repeat Day"
 msgstr ""
 
-#: frappe/automation/doctype/auto_repeat/auto_repeat.py:165
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:168
 msgid "Auto Repeat Day{0} {1} has been repeated."
 msgstr ""
 
-#: frappe/automation/doctype/auto_repeat/auto_repeat.py:448
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:451
 msgid "Auto Repeat Document Creation Failed"
 msgstr ""
 
@@ -2842,7 +2922,7 @@ msgstr ""
 msgid "Auto Repeat created for this document"
 msgstr ""
 
-#: frappe/automation/doctype/auto_repeat/auto_repeat.py:451
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:454
 msgid "Auto Repeat failed for {0}"
 msgstr ""
 
@@ -2885,7 +2965,7 @@ msgstr ""
 msgid "Auto follow documents that you create"
 msgstr ""
 
-#: frappe/automation/doctype/auto_repeat/auto_repeat.py:227
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:230
 msgid "Auto repeat failed. Please enable auto repeat after fixing the issues."
 msgstr ""
 
@@ -2962,7 +3042,7 @@ msgstr ""
 msgid "Average"
 msgstr ""
 
-#: frappe/public/js/frappe/ui/group_by/group_by.js:342
+#: frappe/public/js/frappe/ui/group_by/group_by.js:345
 msgid "Average of {0}"
 msgstr ""
 
@@ -3174,6 +3254,11 @@ msgstr ""
 #: frappe/integrations/doctype/dropbox_settings/dropbox_settings.json
 #: frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.json
 msgid "Backup Frequency"
+msgstr ""
+
+#. Label of a Data field in DocType 'S3 Backup Settings'
+#: frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.json
+msgid "Backup Path"
 msgstr ""
 
 #: frappe/desk/page/backups/backups.py:99
@@ -3605,7 +3690,7 @@ msgstr ""
 msgid "Bucket Name"
 msgstr ""
 
-#: frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py:67
+#: frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py:72
 msgid "Bucket {0} not found."
 msgstr ""
 
@@ -3645,15 +3730,15 @@ msgstr ""
 msgid "Bulk Edit"
 msgstr ""
 
-#: frappe/public/js/frappe/form/grid.js:1170
+#: frappe/public/js/frappe/form/grid.js:1171
 msgid "Bulk Edit {0}"
 msgstr ""
 
-#: frappe/desk/reportview.py:578
+#: frappe/desk/reportview.py:608
 msgid "Bulk Operation Failed"
 msgstr ""
 
-#: frappe/desk/reportview.py:582
+#: frappe/desk/reportview.py:612
 msgid "Bulk Operation Successful"
 msgstr ""
 
@@ -3827,7 +3912,7 @@ msgstr ""
 msgid "Cache"
 msgstr ""
 
-#: frappe/sessions.py:34
+#: frappe/sessions.py:35
 msgid "Cache Cleared"
 msgstr ""
 
@@ -3896,7 +3981,7 @@ msgstr ""
 #. Label of a Link field in DocType 'Newsletter'
 #. Label of a Data field in DocType 'Web Page View'
 #: frappe/email/doctype/newsletter/newsletter.json
-#: frappe/public/js/frappe/utils/utils.js:1730
+#: frappe/public/js/frappe/utils/utils.js:1746
 #: frappe/website/doctype/web_page_view/web_page_view.json
 #: frappe/website/report/website_analytics/website_analytics.js:39
 msgid "Campaign"
@@ -3953,8 +4038,9 @@ msgstr ""
 #. Rule'
 #: frappe/core/doctype/custom_docperm/custom_docperm.json
 #: frappe/core/doctype/docperm/docperm.json
-#: frappe/core/doctype/doctype/doctype_list.js:113
+#: frappe/core/doctype/doctype/doctype_list.js:114
 #: frappe/core/doctype/user_document_type/user_document_type.json
+#: frappe/core/doctype/user_invitation/user_invitation.js:17
 #: frappe/email/doctype/notification/notification.json
 #: frappe/public/js/frappe/form/reminders.js:54
 #: frappe/social/doctype/energy_point_rule/energy_point_rule.json
@@ -3990,11 +4076,13 @@ msgstr ""
 
 #. Option for the 'Comment Type' (Select) field in DocType 'Comment'
 #. Option for the 'Comment Type' (Select) field in DocType 'Communication'
+#. Option for the 'Status' (Select) field in DocType 'User Invitation'
 #. Option for the 'Status' (Select) field in DocType 'Event'
 #. Option for the 'Status' (Select) field in DocType 'ToDo'
 #. Option for the 'Status' (Select) field in DocType 'Integration Request'
 #: frappe/core/doctype/comment/comment.json
 #: frappe/core/doctype/communication/communication.json
+#: frappe/core/doctype/user_invitation/user_invitation.json
 #: frappe/desk/doctype/event/event.json frappe/desk/doctype/todo/todo.json
 #: frappe/desk/form/save.py:60
 #: frappe/integrations/doctype/integration_request/integration_request.json
@@ -4032,11 +4120,11 @@ msgstr ""
 msgid "Cannot Remove"
 msgstr ""
 
-#: frappe/model/base_document.py:1078
+#: frappe/model/base_document.py:1081
 msgid "Cannot Update After Submit"
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:613
+#: frappe/core/doctype/file/file.py:625
 msgid "Cannot access file path {0}"
 msgstr ""
 
@@ -4052,11 +4140,11 @@ msgstr ""
 msgid "Cannot cancel {0}."
 msgstr ""
 
-#: frappe/model/document.py:891
+#: frappe/model/document.py:895
 msgid "Cannot change docstatus from 0 (Draft) to 2 (Cancelled)"
 msgstr ""
 
-#: frappe/model/document.py:905
+#: frappe/model/document.py:909
 msgid "Cannot change docstatus from 1 (Submitted) to 0 (Draft)"
 msgstr ""
 
@@ -4080,11 +4168,11 @@ msgstr ""
 msgid "Cannot create private workspace of other users"
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:151
+#: frappe/core/doctype/file/file.py:156
 msgid "Cannot delete Home and Attachments folders"
 msgstr ""
 
-#: frappe/model/delete_doc.py:384
+#: frappe/model/delete_doc.py:385
 msgid "Cannot delete or cancel because {0} {1} is linked with {2} {3} {4}"
 msgstr ""
 
@@ -4127,7 +4215,7 @@ msgstr ""
 msgid "Cannot delete {0}"
 msgstr ""
 
-#: frappe/utils/nestedset.py:303
+#: frappe/utils/nestedset.py:316
 msgid "Cannot delete {0} as it has child nodes"
 msgstr ""
 
@@ -4147,7 +4235,7 @@ msgstr ""
 msgid "Cannot edit a standard report. Please duplicate and create a new report"
 msgstr ""
 
-#: frappe/model/document.py:911
+#: frappe/model/document.py:915
 msgid "Cannot edit cancelled document"
 msgstr ""
 
@@ -4164,15 +4252,15 @@ msgstr ""
 msgid "Cannot edit standard fields"
 msgstr ""
 
-#: frappe/automation/doctype/auto_repeat/auto_repeat.py:127
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:126
 msgid "Cannot enable {0} for a non-submittable doctype"
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:250
+#: frappe/core/doctype/file/file.py:255
 msgid "Cannot find file {} on disk"
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:559
+#: frappe/core/doctype/file/file.py:571
 msgid "Cannot get file contents of a Folder"
 msgstr ""
 
@@ -4180,11 +4268,11 @@ msgstr ""
 msgid "Cannot have multiple printers mapped to a single print format."
 msgstr ""
 
-#: frappe/public/js/frappe/form/grid.js:1114
+#: frappe/public/js/frappe/form/grid.js:1115
 msgid "Cannot import table with more than 5000 rows."
 msgstr ""
 
-#: frappe/model/document.py:979
+#: frappe/model/document.py:983
 msgid "Cannot link cancelled document: {0}"
 msgstr ""
 
@@ -4196,11 +4284,11 @@ msgstr ""
 msgid "Cannot match column {0} with any field"
 msgstr ""
 
-#: frappe/public/js/frappe/form/grid_row.js:175
+#: frappe/public/js/frappe/form/grid_row.js:176
 msgid "Cannot move row"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:928
+#: frappe/public/js/frappe/views/reports/report_view.js:933
 msgid "Cannot remove ID field"
 msgstr ""
 
@@ -4229,11 +4317,11 @@ msgstr ""
 msgid "Cannot update {0}"
 msgstr ""
 
-#: frappe/model/db_query.py:1130
-msgid "Cannot use sub-query in order by"
+#: frappe/model/db_query.py:1143
+msgid "Cannot use sub-query here."
 msgstr ""
 
-#: frappe/model/db_query.py:1149
+#: frappe/model/db_query.py:1175
 msgid "Cannot use {0} in order/group by"
 msgstr ""
 
@@ -4259,7 +4347,7 @@ msgstr ""
 msgid "Card Break"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:261
+#: frappe/public/js/frappe/views/reports/query_report.js:262
 msgid "Card Label"
 msgstr ""
 
@@ -4290,7 +4378,7 @@ msgstr ""
 msgid "Category Name"
 msgstr ""
 
-#: frappe/utils/data.py:1367
+#: frappe/utils/data.py:1358
 msgid "Cent"
 msgstr ""
 
@@ -4393,7 +4481,7 @@ msgstr ""
 #. Label of a Link field in DocType 'Workspace Chart'
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
 #: frappe/desk/doctype/workspace_chart/workspace_chart.json
-#: frappe/public/js/frappe/views/reports/query_report.js:288
+#: frappe/public/js/frappe/views/reports/query_report.js:289
 #: frappe/public/js/frappe/widgets/widget_dialog.js:104
 msgid "Chart Name"
 msgstr ""
@@ -4412,7 +4500,7 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Dashboard Chart'
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
-#: frappe/public/js/frappe/views/reports/report_view.js:506
+#: frappe/public/js/frappe/views/reports/report_view.js:511
 msgid "Chart Type"
 msgstr ""
 
@@ -4459,7 +4547,7 @@ msgstr ""
 msgid "Check columns to select, drag to set order."
 msgstr ""
 
-#: frappe/automation/doctype/auto_repeat/auto_repeat.py:454
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:457
 msgid "Check the Error Log for more information: {0}"
 msgstr ""
 
@@ -4519,7 +4607,7 @@ msgstr ""
 
 #. Description of the 'Is Child Table' (Check) field in DocType 'DocType'
 #: frappe/core/doctype/doctype/doctype.json
-#: frappe/core/doctype/doctype/doctype_list.js:37
+#: frappe/core/doctype/doctype/doctype_list.js:38
 msgid "Child Tables are shown as a Grid in other DocTypes"
 msgstr ""
 
@@ -4548,6 +4636,7 @@ msgid "Choose authentication method to be used by all users"
 msgstr ""
 
 #. Label of a Data field in DocType 'Contact Us Settings'
+#: frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py:39
 #: frappe/website/doctype/contact_us_settings/contact_us_settings.json
 msgid "City"
 msgstr ""
@@ -4562,12 +4651,16 @@ msgstr ""
 msgid "Clear"
 msgstr ""
 
-#: frappe/public/js/frappe/views/communication.js:423
+#: frappe/public/js/frappe/views/communication.js:426
 msgid "Clear & Add Template"
 msgstr ""
 
 #: frappe/public/js/frappe/views/communication.js:102
 msgid "Clear & Add template"
+msgstr ""
+
+#: frappe/public/js/frappe/form/controls/multiselect_list.js:6
+msgid "Clear All"
 msgstr ""
 
 #: frappe/public/js/frappe/list/list_view.js:1897
@@ -4596,7 +4689,7 @@ msgstr ""
 msgid "Clear User Permissions"
 msgstr ""
 
-#: frappe/public/js/frappe/views/communication.js:424
+#: frappe/public/js/frappe/views/communication.js:427
 msgid "Clear the email message and add the template"
 msgstr ""
 
@@ -4608,7 +4701,11 @@ msgstr ""
 msgid "Click On Customize to add your first widget"
 msgstr ""
 
-#: frappe/website/doctype/web_form/templates/web_form.html:144
+#: frappe/templates/emails/user_invitation.html:8
+msgid "Click below to get started:"
+msgstr ""
+
+#: frappe/website/doctype/web_form/templates/web_form.html:151
 msgid "Click here"
 msgstr ""
 
@@ -4673,7 +4770,7 @@ msgstr ""
 msgid "Click to Set Filters"
 msgstr ""
 
-#: frappe/public/js/frappe/list/list_view.js:714
+#: frappe/public/js/frappe/list/list_view.js:716
 msgid "Click to sort by {0}"
 msgstr ""
 
@@ -4818,7 +4915,7 @@ msgctxt "Shrink code field."
 msgid "Collapse"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:1982
+#: frappe/public/js/frappe/views/reports/query_report.js:2019
 #: frappe/public/js/frappe/views/treeview.js:110
 msgid "Collapse All"
 msgstr ""
@@ -4872,7 +4969,7 @@ msgstr ""
 #: frappe/desk/doctype/number_card/number_card.json
 #: frappe/desk/doctype/todo/todo.json
 #: frappe/desk/doctype/workspace_shortcut/workspace_shortcut.json
-#: frappe/public/js/frappe/views/reports/query_report.js:1165
+#: frappe/public/js/frappe/views/reports/query_report.js:1166
 #: frappe/public/js/frappe/widgets/widget_dialog.js:523
 #: frappe/public/js/frappe/widgets/widget_dialog.js:675
 #: frappe/website/doctype/color/color.json
@@ -4920,11 +5017,11 @@ msgstr ""
 msgid "Column Name cannot be empty"
 msgstr ""
 
-#: frappe/public/js/frappe/form/grid_row.js:434
+#: frappe/public/js/frappe/form/grid_row.js:451
 msgid "Column Width"
 msgstr ""
 
-#: frappe/public/js/frappe/form/grid_row.js:631
+#: frappe/public/js/frappe/form/grid_row.js:648
 msgid "Column width cannot be zero."
 msgstr ""
 
@@ -4951,11 +5048,11 @@ msgstr ""
 msgid "Columns / Fields"
 msgstr ""
 
-#: frappe/public/js/frappe/views/kanban/kanban_view.js:396
+#: frappe/public/js/frappe/views/kanban/kanban_view.js:410
 msgid "Columns based on"
 msgstr ""
 
-#: frappe/integrations/doctype/oauth_client/oauth_client.py:48
+#: frappe/integrations/doctype/oauth_client/oauth_client.py:45
 msgid "Combination of Grant Type (<code>{0}</code>) and Response Type (<code>{1}</code>) not allowed"
 msgstr ""
 
@@ -5013,10 +5110,10 @@ msgstr ""
 msgid "Comment publicity can only be updated by the original author or a System Manager."
 msgstr ""
 
-#: frappe/model/meta.py:54 frappe/public/js/frappe/form/controls/comment.js:9
+#: frappe/model/meta.py:55 frappe/public/js/frappe/form/controls/comment.js:9
 #: frappe/public/js/frappe/model/meta.js:206
 #: frappe/public/js/frappe/model/model.js:135
-#: frappe/website/doctype/web_form/templates/web_form.html:119
+#: frappe/website/doctype/web_form/templates/web_form.html:126
 msgid "Comments"
 msgstr ""
 
@@ -5125,7 +5222,7 @@ msgstr ""
 msgid "Complete By"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:420
+#: frappe/core/doctype/user/user.py:421
 #: frappe/templates/emails/new_user.html:10
 msgid "Complete Registration"
 msgstr ""
@@ -5220,11 +5317,11 @@ msgstr ""
 msgid "Configuration"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:488
+#: frappe/public/js/frappe/views/reports/report_view.js:493
 msgid "Configure Chart"
 msgstr ""
 
-#: frappe/public/js/frappe/form/grid_row.js:386
+#: frappe/public/js/frappe/form/grid_row.js:403
 msgid "Configure Columns"
 msgstr ""
 
@@ -5252,7 +5349,7 @@ msgstr ""
 msgid "Configure various aspects of how document naming works like naming series, current counter."
 msgstr ""
 
-#: frappe/core/doctype/user/user.js:395 frappe/public/js/frappe/dom.js:331
+#: frappe/core/doctype/user/user.js:401 frappe/public/js/frappe/dom.js:331
 #: frappe/www/update-password.html:30
 msgid "Confirm"
 msgstr ""
@@ -5271,7 +5368,7 @@ msgstr ""
 msgid "Confirm Deletion of Account"
 msgstr ""
 
-#: frappe/core/doctype/user/user.js:189
+#: frappe/core/doctype/user/user.js:194
 msgid "Confirm New Password"
 msgstr ""
 
@@ -5302,7 +5399,7 @@ msgstr ""
 msgid "Congratulations on completing the module setup. If you want to learn more you can refer to the documentation <a target=\"_blank\" href=\"{0}\">here</a>."
 msgstr ""
 
-#: frappe/integrations/doctype/connected_app/connected_app.js:25
+#: frappe/integrations/doctype/connected_app/connected_app.js:20
 msgid "Connect to {}"
 msgstr ""
 
@@ -5320,8 +5417,8 @@ msgstr ""
 msgid "Connected User"
 msgstr ""
 
-#: frappe/public/js/frappe/form/print_utils.js:97
-#: frappe/public/js/frappe/form/print_utils.js:121
+#: frappe/public/js/frappe/form/print_utils.js:125
+#: frappe/public/js/frappe/form/print_utils.js:149
 msgid "Connected to QZ Tray!"
 msgstr ""
 
@@ -5515,7 +5612,7 @@ msgstr ""
 msgid "Controls whether new users can sign up using this Social Login Key. If unset, Website Settings is respected."
 msgstr ""
 
-#: frappe/public/js/frappe/utils/utils.js:1041
+#: frappe/public/js/frappe/utils/utils.js:1044
 msgid "Copied to clipboard."
 msgstr ""
 
@@ -5531,8 +5628,12 @@ msgstr ""
 msgid "Copy error to clipboard"
 msgstr ""
 
-#: frappe/public/js/frappe/form/toolbar.js:412
+#: frappe/public/js/frappe/form/toolbar.js:415
 msgid "Copy to Clipboard"
+msgstr ""
+
+#: frappe/core/doctype/user/user.js:469
+msgid "Copy token to clipboard"
 msgstr ""
 
 #. Label of a Data field in DocType 'Website Settings'
@@ -5540,7 +5641,7 @@ msgstr ""
 msgid "Copyright"
 msgstr ""
 
-#: frappe/custom/doctype/customize_form/customize_form.py:120
+#: frappe/custom/doctype/customize_form/customize_form.py:125
 msgid "Core DocTypes cannot be customized."
 msgstr ""
 
@@ -5556,7 +5657,7 @@ msgstr ""
 msgid "Could not connect to outgoing email server"
 msgstr ""
 
-#: frappe/model/document.py:975
+#: frappe/model/document.py:979
 msgid "Could not find {0}"
 msgstr ""
 
@@ -5568,7 +5669,7 @@ msgstr ""
 msgid "Could not start up: "
 msgstr ""
 
-#: frappe/public/js/frappe/web_form/web_form.js:359
+#: frappe/public/js/frappe/web_form/web_form.js:383
 msgid "Couldn't save, please check the data you have entered"
 msgstr ""
 
@@ -5580,7 +5681,7 @@ msgstr ""
 #: frappe/desk/doctype/number_card/number_card.json
 #: frappe/desk/doctype/system_health_report_workers/system_health_report_workers.json
 #: frappe/public/js/frappe/ui/group_by/group_by.js:19
-#: frappe/public/js/frappe/ui/group_by/group_by.js:325
+#: frappe/public/js/frappe/ui/group_by/group_by.js:328
 #: frappe/workflow/doctype/workflow/workflow.js:162
 msgid "Count"
 msgstr ""
@@ -5612,13 +5713,14 @@ msgstr ""
 #. Label of a Data field in DocType 'Contact Us Settings'
 #: frappe/contacts/doctype/address/address.json
 #: frappe/contacts/doctype/address_template/address_template.json
+#: frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py:42
 #: frappe/core/doctype/system_settings/system_settings.json
 #: frappe/geo/doctype/country/country.json
 #: frappe/website/doctype/contact_us_settings/contact_us_settings.json
 msgid "Country"
 msgstr ""
 
-#: frappe/utils/__init__.py:116
+#: frappe/utils/__init__.py:118
 msgid "Country Code Required"
 msgstr ""
 
@@ -5649,13 +5751,13 @@ msgstr ""
 #: frappe/public/js/frappe/form/reminders.js:49
 #: frappe/public/js/frappe/views/file/file_view.js:112
 #: frappe/public/js/frappe/views/interaction.js:18
-#: frappe/public/js/frappe/views/reports/query_report.js:1197
+#: frappe/public/js/frappe/views/reports/query_report.js:1198
 #: frappe/public/js/frappe/views/workspace/workspace.js:1262
 #: frappe/workflow/page/workflow_builder/workflow_builder.js:46
 msgid "Create"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype_list.js:85
+#: frappe/core/doctype/doctype/doctype_list.js:86
 msgid "Create & Continue"
 msgstr ""
 
@@ -5664,13 +5766,13 @@ msgstr ""
 msgid "Create Blogger"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:186
-#: frappe/public/js/frappe/views/reports/query_report.js:231
+#: frappe/public/js/frappe/views/reports/query_report.js:187
+#: frappe/public/js/frappe/views/reports/query_report.js:232
 msgid "Create Card"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:284
-#: frappe/public/js/frappe/views/reports/query_report.js:1124
+#: frappe/public/js/frappe/views/reports/query_report.js:285
+#: frappe/public/js/frappe/views/reports/query_report.js:1125
 msgid "Create Chart"
 msgstr ""
 
@@ -5709,12 +5811,12 @@ msgstr ""
 msgid "Create New"
 msgstr ""
 
-#: frappe/public/js/frappe/list/list_view.js:517
+#: frappe/public/js/frappe/list/list_view.js:519
 msgctxt "Create a new document from list view"
 msgid "Create New"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype_list.js:83
+#: frappe/core/doctype/doctype/doctype_list.js:84
 msgid "Create New DocType"
 msgstr ""
 
@@ -5722,7 +5824,7 @@ msgstr ""
 msgid "Create New Kanban Board"
 msgstr ""
 
-#: frappe/core/doctype/user/user.js:267
+#: frappe/core/doctype/user/user.js:273
 msgid "Create User Email"
 msgstr ""
 
@@ -5745,7 +5847,7 @@ msgstr ""
 #: frappe/public/js/frappe/form/controls/link.js:321
 #: frappe/public/js/frappe/form/controls/link.js:323
 #: frappe/public/js/frappe/form/link_selector.js:139
-#: frappe/public/js/frappe/list/list_view.js:506
+#: frappe/public/js/frappe/list/list_view.js:508
 #: frappe/public/js/frappe/web_form/web_form_list.js:225
 msgid "Create a new {0}"
 msgstr ""
@@ -5772,7 +5874,7 @@ msgstr ""
 msgid "Create or Edit Workflow"
 msgstr ""
 
-#: frappe/public/js/frappe/list/list_view.js:509
+#: frappe/public/js/frappe/list/list_view.js:511
 msgid "Create your first {0}"
 msgstr ""
 
@@ -5793,7 +5895,7 @@ msgstr ""
 msgid "Created At"
 msgstr ""
 
-#: frappe/model/meta.py:51
+#: frappe/model/meta.py:52
 #: frappe/public/js/frappe/list/list_sidebar_group_by.js:73
 #: frappe/public/js/frappe/model/meta.js:203
 #: frappe/public/js/frappe/model/model.js:123
@@ -5805,14 +5907,14 @@ msgid "Created Custom Field {0} in {1}"
 msgstr ""
 
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.js:241
-#: frappe/email/doctype/notification/notification.js:32 frappe/model/meta.py:46
+#: frappe/email/doctype/notification/notification.js:32 frappe/model/meta.py:47
 #: frappe/public/js/frappe/model/meta.js:198
 #: frappe/public/js/frappe/model/model.js:125
 #: frappe/public/js/frappe/views/dashboard/dashboard_view.js:479
 msgid "Created On"
 msgstr ""
 
-#: frappe/public/js/frappe/desk.js:504
+#: frappe/public/js/frappe/desk.js:506
 #: frappe/public/js/frappe/views/treeview.js:359
 msgid "Creating {0}"
 msgstr ""
@@ -6133,7 +6235,7 @@ msgstr ""
 #. Label of a Check field in DocType 'DocType'
 #. Label of a Check field in DocType 'Website Theme'
 #: frappe/core/doctype/doctype/doctype.json
-#: frappe/core/doctype/doctype/doctype_list.js:65
+#: frappe/core/doctype/doctype/doctype_list.js:66
 #: frappe/website/doctype/website_theme/website_theme.json
 msgid "Custom?"
 msgstr ""
@@ -6164,13 +6266,13 @@ msgstr ""
 msgid "Customizations Reset"
 msgstr ""
 
-#: frappe/modules/utils.py:96
+#: frappe/modules/utils.py:97
 msgid "Customizations for <b>{0}</b> exported to:<br>{1}"
 msgstr ""
 
 #: frappe/printing/page/print/print.js:171
 #: frappe/public/js/frappe/form/templates/print_layout.html:39
-#: frappe/public/js/frappe/form/toolbar.js:538
+#: frappe/public/js/frappe/form/toolbar.js:541
 #: frappe/public/js/frappe/views/dashboard/dashboard_view.js:197
 msgid "Customize"
 msgstr ""
@@ -6195,7 +6297,7 @@ msgstr ""
 #: frappe/core/doctype/doctype/doctype.js:65
 #: frappe/core/workspace/build/build.json
 #: frappe/custom/doctype/customize_form/customize_form.json
-#: frappe/public/js/frappe/views/kanban/kanban_view.js:342
+#: frappe/public/js/frappe/views/kanban/kanban_view.js:356
 msgid "Customize Form"
 msgstr ""
 
@@ -6289,7 +6391,7 @@ msgstr ""
 msgid "Daily Event Digest is sent for Calendar Events where reminders are set."
 msgstr ""
 
-#: frappe/desk/doctype/event/event.py:97
+#: frappe/desk/doctype/event/event.py:101
 msgid "Daily Events should finish on the Same Day."
 msgstr ""
 
@@ -6442,7 +6544,7 @@ msgstr ""
 msgid "Data Import Template"
 msgstr ""
 
-#: frappe/custom/doctype/customize_form/customize_form.py:612
+#: frappe/custom/doctype/customize_form/customize_form.py:619
 msgid "Data Too Long"
 msgstr ""
 
@@ -6475,7 +6577,7 @@ msgstr ""
 msgid "Database Storage Usage By Tables"
 msgstr ""
 
-#: frappe/custom/doctype/customize_form/customize_form.py:246
+#: frappe/custom/doctype/customize_form/customize_form.py:251
 msgid "Database Table Row Size Limit"
 msgstr ""
 
@@ -6804,6 +6906,12 @@ msgstr ""
 msgid "Defines actions on states and the next step and allowed roles."
 msgstr ""
 
+#. Description of the 'Delete Background Exported Reports After (Hours)' (Int)
+#. field in DocType 'System Settings'
+#: frappe/core/doctype/system_settings/system_settings.json
+msgid "Defines how long exported reports sent via email are kept in the system. Older files will be automatically deleted."
+msgstr ""
+
 #. Description of a DocType
 #: frappe/workflow/doctype/workflow/workflow.json
 msgid "Defines workflow states and rules for a document."
@@ -6821,10 +6929,10 @@ msgstr ""
 #: frappe/core/doctype/docperm/docperm.json
 #: frappe/core/doctype/user_document_type/user_document_type.json
 #: frappe/core/doctype/user_permission/user_permission_list.js:189
-#: frappe/public/js/frappe/form/footer/form_timeline.js:615
+#: frappe/public/js/frappe/form/footer/form_timeline.js:616
 #: frappe/public/js/frappe/form/grid.js:63
-#: frappe/public/js/frappe/form/toolbar.js:447
-#: frappe/public/js/frappe/views/reports/report_view.js:1740
+#: frappe/public/js/frappe/form/toolbar.js:450
+#: frappe/public/js/frappe/views/reports/report_view.js:1749
 #: frappe/public/js/frappe/views/treeview.js:295
 #: frappe/public/js/frappe/views/workspace/workspace.js:868
 #: frappe/public/js/frappe/web_form/web_form_list.js:285
@@ -6838,12 +6946,22 @@ msgctxt "Button in list view actions menu"
 msgid "Delete"
 msgstr ""
 
+#: frappe/website/doctype/web_form/templates/web_form.html:49
+msgctxt "Button in web form"
+msgid "Delete"
+msgstr ""
+
 #: frappe/www/me.html:75
 msgid "Delete Account"
 msgstr ""
 
 #: frappe/public/js/frappe/form/grid.js:63
 msgid "Delete All"
+msgstr ""
+
+#. Label of a Int field in DocType 'System Settings'
+#: frappe/core/doctype/system_settings/system_settings.json
+msgid "Delete Background Exported Reports After (Hours)"
 msgstr ""
 
 #: frappe/public/js/form_builder/components/Section.vue:196
@@ -6855,7 +6973,7 @@ msgstr ""
 msgid "Delete Data"
 msgstr ""
 
-#: frappe/public/js/frappe/views/kanban/kanban_view.js:105
+#: frappe/public/js/frappe/views/kanban/kanban_view.js:115
 msgid "Delete Kanban Board"
 msgstr ""
 
@@ -6873,7 +6991,7 @@ msgstr ""
 msgid "Delete Workspace"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:868
+#: frappe/public/js/frappe/views/reports/query_report.js:869
 msgid "Delete and Generate New"
 msgstr ""
 
@@ -6882,7 +7000,7 @@ msgctxt "Button text"
 msgid "Delete column"
 msgstr ""
 
-#: frappe/public/js/frappe/form/footer/form_timeline.js:723
+#: frappe/public/js/frappe/form/footer/form_timeline.js:724
 msgid "Delete comment?"
 msgstr ""
 
@@ -6958,11 +7076,15 @@ msgstr ""
 msgid "Deleted Name"
 msgstr ""
 
-#: frappe/desk/reportview.py:582
+#: frappe/desk/reportview.py:612
 msgid "Deleted all documents successfully"
 msgstr ""
 
-#: frappe/desk/reportview.py:560
+#: frappe/public/js/frappe/web_form/web_form.js:211
+msgid "Deleted!"
+msgstr ""
+
+#: frappe/desk/reportview.py:590
 msgid "Deleting {0}"
 msgstr ""
 
@@ -6979,7 +7101,7 @@ msgstr ""
 msgid "Deletion Steps "
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_utils.js:282
+#: frappe/public/js/frappe/views/reports/report_utils.js:287
 msgid "Delimiter must be a single character"
 msgstr ""
 
@@ -7145,7 +7267,7 @@ msgstr ""
 #: frappe/public/js/form_builder/components/Tabs.vue:92
 #: frappe/public/js/form_builder/store.js:259
 #: frappe/public/js/form_builder/utils.js:38
-#: frappe/public/js/frappe/form/layout.js:153
+#: frappe/public/js/frappe/form/layout.js:152
 #: frappe/public/js/frappe/views/treeview.js:258
 msgid "Details"
 msgstr ""
@@ -7280,8 +7402,8 @@ msgstr ""
 #: frappe/printing/doctype/print_format/print_format.json
 #: frappe/printing/doctype/print_style/print_style.json
 #: frappe/public/js/frappe/form/templates/address_list.html:29
-#: frappe/public/js/frappe/model/indicator.js:108
-#: frappe/public/js/frappe/model/indicator.js:115
+#: frappe/public/js/frappe/model/indicator.js:112
+#: frappe/public/js/frappe/model/indicator.js:119
 #: frappe/website/doctype/blogger/blogger.json
 msgid "Disabled"
 msgstr ""
@@ -7292,7 +7414,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/views/dashboard/dashboard_view.js:71
 #: frappe/public/js/frappe/views/workspace/workspace.js:547
-#: frappe/public/js/frappe/web_form/web_form.js:187
+#: frappe/public/js/frappe/web_form/web_form.js:193
 msgid "Discard"
 msgstr ""
 
@@ -7306,7 +7428,7 @@ msgctxt "Discard Email"
 msgid "Discard"
 msgstr ""
 
-#: frappe/public/js/frappe/web_form/web_form.js:184
+#: frappe/public/js/frappe/web_form/web_form.js:190
 msgid "Discard?"
 msgstr ""
 
@@ -7325,7 +7447,7 @@ msgstr ""
 msgid "Discussion Topic"
 msgstr ""
 
-#: frappe/public/js/frappe/form/footer/form_timeline.js:627
+#: frappe/public/js/frappe/form/footer/form_timeline.js:628
 #: frappe/templates/discussions/reply_card.html:16
 #: frappe/templates/discussions/reply_section.html:29
 msgid "Dismiss"
@@ -7368,11 +7490,11 @@ msgstr ""
 msgid "Do not create new user if user with email does not exist in the system"
 msgstr ""
 
-#: frappe/public/js/frappe/form/grid.js:1175
+#: frappe/public/js/frappe/form/grid.js:1176
 msgid "Do not edit headers which are preset in the template"
 msgstr ""
 
-#: frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py:65
+#: frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py:70
 msgid "Do not have permission to access bucket {0}."
 msgstr ""
 
@@ -7442,6 +7564,7 @@ msgstr ""
 #. Option for the 'Type' (Select) field in DocType 'Workspace Shortcut'
 #. Label of a Link field in DocType 'Webhook'
 #. Label of a Link field in DocType 'Print Format'
+#. Option for the 'Print Format For' (Select) field in DocType 'Print Format'
 #: frappe/core/doctype/amended_document_naming_settings/amended_document_naming_settings.json
 #: frappe/core/doctype/audit_trail/audit_trail.json
 #: frappe/core/doctype/data_export/exporter.py:26
@@ -7511,11 +7634,11 @@ msgstr ""
 msgid "DocType View"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:645
+#: frappe/core/doctype/doctype/doctype.py:647
 msgid "DocType can not be merged"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:639
+#: frappe/core/doctype/doctype/doctype.py:641
 msgid "DocType can only be renamed by Administrator"
 msgstr ""
 
@@ -7536,7 +7659,7 @@ msgstr ""
 msgid "DocType must have atleast one field"
 msgstr ""
 
-#: frappe/core/doctype/log_settings/log_settings.py:58
+#: frappe/core/doctype/log_settings/log_settings.py:57
 msgid "DocType not supported by Log Settings."
 msgstr ""
 
@@ -7549,15 +7672,15 @@ msgstr ""
 msgid "DocType required"
 msgstr ""
 
-#: frappe/modules/utils.py:175
+#: frappe/modules/utils.py:176
 msgid "DocType {0} does not exist."
 msgstr ""
 
-#: frappe/modules/utils.py:238
+#: frappe/modules/utils.py:239
 msgid "DocType {} not found"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1007
+#: frappe/core/doctype/doctype/doctype.py:1009
 msgid "DocType's name should not start or end with whitespace"
 msgstr ""
 
@@ -7571,7 +7694,7 @@ msgstr ""
 msgid "Doctype"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1001
+#: frappe/core/doctype/doctype/doctype.py:1003
 msgid "Doctype name is limited to {0} characters ({1})"
 msgstr ""
 
@@ -7730,7 +7853,7 @@ msgstr ""
 msgid "Document States"
 msgstr ""
 
-#: frappe/model/meta.py:47 frappe/public/js/frappe/model/meta.js:199
+#: frappe/model/meta.py:48 frappe/public/js/frappe/model/meta.js:199
 #: frappe/public/js/frappe/model/model.js:137
 msgid "Document Status"
 msgstr ""
@@ -7831,19 +7954,19 @@ msgid "Document Types and Permissions"
 msgstr ""
 
 #: frappe/core/doctype/submission_queue/submission_queue.py:163
-#: frappe/model/document.py:1789
+#: frappe/model/document.py:1793
 msgid "Document Unlocked"
 msgstr ""
 
-#: frappe/public/js/frappe/list/list_view.js:1106
+#: frappe/public/js/frappe/list/list_view.js:1108
 msgid "Document has been cancelled"
 msgstr ""
 
-#: frappe/public/js/frappe/list/list_view.js:1105
+#: frappe/public/js/frappe/list/list_view.js:1107
 msgid "Document has been submitted"
 msgstr ""
 
-#: frappe/public/js/frappe/list/list_view.js:1104
+#: frappe/public/js/frappe/list/list_view.js:1106
 msgid "Document is in draft state"
 msgstr ""
 
@@ -7984,13 +8107,13 @@ msgstr ""
 msgid "Double click to edit label"
 msgstr ""
 
-#: frappe/core/doctype/file/file.js:15
+#: frappe/core/doctype/file/file.js:15 frappe/core/doctype/user/user.js:456
 #: frappe/email/doctype/auto_email_report/auto_email_report.js:8
 #: frappe/public/js/frappe/form/grid.js:63
 msgid "Download"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_utils.js:229
+#: frappe/public/js/frappe/views/reports/report_utils.js:234
 msgctxt "Export report"
 msgid "Download"
 msgstr ""
@@ -8017,7 +8140,7 @@ msgstr ""
 msgid "Download PDF"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:764
+#: frappe/public/js/frappe/views/reports/query_report.js:765
 msgid "Download Report"
 msgstr ""
 
@@ -8122,7 +8245,7 @@ msgid "Due Date Based On"
 msgstr ""
 
 #: frappe/public/js/frappe/form/grid_row_form.js:42
-#: frappe/public/js/frappe/form/toolbar.js:401
+#: frappe/public/js/frappe/form/toolbar.js:404
 #: frappe/public/js/frappe/views/workspace/workspace.js:853
 #: frappe/public/js/frappe/views/workspace/workspace.js:1020
 msgid "Duplicate"
@@ -8242,18 +8365,18 @@ msgstr ""
 #: frappe/printing/page/print_format_builder_beta/print_format_builder_beta.js:46
 #: frappe/printing/page/print_format_builder_beta/print_format_builder_beta.js:85
 #: frappe/public/js/frappe/form/controls/markdown_editor.js:31
-#: frappe/public/js/frappe/form/footer/form_timeline.js:656
-#: frappe/public/js/frappe/form/footer/form_timeline.js:665
+#: frappe/public/js/frappe/form/footer/form_timeline.js:657
+#: frappe/public/js/frappe/form/footer/form_timeline.js:666
 #: frappe/public/js/frappe/form/templates/address_list.html:7
 #: frappe/public/js/frappe/form/templates/contact_list.html:7
-#: frappe/public/js/frappe/form/toolbar.js:683
-#: frappe/public/js/frappe/views/reports/query_report.js:812
-#: frappe/public/js/frappe/views/reports/query_report.js:1654
+#: frappe/public/js/frappe/form/toolbar.js:686
+#: frappe/public/js/frappe/views/reports/query_report.js:813
+#: frappe/public/js/frappe/views/reports/query_report.js:1689
 #: frappe/public/js/frappe/views/workspace/workspace.js:98
 #: frappe/public/js/frappe/views/workspace/workspace.js:847
 #: frappe/public/js/frappe/widgets/base_widget.js:64
 #: frappe/public/js/frappe/widgets/chart_widget.js:299
-#: frappe/public/js/frappe/widgets/number_card_widget.js:340
+#: frappe/public/js/frappe/widgets/number_card_widget.js:343
 #: frappe/templates/discussions/reply_card.html:29
 #: frappe/templates/discussions/reply_section.html:29
 #: frappe/workflow/page/workflow_builder/workflow_builder.js:46
@@ -8271,7 +8394,7 @@ msgctxt "Button in web form"
 msgid "Edit"
 msgstr ""
 
-#: frappe/public/js/frappe/form/grid_row.js:341
+#: frappe/public/js/frappe/form/grid_row.js:346
 msgctxt "Edit grid row"
 msgid "Edit"
 msgstr ""
@@ -8284,7 +8407,7 @@ msgstr ""
 msgid "Edit Custom HTML"
 msgstr ""
 
-#: frappe/public/js/frappe/form/toolbar.js:557
+#: frappe/public/js/frappe/form/toolbar.js:560
 msgid "Edit DocType"
 msgstr ""
 
@@ -8306,7 +8429,7 @@ msgstr ""
 msgid "Edit Footer"
 msgstr ""
 
-#: frappe/printing/doctype/print_format/print_format.js:28
+#: frappe/printing/doctype/print_format/print_format.js:29
 msgid "Edit Format"
 msgstr ""
 
@@ -8370,7 +8493,7 @@ msgstr ""
 msgid "Edit to add content"
 msgstr ""
 
-#: frappe/public/js/frappe/web_form/web_form.js:446
+#: frappe/public/js/frappe/web_form/web_form.js:470
 msgctxt "Button in web form"
 msgid "Edit your response"
 msgstr ""
@@ -8379,14 +8502,14 @@ msgstr ""
 msgid "Edit your workflow visually using the Workflow Builder."
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:679
+#: frappe/public/js/frappe/views/reports/report_view.js:684
 msgid "Edit {0}"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocType'
 #. Label of a Check field in DocType 'Customize Form'
 #: frappe/core/doctype/doctype/doctype.json
-#: frappe/core/doctype/doctype/doctype_list.js:41
+#: frappe/core/doctype/doctype/doctype_list.js:42
 #: frappe/custom/doctype/customize_form/customize_form.json
 msgid "Editable Grid"
 msgstr ""
@@ -8425,11 +8548,14 @@ msgstr ""
 #. Label of a Data field in DocType 'User'
 #. Label of a Section Break field in DocType 'User'
 #. Label of a Check field in DocType 'User Document Type'
+#. Label of a Data field in DocType 'User Invitation'
 #. Label of a Data field in DocType 'Event Participants'
 #. Label of a Data field in DocType 'Email Group Member'
 #. Label of a Data field in DocType 'Email Unsubscribe'
 #. Option for the 'Channel' (Select) field in DocType 'Notification'
 #. Label of a Data field in DocType 'Personal Data Deletion Request'
+#. Label of a field in the request-data Web Form
+#. Label of a field in the request-to-delete-data Web Form
 #: frappe/automation/workspace/tools/tools.json
 #: frappe/core/doctype/communication/communication.json
 #: frappe/core/doctype/custom_docperm/custom_docperm.json
@@ -8438,17 +8564,20 @@ msgstr ""
 #: frappe/core/doctype/system_settings/system_settings.json
 #: frappe/core/doctype/user/user.json
 #: frappe/core/doctype/user_document_type/user_document_type.json
+#: frappe/core/doctype/user_invitation/user_invitation.json
 #: frappe/desk/doctype/event_participants/event_participants.json
 #: frappe/email/doctype/email_group_member/email_group_member.json
 #: frappe/email/doctype/email_unsubscribe/email_unsubscribe.json
 #: frappe/email/doctype/newsletter/newsletter.js:156
 #: frappe/email/doctype/notification/notification.json
 #: frappe/public/js/frappe/form/success_action.js:85
-#: frappe/public/js/frappe/form/toolbar.js:365
+#: frappe/public/js/frappe/form/toolbar.js:368
 #: frappe/templates/includes/comments/comments.html:25
 #: frappe/templates/signup.html:9
 #: frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.json
-#: frappe/www/login.html:7 frappe/www/login.py:102
+#: frappe/website/web_form/request_data/request_data.json
+#: frappe/website/web_form/request_to_delete_data/request_to_delete_data.json
+#: frappe/www/login.html:7 frappe/www/login.py:104
 msgid "Email"
 msgstr ""
 
@@ -8481,7 +8610,7 @@ msgstr ""
 msgid "Email Account Name"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:687
+#: frappe/core/doctype/user/user.py:698
 msgid "Email Account added multiple times"
 msgstr ""
 
@@ -8566,6 +8695,7 @@ msgid "Email IDs"
 msgstr ""
 
 #. Label of a Data field in DocType 'Contact Us Settings'
+#: frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py:48
 #: frappe/website/doctype/contact_us_settings/contact_us_settings.json
 msgid "Email Id"
 msgstr ""
@@ -8585,7 +8715,7 @@ msgstr ""
 msgid "Email Queue Recipient"
 msgstr ""
 
-#: frappe/email/queue.py:160
+#: frappe/email/queue.py:161
 msgid "Email Queue flushing aborted due to too many failures."
 msgstr ""
 
@@ -8616,7 +8746,9 @@ msgstr ""
 msgid "Email Sent"
 msgstr ""
 
+#. Label of a Datetime field in DocType 'User Invitation'
 #. Label of a Datetime field in DocType 'Newsletter'
+#: frappe/core/doctype/user_invitation/user_invitation.json
 #: frappe/email/doctype/newsletter/newsletter.json
 msgid "Email Sent At"
 msgstr ""
@@ -8680,11 +8812,11 @@ msgstr ""
 msgid "Email has been moved to trash"
 msgstr ""
 
-#: frappe/public/js/frappe/views/communication.js:807
+#: frappe/public/js/frappe/views/communication.js:810
 msgid "Email not sent to {0} (unsubscribed / disabled)"
 msgstr ""
 
-#: frappe/utils/oauth.py:164
+#: frappe/utils/oauth.py:163
 msgid "Email not verified with {0}"
 msgstr ""
 
@@ -8705,7 +8837,7 @@ msgstr ""
 msgid "Emails are already being pulled from this account."
 msgstr ""
 
-#: frappe/email/queue.py:137
+#: frappe/email/queue.py:138
 msgid "Emails are muted"
 msgstr ""
 
@@ -8733,7 +8865,7 @@ msgstr ""
 msgid "Enable"
 msgstr ""
 
-#: frappe/automation/doctype/auto_repeat/auto_repeat.py:119
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:118
 msgid "Enable Allow Auto Repeat for the doctype {0} in Customize Form"
 msgstr ""
 
@@ -8919,8 +9051,8 @@ msgstr ""
 #: frappe/integrations/doctype/dropbox_settings/dropbox_settings.json
 #: frappe/integrations/doctype/ldap_settings/ldap_settings.json
 #: frappe/integrations/doctype/webhook/webhook.json
-#: frappe/public/js/frappe/model/indicator.js:106
-#: frappe/public/js/frappe/model/indicator.js:117
+#: frappe/public/js/frappe/model/indicator.js:110
+#: frappe/public/js/frappe/model/indicator.js:121
 #: frappe/social/doctype/energy_point_rule/energy_point_rule.json
 #: frappe/social/doctype/energy_point_settings/energy_point_settings.json
 #: frappe/website/doctype/portal_menu_item/portal_menu_item.json
@@ -8977,11 +9109,11 @@ msgstr ""
 msgid "Encrypt Backups"
 msgstr ""
 
-#: frappe/utils/password.py:184
+#: frappe/utils/password.py:189
 msgid "Encryption key is in invalid format!"
 msgstr ""
 
-#: frappe/utils/password.py:199
+#: frappe/utils/password.py:204
 msgid "Encryption key is invalid! Please check site_config.json"
 msgstr ""
 
@@ -8992,7 +9124,7 @@ msgstr ""
 #. Label of a Date field in DocType 'Auto Repeat'
 #. Label of a Datetime field in DocType 'Web Page'
 #: frappe/automation/doctype/auto_repeat/auto_repeat.json
-#: frappe/automation/doctype/auto_repeat/auto_repeat.py:142
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:145
 #: frappe/public/js/frappe/utils/common.js:416
 #: frappe/website/doctype/web_page/web_page.json
 msgid "End Date"
@@ -9005,6 +9137,10 @@ msgstr ""
 
 #: frappe/website/doctype/web_page/web_page.py:208
 msgid "End Date cannot be before Start Date!"
+msgstr ""
+
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:141
+msgid "End Date cannot be today."
 msgstr ""
 
 #. Label of a Datetime field in DocType 'RQ Job'
@@ -9088,7 +9224,7 @@ msgstr ""
 msgid "Enter Code displayed in OTP App."
 msgstr ""
 
-#: frappe/public/js/frappe/views/communication.js:762
+#: frappe/public/js/frappe/views/communication.js:765
 msgid "Enter Email Recipient(s)"
 msgstr ""
 
@@ -9158,10 +9294,17 @@ msgstr ""
 #. Label of a Code field in DocType 'Email Queue Recipient'
 #. Label of a Code field in DocType 'Integration Request'
 #. Label of a Text field in DocType 'Webhook Request Log'
+#: frappe/core/api/user_invitation.py:73 frappe/core/api/user_invitation.py:78
+#: frappe/core/api/user_invitation.py:84 frappe/core/api/user_invitation.py:115
 #: frappe/core/doctype/communication/communication.json
 #: frappe/core/doctype/data_import/data_import.json
 #: frappe/core/doctype/error_log/error_log.json
 #: frappe/core/doctype/prepared_report/prepared_report.json
+#: frappe/core/doctype/user_invitation/user_invitation.py:95
+#: frappe/core/doctype/user_invitation/user_invitation.py:99
+#: frappe/core/doctype/user_invitation/user_invitation.py:102
+#: frappe/core/doctype/user_invitation/user_invitation.py:125
+#: frappe/core/doctype/user_invitation/user_invitation.py:127
 #: frappe/desk/page/backups/backups.js:37
 #: frappe/email/doctype/email_queue/email_queue.json
 #: frappe/email/doctype/email_queue_recipient/email_queue_recipient.json
@@ -9172,7 +9315,7 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#: frappe/public/js/frappe/web_form/web_form.js:240
+#: frappe/public/js/frappe/web_form/web_form.js:264
 msgctxt "Title of error message in web form"
 msgid "Error"
 msgstr ""
@@ -9196,7 +9339,7 @@ msgstr ""
 msgid "Error Message"
 msgstr ""
 
-#: frappe/public/js/frappe/form/print_utils.js:128
+#: frappe/public/js/frappe/form/print_utils.js:156
 msgid "Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a target=\"_blank\" href=\"https://qz.io/download/\">Click here to Download and install QZ Tray</a>.<br> <a target=\"_blank\" href=\"https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing\">Click here to learn more about Raw Printing</a>."
 msgstr ""
 
@@ -9242,7 +9385,7 @@ msgstr ""
 msgid "Error while evaluating Notification {0}. Please fix your template."
 msgstr ""
 
-#: frappe/model/document.py:864
+#: frappe/model/document.py:868
 msgid "Error: Document has been modified after you have opened it"
 msgstr ""
 
@@ -9301,7 +9444,7 @@ msgstr ""
 msgid "Events"
 msgstr ""
 
-#: frappe/desk/doctype/event/event.py:268
+#: frappe/desk/doctype/event/event.py:272
 msgid "Events in Today's Calendar"
 msgstr ""
 
@@ -9396,7 +9539,7 @@ msgstr ""
 msgid "Executing..."
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:1996
+#: frappe/public/js/frappe/views/reports/query_report.js:2033
 msgid "Execution Time: {0} sec"
 msgstr ""
 
@@ -9414,7 +9557,7 @@ msgctxt "Enlarge code field."
 msgid "Expand"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:1982
+#: frappe/public/js/frappe/views/reports/query_report.js:2019
 #: frappe/public/js/frappe/views/treeview.js:114
 msgid "Expand All"
 msgstr ""
@@ -9441,7 +9584,9 @@ msgid "Expire Notification On"
 msgstr ""
 
 #. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
+#. Option for the 'Status' (Select) field in DocType 'User Invitation'
 #: frappe/core/doctype/communication/communication.json
+#: frappe/core/doctype/user_invitation/user_invitation.json
 msgid "Expired"
 msgstr ""
 
@@ -9469,8 +9614,8 @@ msgstr ""
 #: frappe/core/doctype/recorder/recorder_list.js:37
 #: frappe/public/js/frappe/data_import/data_exporter.js:92
 #: frappe/public/js/frappe/data_import/data_exporter.js:243
-#: frappe/public/js/frappe/views/reports/query_report.js:1689
-#: frappe/public/js/frappe/views/reports/report_view.js:1628
+#: frappe/public/js/frappe/views/reports/query_report.js:1726
+#: frappe/public/js/frappe/views/reports/report_view.js:1630
 msgid "Export"
 msgstr ""
 
@@ -9511,7 +9656,7 @@ msgstr ""
 msgid "Export Import Log"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_utils.js:227
+#: frappe/public/js/frappe/views/reports/report_utils.js:232
 msgctxt "Export report"
 msgid "Export Report: {0}"
 msgstr ""
@@ -9520,16 +9665,20 @@ msgstr ""
 msgid "Export Type"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1639
+#: frappe/public/js/frappe/views/reports/report_view.js:1641
 msgid "Export all matching rows?"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1649
+#: frappe/public/js/frappe/views/reports/report_view.js:1651
 msgid "Export all {0} rows?"
 msgstr ""
 
 #: frappe/public/js/frappe/views/file/file_view.js:154
 msgid "Export as zip"
+msgstr ""
+
+#: frappe/public/js/frappe/views/reports/report_utils.js:179
+msgid "Export in Background"
 msgstr ""
 
 #: frappe/public/js/frappe/utils/tools.js:11
@@ -9654,15 +9803,15 @@ msgstr ""
 msgid "Failed to connect to server"
 msgstr ""
 
-#: frappe/auth.py:687
+#: frappe/auth.py:690
 msgid "Failed to decode token, please provide a valid base64-encoded token."
 msgstr ""
 
-#: frappe/utils/password.py:198
+#: frappe/utils/password.py:203
 msgid "Failed to decrypt key {0}"
 msgstr ""
 
-#: frappe/desk/reportview.py:576
+#: frappe/desk/reportview.py:606
 msgid "Failed to delete {0} documents: {1}"
 msgstr ""
 
@@ -9686,11 +9835,11 @@ msgstr ""
 msgid "Failed to generate preview of series"
 msgstr ""
 
-#: frappe/handler.py:75
+#: frappe/handler.py:76
 msgid "Failed to get method for command {0} with {1}"
 msgstr ""
 
-#: frappe/api/v2.py:45
+#: frappe/api/v2.py:46
 msgid "Failed to get method {0} with {1}"
 msgstr ""
 
@@ -9820,14 +9969,14 @@ msgstr ""
 #: frappe/desk/page/leaderboard/leaderboard.js:131
 #: frappe/public/js/frappe/list/bulk_operations.js:327
 #: frappe/public/js/frappe/list/list_view_permission_restrictions.html:3
-#: frappe/public/js/frappe/views/reports/query_report.js:235
-#: frappe/public/js/frappe/views/reports/query_report.js:1748
+#: frappe/public/js/frappe/views/reports/query_report.js:236
+#: frappe/public/js/frappe/views/reports/query_report.js:1785
 #: frappe/website/doctype/web_form_field/web_form_field.json
 #: frappe/website/doctype/web_form_list_column/web_form_list_column.json
 msgid "Field"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:414
+#: frappe/core/doctype/doctype/doctype.py:416
 msgid "Field \"route\" is mandatory for Web Views"
 msgstr ""
 
@@ -9844,7 +9993,7 @@ msgstr ""
 msgid "Field Description"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1056
+#: frappe/core/doctype/doctype/doctype.py:1058
 msgid "Field Missing"
 msgstr ""
 
@@ -9879,7 +10028,7 @@ msgstr ""
 msgid "Field Type"
 msgstr ""
 
-#: frappe/desk/reportview.py:184
+#: frappe/desk/reportview.py:180
 msgid "Field not permitted in query"
 msgstr ""
 
@@ -9897,7 +10046,7 @@ msgstr ""
 msgid "Field type cannot be changed for {0}"
 msgstr ""
 
-#: frappe/database/database.py:844
+#: frappe/database/database.py:843
 msgid "Field {0} does not exist on {1}"
 msgstr ""
 
@@ -9923,20 +10072,20 @@ msgstr ""
 #: frappe/custom/doctype/doctype_layout_field/doctype_layout_field.json
 #: frappe/desk/doctype/form_tour_step/form_tour_step.json
 #: frappe/integrations/doctype/webhook_data/webhook_data.json
-#: frappe/public/js/frappe/form/grid_row.js:434
+#: frappe/public/js/frappe/form/grid_row.js:451
 #: frappe/website/doctype/web_template_field/web_template_field.json
 msgid "Fieldname"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:270
+#: frappe/core/doctype/doctype/doctype.py:272
 msgid "Fieldname '{0}' conflicting with a {1} of the name {2} in {3}"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1055
+#: frappe/core/doctype/doctype/doctype.py:1057
 msgid "Fieldname called {0} must exist to enable autonaming"
 msgstr ""
 
-#: frappe/database/schema.py:124 frappe/database/schema.py:318
+#: frappe/database/schema.py:128 frappe/database/schema.py:322
 msgid "Fieldname is limited to 64 characters ({0})"
 msgstr ""
 
@@ -9952,15 +10101,15 @@ msgstr ""
 msgid "Fieldname {0} appears multiple times"
 msgstr ""
 
-#: frappe/database/schema.py:308
+#: frappe/database/schema.py:312
 msgid "Fieldname {0} cannot have special characters like {1}"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1872
+#: frappe/core/doctype/doctype/doctype.py:1885
 msgid "Fieldname {0} conflicting with meta object"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:493
+#: frappe/core/doctype/doctype/doctype.py:495
 #: frappe/public/js/form_builder/utils.js:302
 msgid "Fieldname {0} is restricted"
 msgstr ""
@@ -9993,7 +10142,7 @@ msgstr ""
 msgid "Fields Multicheck"
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:408
+#: frappe/core/doctype/file/file.py:417
 msgid "Fields `file_name` or `file_url` must be set for File"
 msgstr ""
 
@@ -10021,7 +10170,7 @@ msgstr ""
 msgid "Fieldtype cannot be changed from {0} to {1}"
 msgstr ""
 
-#: frappe/custom/doctype/customize_form/customize_form.py:586
+#: frappe/custom/doctype/customize_form/customize_form.py:593
 msgid "Fieldtype cannot be changed from {0} to {1} in row {2}"
 msgstr ""
 
@@ -10092,7 +10241,7 @@ msgstr ""
 msgid "File backup is ready"
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:616
+#: frappe/core/doctype/file/file.py:628
 msgid "File name cannot have {0}"
 msgstr ""
 
@@ -10100,7 +10249,7 @@ msgstr ""
 msgid "File not attached"
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:726 frappe/public/js/frappe/request.js:197
+#: frappe/core/doctype/file/file.py:738 frappe/public/js/frappe/request.js:197
 #: frappe/utils/file_manager.py:222
 msgid "File size exceeded the maximum allowed size of {0} MB"
 msgstr ""
@@ -10109,11 +10258,11 @@ msgstr ""
 msgid "File too big"
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:373
+#: frappe/core/doctype/file/file.py:378
 msgid "File type of {0} is not allowed"
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:361 frappe/core/doctype/file/file.py:424
+#: frappe/core/doctype/file/file.py:366 frappe/core/doctype/file/file.py:436
 msgid "File {0} does not exist"
 msgstr ""
 
@@ -10166,11 +10315,11 @@ msgstr ""
 msgid "Filter Values"
 msgstr ""
 
-#: frappe/utils/data.py:1841
+#: frappe/utils/data.py:1860
 msgid "Filter must be a tuple or list (in a list)"
 msgstr ""
 
-#: frappe/utils/data.py:1849
+#: frappe/utils/data.py:1868
 msgid "Filter must have 4 values (doctype, fieldname, operator, value): {0}"
 msgstr ""
 
@@ -10239,7 +10388,7 @@ msgstr ""
 msgid "Filters applied for {0}"
 msgstr ""
 
-#: frappe/public/js/frappe/views/kanban/kanban_view.js:187
+#: frappe/public/js/frappe/views/kanban/kanban_view.js:201
 msgid "Filters saved"
 msgstr ""
 
@@ -10252,7 +10401,7 @@ msgstr ""
 msgid "Filters {0}"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1428
+#: frappe/public/js/frappe/views/reports/report_view.js:1430
 msgid "Filters:"
 msgstr ""
 
@@ -10284,8 +10433,12 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Contact'
 #. Label of a Data field in DocType 'User'
+#. Label of a field in the edit-profile Web Form
 #: frappe/contacts/doctype/contact/contact.json
-#: frappe/core/doctype/user/user.json frappe/www/complete_signup.html:15
+#: frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py:44
+#: frappe/core/doctype/user/user.json
+#: frappe/core/web_form/edit_profile/edit_profile.json
+#: frappe/www/complete_signup.html:15
 msgid "First Name"
 msgstr ""
 
@@ -10370,7 +10523,7 @@ msgstr ""
 msgid "Folder name should not include '/' (slash)"
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:470
+#: frappe/core/doctype/file/file.py:482
 msgid "Folder {0} is not empty"
 msgstr ""
 
@@ -10564,8 +10717,8 @@ msgstr ""
 msgid "For Value"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:1993
-#: frappe/public/js/frappe/views/reports/report_view.js:102
+#: frappe/public/js/frappe/views/reports/query_report.js:2030
+#: frappe/public/js/frappe/views/reports/report_view.js:108
 msgid "For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 & 10)."
 msgstr ""
 
@@ -10594,7 +10747,7 @@ msgstr ""
 #. Description of the 'Enable Automatic Linking in Documents' (Check) field in
 #. DocType 'Email Account'
 #: frappe/email/doctype/email_account/email_account.json
-msgid "For more information, <a class=\"text-muted\" href=\"https://erpnext.com/docs/user/manual/en/setting-up/email/linking-emails-to-document\">click here</a>."
+msgid "For more information, <a class=\"text-muted\" href=\"https://docs.frappe.io/erpnext/user/manual/en/linking-emails-to-document\">click here</a>."
 msgstr ""
 
 #: frappe/integrations/doctype/google_settings/google_settings.js:7
@@ -10611,7 +10764,7 @@ msgstr ""
 msgid "For updating, you can update only selective columns."
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1716
+#: frappe/core/doctype/doctype/doctype.py:1729
 msgid "For {0} at level {1} in {2} in row {3}"
 msgstr ""
 
@@ -10742,7 +10895,7 @@ msgstr ""
 #. Login Key'
 #: frappe/integrations/doctype/social_login_key/social_login_key.json
 #: frappe/www/login.html:63 frappe/www/login.html:161 frappe/www/login.py:53
-#: frappe/www/login.py:151
+#: frappe/www/login.py:153
 msgid "Frappe"
 msgstr ""
 
@@ -10822,7 +10975,7 @@ msgstr ""
 msgid "From Date Field"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:1709
+#: frappe/public/js/frappe/views/reports/query_report.js:1746
 msgid "From Document Type"
 msgstr ""
 
@@ -10872,7 +11025,7 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Number Card'
 #: frappe/desk/doctype/number_card/number_card.json
-#: frappe/public/js/frappe/views/reports/query_report.js:245
+#: frappe/public/js/frappe/views/reports/query_report.js:246
 #: frappe/public/js/frappe/widgets/widget_dialog.js:684
 msgid "Function"
 msgstr ""
@@ -10886,7 +11039,7 @@ msgid "Function {0} is not whitelisted."
 msgstr ""
 
 #: frappe/public/js/frappe/views/treeview.js:385
-msgid "Further nodes can be only created under 'Group' type nodes"
+msgid "Further sub-groups can only be created under records marked as 'Group'"
 msgstr ""
 
 #: frappe/core/doctype/communication/communication.js:291
@@ -10951,7 +11104,7 @@ msgstr ""
 msgid "Generate Keys"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:806
+#: frappe/public/js/frappe/views/reports/query_report.js:807
 msgid "Generate New Report"
 msgstr ""
 
@@ -10960,7 +11113,7 @@ msgid "Generate Random Password"
 msgstr ""
 
 #: frappe/public/js/frappe/ui/toolbar/toolbar.js:162
-#: frappe/public/js/frappe/utils/utils.js:1769
+#: frappe/public/js/frappe/utils/utils.js:1785
 msgid "Generate Tracking URL"
 msgstr ""
 
@@ -11071,7 +11224,7 @@ msgid "Global Unsubscribe"
 msgstr ""
 
 #: frappe/desk/page/user_profile/user_profile_controller.js:68
-#: frappe/public/js/frappe/form/toolbar.js:778
+#: frappe/public/js/frappe/form/toolbar.js:781
 msgid "Go"
 msgstr ""
 
@@ -11344,7 +11497,9 @@ msgid "Grid Empty State"
 msgstr ""
 
 #. Label of a Int field in DocType 'DocType'
+#. Label of a Int field in DocType 'Customize Form'
 #: frappe/core/doctype/doctype/doctype.json
+#: frappe/custom/doctype/customize_form/customize_form.json
 msgid "Grid Page Length"
 msgstr ""
 
@@ -11381,10 +11536,6 @@ msgstr ""
 msgid "Group By field is required to create a dashboard chart"
 msgstr ""
 
-#: frappe/public/js/frappe/views/treeview.js:384
-msgid "Group Node"
-msgstr ""
-
 #. Label of a Data field in DocType 'LDAP Settings'
 #: frappe/integrations/doctype/ldap_settings/ldap_settings.json
 msgid "Group Object Class"
@@ -11395,7 +11546,7 @@ msgstr ""
 msgid "Group your custom doctypes under modules"
 msgstr ""
 
-#: frappe/public/js/frappe/ui/group_by/group_by.js:425
+#: frappe/public/js/frappe/ui/group_by/group_by.js:428
 msgid "Grouped by <span style='font-weight:600;'>{0}</b>"
 msgstr ""
 
@@ -11437,7 +11588,7 @@ msgstr ""
 #: frappe/email/doctype/notification/notification.json
 #: frappe/printing/doctype/letter_head/letter_head.json
 #: frappe/printing/doctype/print_format/print_format.json
-#: frappe/printing/doctype/print_format/print_format.py:93
+#: frappe/printing/doctype/print_format/print_format.py:102
 #: frappe/public/js/print_format_builder/Field.vue:86
 #: frappe/website/doctype/blog_post/blog_post.json
 #: frappe/website/doctype/web_form_field/web_form_field.json
@@ -11597,6 +11748,12 @@ msgstr ""
 msgid "Hello"
 msgstr ""
 
+#: frappe/templates/emails/user_invitation.html:2
+#: frappe/templates/emails/user_invitation_cancelled.html:2
+#: frappe/templates/emails/user_invitation_expired.html:2
+msgid "Hello,"
+msgstr ""
+
 #. Label of a Section Break field in DocType 'Server Script'
 #. Label of a HTML field in DocType 'Property Setter'
 #: frappe/core/doctype/server_script/server_script.json
@@ -11662,7 +11819,7 @@ msgstr ""
 msgid "Helvetica Neue"
 msgstr ""
 
-#: frappe/public/js/frappe/utils/utils.js:1766
+#: frappe/public/js/frappe/utils/utils.js:1782
 msgid "Here's your tracking URL"
 msgstr ""
 
@@ -11818,7 +11975,7 @@ msgstr ""
 msgid "Hide descendant records of <b>For Value</b>."
 msgstr ""
 
-#: frappe/public/js/frappe/form/layout.js:286
+#: frappe/public/js/frappe/form/layout.js:285
 msgid "Hide details"
 msgstr ""
 
@@ -11937,11 +12094,11 @@ msgstr ""
 msgid "I guess you don't have access to any workspace yet, but you can create one just for yourself. Click on the <b>Create Workspace</b> button to create one.<br>"
 msgstr ""
 
-#: frappe/core/doctype/data_import/importer.py:1127
-#: frappe/core/doctype/data_import/importer.py:1133
-#: frappe/core/doctype/data_import/importer.py:1198
+#: frappe/core/doctype/data_import/importer.py:1130
+#: frappe/core/doctype/data_import/importer.py:1136
 #: frappe/core/doctype/data_import/importer.py:1201
-#: frappe/desk/report/todo/todo.py:36 frappe/model/meta.py:45
+#: frappe/core/doctype/data_import/importer.py:1204
+#: frappe/desk/report/todo/todo.py:36 frappe/model/meta.py:46
 #: frappe/public/js/frappe/data_import/data_exporter.js:330
 #: frappe/public/js/frappe/data_import/data_exporter.js:345
 #: frappe/public/js/frappe/list/list_settings.js:337
@@ -11952,8 +12109,8 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: frappe/desk/reportview.py:470
-#: frappe/public/js/frappe/views/reports/report_view.js:985
+#: frappe/desk/reportview.py:500
+#: frappe/public/js/frappe/views/reports/report_view.js:990
 msgctxt "Label of name column in report"
 msgid "ID"
 msgstr ""
@@ -12049,7 +12206,7 @@ msgstr ""
 msgid "If Checked workflow status will not override status in list view"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1728
+#: frappe/core/doctype/doctype/doctype.py:1741
 #: frappe/public/js/frappe/roles_editor.js:65
 msgid "If Owner"
 msgstr ""
@@ -12136,6 +12293,12 @@ msgstr ""
 msgid "If enabled, users will be notified every time they login. If not enabled, users will only be notified once."
 msgstr ""
 
+#. Description of the 'Backup Path' (Data) field in DocType 'S3 Backup
+#. Settings'
+#: frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.json
+msgid "If it's empty, it will backup to the root of the bucket."
+msgstr ""
+
 #. Description of the 'Default Workspace' (Link) field in DocType 'User'
 #: frappe/core/doctype/user/user.json
 msgid "If left empty, the default workspace will be the last visited workspace"
@@ -12183,6 +12346,10 @@ msgstr ""
 msgid "If these instructions where not helpful, please add in your suggestions on GitHub Issues."
 msgstr ""
 
+#: frappe/templates/emails/user_invitation_cancelled.html:8
+msgid "If this was a mistake or you need access again, please reach out to your team."
+msgstr ""
+
 #. Description of the 'Fetch on Save if Empty' (Check) field in DocType
 #. 'DocField'
 #. Description of the 'Fetch on Save if Empty' (Check) field in DocType 'Custom
@@ -12214,7 +12381,11 @@ msgstr ""
 msgid "If you are uploading new records, leave the \"name\" (ID) column blank."
 msgstr ""
 
-#: frappe/utils/password.py:201
+#: frappe/templates/emails/user_invitation.html:19
+msgid "If you have any questions, reach out to your system administrator."
+msgstr ""
+
+#: frappe/utils/password.py:206
 msgid "If you have recently restored the site you may need to copy the site config contaning original Encryption Key."
 msgstr ""
 
@@ -12276,8 +12447,8 @@ msgstr ""
 msgid "Illegal Document Status for {0}"
 msgstr ""
 
-#: frappe/model/db_query.py:443 frappe/model/db_query.py:446
-#: frappe/model/db_query.py:1133
+#: frappe/model/db_query.py:445 frappe/model/db_query.py:448
+#: frappe/model/db_query.py:1129
 msgid "Illegal SQL Query"
 msgstr ""
 
@@ -12359,11 +12530,11 @@ msgstr ""
 
 #. Option for the 'Operation' (Select) field in DocType 'Activity Log'
 #: frappe/core/doctype/activity_log/activity_log.json
-#: frappe/core/doctype/user/user.js:367
+#: frappe/core/doctype/user/user.js:373
 msgid "Impersonate"
 msgstr ""
 
-#: frappe/core/doctype/user/user.js:394
+#: frappe/core/doctype/user/user.js:400
 msgid "Impersonate as {0}"
 msgstr ""
 
@@ -12375,7 +12546,7 @@ msgstr ""
 msgid "Impersonating {0}"
 msgstr ""
 
-#: frappe/core/doctype/log_settings/log_settings.py:57
+#: frappe/core/doctype/log_settings/log_settings.py:56
 msgid "Implement `clear_old_logs` method to enable auto error clearing."
 msgstr ""
 
@@ -12623,11 +12794,12 @@ msgstr ""
 msgid "Include Web View Link in Email"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:1526
+#: frappe/public/js/frappe/form/print_utils.js:59
+#: frappe/public/js/frappe/views/reports/query_report.js:1551
 msgid "Include filters"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:1518
+#: frappe/public/js/frappe/views/reports/query_report.js:1543
 msgid "Include indentation"
 msgstr ""
 
@@ -12665,7 +12837,7 @@ msgstr ""
 msgid "Incomplete Virtual Doctype Implementation"
 msgstr ""
 
-#: frappe/auth.py:246
+#: frappe/auth.py:249
 msgid "Incomplete login details"
 msgstr ""
 
@@ -12677,7 +12849,7 @@ msgstr ""
 msgid "Incorrect URL"
 msgstr ""
 
-#: frappe/utils/password.py:90
+#: frappe/utils/password.py:95
 msgid "Incorrect User or Password"
 msgstr ""
 
@@ -12685,11 +12857,11 @@ msgstr ""
 msgid "Incorrect Verification code"
 msgstr ""
 
-#: frappe/model/document.py:1392
+#: frappe/model/document.py:1396
 msgid "Incorrect value in row {0}:"
 msgstr ""
 
-#: frappe/model/document.py:1394
+#: frappe/model/document.py:1398
 msgid "Incorrect value:"
 msgstr ""
 
@@ -12698,10 +12870,10 @@ msgstr ""
 #. Label of a Check field in DocType 'Custom Field'
 #: frappe/core/doctype/docfield/docfield.json
 #: frappe/core/doctype/recorder_query/recorder_query.json
-#: frappe/custom/doctype/custom_field/custom_field.json frappe/model/meta.py:48
+#: frappe/custom/doctype/custom_field/custom_field.json frappe/model/meta.py:49
 #: frappe/public/js/frappe/model/meta.js:200
 #: frappe/public/js/frappe/model/model.js:124
-#: frappe/public/js/frappe/views/reports/report_view.js:1006
+#: frappe/public/js/frappe/views/reports/report_view.js:1011
 msgid "Index"
 msgstr ""
 
@@ -12773,7 +12945,7 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Custom Field'
 #: frappe/custom/doctype/custom_field/custom_field.json
-#: frappe/public/js/frappe/views/reports/query_report.js:1754
+#: frappe/public/js/frappe/views/reports/query_report.js:1791
 msgid "Insert After"
 msgstr ""
 
@@ -12789,7 +12961,7 @@ msgstr ""
 msgid "Insert Below"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:391
+#: frappe/public/js/frappe/views/reports/report_view.js:396
 msgid "Insert Column Before {0}"
 msgstr ""
 
@@ -12845,15 +13017,15 @@ msgstr ""
 msgid "Insufficient Permission for {0}"
 msgstr ""
 
-#: frappe/desk/reportview.py:339
+#: frappe/desk/reportview.py:335
 msgid "Insufficient Permissions for deleting Report"
 msgstr ""
 
-#: frappe/desk/reportview.py:310
+#: frappe/desk/reportview.py:306
 msgid "Insufficient Permissions for editing Report"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:442
+#: frappe/core/doctype/doctype/doctype.py:444
 msgid "Insufficient attachment limit"
 msgstr ""
 
@@ -12965,17 +13137,17 @@ msgid "Invalid"
 msgstr ""
 
 #: frappe/public/js/form_builder/utils.js:221
-#: frappe/public/js/frappe/form/grid_row.js:800
-#: frappe/public/js/frappe/form/layout.js:803
-#: frappe/public/js/frappe/views/reports/report_view.js:717
+#: frappe/public/js/frappe/form/grid_row.js:817
+#: frappe/public/js/frappe/form/layout.js:802
+#: frappe/public/js/frappe/views/reports/report_view.js:722
 msgid "Invalid \"depends_on\" expression"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:513
+#: frappe/public/js/frappe/views/reports/query_report.js:514
 msgid "Invalid \"depends_on\" expression set in filter {0}"
 msgstr ""
 
-#: frappe/public/js/frappe/form/save.js:159
+#: frappe/public/js/frappe/form/save.js:210
 msgid "Invalid \"mandatory_depends_on\" expression"
 msgstr ""
 
@@ -12999,7 +13171,7 @@ msgstr ""
 msgid "Invalid Credentials"
 msgstr ""
 
-#: frappe/utils/data.py:105 frappe/utils/data.py:257
+#: frappe/utils/data.py:105 frappe/utils/data.py:254
 msgid "Invalid Date"
 msgstr ""
 
@@ -13011,11 +13183,15 @@ msgstr ""
 msgid "Invalid DocType: {0}"
 msgstr ""
 
+#: frappe/email/doctype/email_group/email_group.py:51
+msgid "Invalid Doctype"
+msgstr ""
+
 #: frappe/core/doctype/doctype/doctype.py:1237
 msgid "Invalid Fieldname"
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:207
+#: frappe/core/doctype/file/file.py:212
 msgid "Invalid File URL"
 msgstr ""
 
@@ -13035,7 +13211,7 @@ msgstr ""
 msgid "Invalid Link"
 msgstr ""
 
-#: frappe/www/login.py:126
+#: frappe/www/login.py:128
 msgid "Invalid Login Token"
 msgstr ""
 
@@ -13047,7 +13223,7 @@ msgstr ""
 msgid "Invalid Mail Server. Please rectify and try again."
 msgstr ""
 
-#: frappe/model/naming.py:94
+#: frappe/model/naming.py:102
 msgid "Invalid Naming Series: {}"
 msgstr ""
 
@@ -13069,22 +13245,22 @@ msgstr ""
 msgid "Invalid Output Format"
 msgstr ""
 
-#: frappe/integrations/doctype/connected_app/connected_app.py:194
+#: frappe/integrations/doctype/connected_app/connected_app.py:201
 msgid "Invalid Parameters."
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:1173 frappe/www/update-password.html:121
+#: frappe/core/doctype/user/user.py:1186 frappe/www/update-password.html:121
 #: frappe/www/update-password.html:142 frappe/www/update-password.html:144
 #: frappe/www/update-password.html:245
 msgid "Invalid Password"
 msgstr ""
 
-#: frappe/utils/__init__.py:109
+#: frappe/utils/__init__.py:111
 msgid "Invalid Phone Number"
 msgstr ""
 
-#: frappe/auth.py:95 frappe/utils/oauth.py:185 frappe/utils/oauth.py:192
-#: frappe/www/login.py:126
+#: frappe/auth.py:98 frappe/utils/oauth.py:184 frappe/utils/oauth.py:191
+#: frappe/www/login.py:128
 msgid "Invalid Request"
 msgstr ""
 
@@ -13100,7 +13276,7 @@ msgstr ""
 msgid "Invalid Transition"
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:218
+#: frappe/core/doctype/file/file.py:223
 #: frappe/public/js/frappe/file_uploader/FileUploader.vue:530
 #: frappe/public/js/frappe/widgets/widget_dialog.js:583
 #: frappe/utils/csvutils.py:201 frappe/utils/csvutils.py:222
@@ -13119,15 +13295,19 @@ msgstr ""
 msgid "Invalid Webhook Secret"
 msgstr ""
 
-#: frappe/desk/reportview.py:169
+#: frappe/desk/reportview.py:165
 msgid "Invalid aggregate function"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:400
+#: frappe/core/doctype/user_invitation/user_invitation.py:195
+msgid "Invalid app"
+msgstr ""
+
+#: frappe/public/js/frappe/views/reports/report_view.js:405
 msgid "Invalid column"
 msgstr ""
 
-#: frappe/model/document.py:894 frappe/model/document.py:908
+#: frappe/model/document.py:898 frappe/model/document.py:912
 msgid "Invalid docstatus"
 msgstr ""
 
@@ -13139,11 +13319,15 @@ msgstr ""
 msgid "Invalid expression set in filter {0} ({1})"
 msgstr ""
 
-#: frappe/utils/data.py:1953
+#: frappe/desk/page/user_profile/user_profile.py:34
+msgid "Invalid field for grouping"
+msgstr ""
+
+#: frappe/utils/data.py:1972
 msgid "Invalid field name {0}"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1064
+#: frappe/core/doctype/doctype/doctype.py:1066
 msgid "Invalid fieldname '{0}' in autoname"
 msgstr ""
 
@@ -13160,17 +13344,29 @@ msgstr ""
 msgid "Invalid include path"
 msgstr ""
 
+#: frappe/core/api/user_invitation.py:17
+msgid "Invalid input"
+msgstr ""
+
 #: frappe/desk/doctype/dashboard/dashboard.py:67
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.py:414
 msgid "Invalid json added in the custom options: {0}"
 msgstr ""
 
-#: frappe/model/naming.py:472
+#: frappe/core/api/user_invitation.py:115
+msgid "Invalid key"
+msgstr ""
+
+#: frappe/model/naming.py:480
 msgid "Invalid name type (integer) for varchar name column"
 msgstr ""
 
 #: frappe/model/naming.py:55
 msgid "Invalid naming series {}: dot (.) missing"
+msgstr ""
+
+#: frappe/model/naming.py:69
+msgid "Invalid naming series {}: dot (.) missing before the numeric placeholders. Kindly use a format like <b>ABCD.#####</b>."
 msgstr ""
 
 #: frappe/core/doctype/data_import/importer.py:446
@@ -13185,11 +13381,15 @@ msgstr ""
 msgid "Invalid request arguments"
 msgstr ""
 
+#: frappe/core/doctype/user_invitation/user_invitation.py:181
+msgid "Invalid role"
+msgstr ""
+
 #: frappe/core/doctype/data_import/importer.py:423
 msgid "Invalid template file for import"
 msgstr ""
 
-#: frappe/integrations/doctype/connected_app/connected_app.py:200
+#: frappe/integrations/doctype/connected_app/connected_app.py:207
 msgid "Invalid token state! Check if the token has been created by the OAuth user."
 msgstr ""
 
@@ -13198,7 +13398,7 @@ msgstr ""
 msgid "Invalid username or password"
 msgstr ""
 
-#: frappe/public/js/frappe/web_form/web_form.js:229
+#: frappe/public/js/frappe/web_form/web_form.js:253
 msgctxt "Error message in web form"
 msgid "Invalid values for fields:"
 msgstr ""
@@ -13216,8 +13416,45 @@ msgstr ""
 msgid "Inverse"
 msgstr ""
 
+#: frappe/core/doctype/user_invitation/user_invitation.py:95
+msgid "Invitation already accepted"
+msgstr ""
+
+#: frappe/core/doctype/user_invitation/user_invitation.py:99
+msgid "Invitation already exists"
+msgstr ""
+
+#: frappe/core/api/user_invitation.py:84
+msgid "Invitation cannot be cancelled"
+msgstr ""
+
+#: frappe/core/doctype/user_invitation/user_invitation.py:127
+msgid "Invitation is cancelled"
+msgstr ""
+
+#: frappe/core/doctype/user_invitation/user_invitation.py:125
+msgid "Invitation is expired"
+msgstr ""
+
+#: frappe/core/api/user_invitation.py:73 frappe/core/api/user_invitation.py:78
+msgid "Invitation not found"
+msgstr ""
+
+#: frappe/core/doctype/user_invitation/user_invitation.py:59
+msgid "Invitation to join {0} cancelled"
+msgstr ""
+
+#: frappe/core/doctype/user_invitation/user_invitation.py:76
+msgid "Invitation to join {0} expired"
+msgstr ""
+
 #: frappe/contacts/doctype/contact/contact.js:30
 msgid "Invite as User"
+msgstr ""
+
+#. Label of a Link field in DocType 'User Invitation'
+#: frappe/core/doctype/user_invitation/user_invitation.json
+msgid "Invited By"
 msgstr ""
 
 #: frappe/public/js/frappe/ui/filters/filter.js:22
@@ -13244,7 +13481,7 @@ msgstr ""
 #. Label of a Check field in DocType 'DocType'
 #. Label of a Check field in DocType 'DocType Link'
 #: frappe/core/doctype/doctype/doctype.json
-#: frappe/core/doctype/doctype/doctype_list.js:34
+#: frappe/core/doctype/doctype/doctype_list.js:35
 #: frappe/core/doctype/doctype_link/doctype_link.json
 msgid "Is Child Table"
 msgstr ""
@@ -13297,6 +13534,10 @@ msgstr ""
 msgid "Is Global"
 msgstr ""
 
+#: frappe/public/js/frappe/views/treeview.js:384
+msgid "Is Group"
+msgstr ""
+
 #. Label of a Check field in DocType 'Workspace'
 #: frappe/desk/doctype/workspace/workspace.json
 msgid "Is Hidden"
@@ -13322,8 +13563,13 @@ msgstr ""
 msgid "Is Primary"
 msgstr ""
 
+#: frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py:43
+msgid "Is Primary Address"
+msgstr ""
+
 #. Label of a Check field in DocType 'Contact'
 #: frappe/contacts/doctype/contact/contact.json
+#: frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py:49
 msgid "Is Primary Contact"
 msgstr ""
 
@@ -13377,7 +13623,7 @@ msgstr ""
 #. Label of a Check field in DocType 'DocType'
 #. Label of a Check field in DocType 'Onboarding Step'
 #: frappe/core/doctype/doctype/doctype.json
-#: frappe/core/doctype/doctype/doctype_list.js:48
+#: frappe/core/doctype/doctype/doctype_list.js:49
 #: frappe/desk/doctype/onboarding_step/onboarding_step.json
 msgid "Is Single"
 msgstr ""
@@ -13415,7 +13661,7 @@ msgstr ""
 
 #. Label of a Check field in DocType 'DocType'
 #: frappe/core/doctype/doctype/doctype.json
-#: frappe/core/doctype/doctype/doctype_list.js:25
+#: frappe/core/doctype/doctype/doctype_list.js:26
 msgid "Is Submittable"
 msgstr ""
 
@@ -13578,8 +13824,8 @@ msgstr ""
 msgid "Join video conference with {0}"
 msgstr ""
 
-#: frappe/public/js/frappe/form/toolbar.js:379
-#: frappe/public/js/frappe/form/toolbar.js:768
+#: frappe/public/js/frappe/form/toolbar.js:382
+#: frappe/public/js/frappe/form/toolbar.js:771
 msgid "Jump to field"
 msgstr ""
 
@@ -13614,11 +13860,11 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Kanban Board'
 #: frappe/desk/doctype/kanban_board/kanban_board.json
-#: frappe/public/js/frappe/views/kanban/kanban_view.js:387
+#: frappe/public/js/frappe/views/kanban/kanban_view.js:401
 msgid "Kanban Board Name"
 msgstr ""
 
-#: frappe/public/js/frappe/views/kanban/kanban_view.js:264
+#: frappe/public/js/frappe/views/kanban/kanban_view.js:278
 msgctxt "Button in kanban view menu"
 msgid "Kanban Settings"
 msgstr ""
@@ -13639,12 +13885,14 @@ msgstr ""
 
 #. Label of a Data field in DocType 'DefaultValue'
 #. Label of a Data field in DocType 'Document Share Key'
+#. Label of a Data field in DocType 'User Invitation'
 #. Label of a Data field in DocType 'Query Parameters'
 #. Label of a Data field in DocType 'Webhook Data'
 #. Label of a Small Text field in DocType 'Webhook Header'
 #. Label of a Data field in DocType 'Website Meta Tag'
 #: frappe/core/doctype/defaultvalue/defaultvalue.json
 #: frappe/core/doctype/document_share_key/document_share_key.json
+#: frappe/core/doctype/user_invitation/user_invitation.json
 #: frappe/integrations/doctype/query_parameters/query_parameters.json
 #: frappe/integrations/doctype/webhook_data/webhook_data.json
 #: frappe/integrations/doctype/webhook_header/webhook_header.json
@@ -13898,7 +14146,7 @@ msgstr ""
 msgid "Landing Page"
 msgstr ""
 
-#: frappe/public/js/frappe/form/print_utils.js:30
+#: frappe/public/js/frappe/form/print_utils.js:23
 msgid "Landscape"
 msgstr ""
 
@@ -13906,10 +14154,13 @@ msgstr ""
 #. Label of a Link field in DocType 'System Settings'
 #. Label of a Link field in DocType 'Translation'
 #. Label of a Link field in DocType 'User'
+#. Label of a field in the edit-profile Web Form
 #: frappe/core/doctype/language/language.json
 #: frappe/core/doctype/system_settings/system_settings.json
 #: frappe/core/doctype/translation/translation.json
-#: frappe/core/doctype/user/user.json frappe/printing/page/print/print.js:104
+#: frappe/core/doctype/user/user.json
+#: frappe/core/web_form/edit_profile/edit_profile.json
+#: frappe/printing/page/print/print.js:104
 #: frappe/public/js/frappe/form/templates/print_layout.html:11
 msgid "Language"
 msgstr ""
@@ -14001,8 +14252,12 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Contact'
 #. Label of a Data field in DocType 'User'
+#. Label of a field in the edit-profile Web Form
 #: frappe/contacts/doctype/contact/contact.json
-#: frappe/core/doctype/user/user.json frappe/www/complete_signup.html:19
+#: frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py:45
+#: frappe/core/doctype/user/user.json
+#: frappe/core/web_form/edit_profile/edit_profile.json
+#: frappe/www/complete_signup.html:19
 msgid "Last Name"
 msgstr ""
 
@@ -14037,12 +14292,12 @@ msgstr ""
 msgid "Last Synced On"
 msgstr ""
 
-#: frappe/model/meta.py:50 frappe/public/js/frappe/model/meta.js:202
+#: frappe/model/meta.py:51 frappe/public/js/frappe/model/meta.js:202
 #: frappe/public/js/frappe/model/model.js:130
 msgid "Last Updated By"
 msgstr ""
 
-#: frappe/model/meta.py:49 frappe/public/js/frappe/model/meta.js:201
+#: frappe/model/meta.py:50 frappe/public/js/frappe/model/meta.js:201
 #: frappe/public/js/frappe/model/model.js:126
 msgid "Last Updated On"
 msgstr ""
@@ -14172,7 +14427,7 @@ msgstr ""
 msgid "Length of passed data array is greater than value of maximum allowed label points!"
 msgstr ""
 
-#: frappe/database/schema.py:131
+#: frappe/database/schema.py:135
 msgid "Length of {0} should be between 1 and 1000"
 msgstr ""
 
@@ -14227,7 +14482,7 @@ msgstr ""
 #: frappe/core/doctype/report/report.json
 #: frappe/printing/doctype/letter_head/letter_head.json
 #: frappe/printing/page/print/print.js:127
-#: frappe/public/js/frappe/form/print_utils.js:20
+#: frappe/public/js/frappe/form/print_utils.js:50
 #: frappe/public/js/frappe/form/templates/print_layout.html:16
 #: frappe/public/js/frappe/list/bulk_operations.js:52
 #: frappe/public/js/print_format_builder/LetterHeadEditor.vue:144
@@ -14346,7 +14601,7 @@ msgstr ""
 msgid "Liked"
 msgstr ""
 
-#: frappe/model/meta.py:53 frappe/public/js/frappe/model/meta.js:205
+#: frappe/model/meta.py:54 frappe/public/js/frappe/model/meta.js:205
 #: frappe/public/js/frappe/model/model.js:134
 msgid "Liked By"
 msgstr ""
@@ -14525,6 +14780,7 @@ msgstr ""
 #. Label of a Table field in DocType 'Contact'
 #. Label of a Table field in DocType 'DocType'
 #. Label of a Table field in DocType 'Customize Form'
+#. Label of a Table field in DocType 'Event'
 #. Label of a Table field in DocType 'Workspace'
 #: frappe/contacts/doctype/address/address.js:39
 #: frappe/contacts/doctype/address/address.json
@@ -14532,8 +14788,9 @@ msgstr ""
 #: frappe/contacts/doctype/contact/contact.json
 #: frappe/core/doctype/doctype/doctype.json
 #: frappe/custom/doctype/customize_form/customize_form.json
+#: frappe/desk/doctype/event/event.json
 #: frappe/desk/doctype/workspace/workspace.json
-#: frappe/public/js/frappe/form/toolbar.js:390
+#: frappe/public/js/frappe/form/toolbar.js:393
 msgid "Links"
 msgstr ""
 
@@ -14636,7 +14893,7 @@ msgstr ""
 #: frappe/public/js/frappe/list/base_list.js:486
 #: frappe/public/js/frappe/list/list_view.js:365
 #: frappe/public/js/frappe/ui/listing.html:16
-#: frappe/public/js/frappe/views/reports/query_report.js:1021
+#: frappe/public/js/frappe/views/reports/query_report.js:1022
 msgid "Loading"
 msgstr ""
 
@@ -14662,7 +14919,7 @@ msgstr ""
 #: frappe/public/js/frappe/list/list_sidebar_group_by.js:125
 #: frappe/public/js/frappe/views/kanban/kanban_board.html:11
 #: frappe/public/js/frappe/widgets/chart_widget.js:50
-#: frappe/public/js/frappe/widgets/number_card_widget.js:176
+#: frappe/public/js/frappe/widgets/number_card_widget.js:179
 #: frappe/public/js/frappe/widgets/quick_list_widget.js:128
 msgid "Loading..."
 msgstr ""
@@ -14675,6 +14932,11 @@ msgstr ""
 #. Label of a Code field in DocType 'Package Import'
 #: frappe/core/doctype/package_import/package_import.json
 msgid "Log"
+msgstr ""
+
+#. Label of a Check field in DocType 'System Settings'
+#: frappe/core/doctype/system_settings/system_settings.json
+msgid "Log API Requests"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Access Log'
@@ -14718,7 +14980,7 @@ msgstr ""
 msgid "Log out"
 msgstr ""
 
-#: frappe/handler.py:122
+#: frappe/handler.py:123
 msgid "Logged Out"
 msgstr ""
 
@@ -14764,7 +15026,7 @@ msgstr ""
 msgid "Login Page"
 msgstr ""
 
-#: frappe/www/login.py:154
+#: frappe/www/login.py:156
 msgid "Login To {0}"
 msgstr ""
 
@@ -14784,7 +15046,7 @@ msgstr ""
 msgid "Login link sent to your email"
 msgstr ""
 
-#: frappe/auth.py:332 frappe/auth.py:335
+#: frappe/auth.py:335 frappe/auth.py:338
 msgid "Login not allowed at this time"
 msgstr ""
 
@@ -14835,7 +15097,7 @@ msgstr ""
 msgid "Login with email link expiry (in minutes)"
 msgstr ""
 
-#: frappe/auth.py:128
+#: frappe/auth.py:131
 msgid "Login with username and password is not allowed."
 msgstr ""
 
@@ -14848,7 +15110,7 @@ msgstr ""
 msgid "Logout"
 msgstr ""
 
-#: frappe/core/doctype/user/user.js:195
+#: frappe/core/doctype/user/user.js:200
 msgid "Logout All Sessions"
 msgstr ""
 
@@ -14955,7 +15217,9 @@ msgid "Major"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocType'
+#. Label of a Check field in DocType 'Customize Form'
 #: frappe/core/doctype/doctype/doctype.json
+#: frappe/custom/doctype/customize_form/customize_form.json
 msgid "Make \"name\" searchable in Global Search"
 msgstr ""
 
@@ -15028,7 +15292,7 @@ msgstr ""
 msgid "Mandatory Depends On (JS)"
 msgstr ""
 
-#: frappe/website/doctype/web_form/web_form.py:471
+#: frappe/website/doctype/web_form/web_form.py:499
 msgid "Mandatory Information missing:"
 msgstr ""
 
@@ -15040,15 +15304,15 @@ msgstr ""
 msgid "Mandatory field: {0}"
 msgstr ""
 
-#: frappe/public/js/frappe/form/save.js:120
+#: frappe/public/js/frappe/form/save.js:172
 msgid "Mandatory fields required in table {0}, Row {1}"
 msgstr ""
 
-#: frappe/public/js/frappe/form/save.js:125
+#: frappe/public/js/frappe/form/save.js:177
 msgid "Mandatory fields required in {0}"
 msgstr ""
 
-#: frappe/public/js/frappe/web_form/web_form.js:234
+#: frappe/public/js/frappe/web_form/web_form.js:258
 msgctxt "Error message in web form"
 msgid "Mandatory fields required:"
 msgstr ""
@@ -15211,6 +15475,11 @@ msgstr ""
 msgid "Max auto email report per user"
 msgstr ""
 
+#. Label of a Int field in DocType 'System Settings'
+#: frappe/core/doctype/system_settings/system_settings.json
+msgid "Max signups allowed per hour"
+msgstr ""
+
 #: frappe/core/doctype/doctype/doctype.py:1307
 msgid "Max width for type Currency is 100px in row {0}"
 msgstr ""
@@ -15220,7 +15489,7 @@ msgstr ""
 msgid "Maximum"
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:318
+#: frappe/core/doctype/file/file.py:323
 msgid "Maximum Attachment Limit of {0} has been reached for {1} {2}."
 msgstr ""
 
@@ -15262,7 +15531,7 @@ msgstr ""
 #. Label of a Data field in DocType 'Web Page View'
 #: frappe/desk/doctype/todo/todo.json
 #: frappe/public/js/frappe/form/sidebar/assign_to.js:220
-#: frappe/public/js/frappe/utils/utils.js:1738
+#: frappe/public/js/frappe/utils/utils.js:1754
 #: frappe/website/doctype/web_page_view/web_page_view.json
 #: frappe/website/report/website_analytics/website_analytics.js:40
 msgid "Medium"
@@ -15314,7 +15583,7 @@ msgstr ""
 msgid "Merge with existing"
 msgstr ""
 
-#: frappe/utils/nestedset.py:311
+#: frappe/utils/nestedset.py:324
 msgid "Merging is only possible between Group-to-Group or Leaf Node-to-Leaf Node"
 msgstr ""
 
@@ -15388,7 +15657,7 @@ msgstr ""
 msgid "Message Type"
 msgstr ""
 
-#: frappe/public/js/frappe/views/communication.js:941
+#: frappe/public/js/frappe/views/communication.js:944
 msgid "Message clipped"
 msgstr ""
 
@@ -15503,6 +15772,11 @@ msgstr ""
 msgid "Middle Name"
 msgstr ""
 
+#. Label of a field in the edit-profile Web Form
+#: frappe/core/web_form/edit_profile/edit_profile.json
+msgid "Middle Name (Optional)"
+msgstr ""
+
 #. Name of a DocType
 #. Label of a Link in the Tools Workspace
 #: frappe/automation/doctype/milestone/milestone.json
@@ -15557,7 +15831,7 @@ msgstr ""
 msgid "Missing Field"
 msgstr ""
 
-#: frappe/public/js/frappe/form/save.js:131
+#: frappe/public/js/frappe/form/save.js:183
 msgid "Missing Fields"
 msgstr ""
 
@@ -15580,7 +15854,7 @@ msgstr ""
 msgid "Missing Values Required"
 msgstr ""
 
-#: frappe/www/login.py:105
+#: frappe/www/login.py:107
 msgid "Mobile"
 msgstr ""
 
@@ -15591,6 +15865,11 @@ msgstr ""
 #: frappe/tests/test_translate.py:89 frappe/tests/test_translate.py:91
 #: frappe/tests/test_translate.py:94
 msgid "Mobile No"
+msgstr ""
+
+#. Label of a field in the edit-profile Web Form
+#: frappe/core/web_form/edit_profile/edit_profile.json
+msgid "Mobile Number"
 msgstr ""
 
 #. Label of a Check field in DocType 'Form Tour Step'
@@ -15628,7 +15907,7 @@ msgstr ""
 #. Label of a Link field in DocType 'Website Theme'
 #: frappe/core/doctype/block_module/block_module.json
 #: frappe/core/doctype/doctype/doctype.json
-#: frappe/core/doctype/doctype/doctype_list.js:17
+#: frappe/core/doctype/doctype/doctype_list.js:18
 #: frappe/core/doctype/page/page.json frappe/core/doctype/report/report.json
 #: frappe/core/doctype/user_type_module/user_type_module.json
 #: frappe/desk/doctype/dashboard/dashboard.json
@@ -15709,7 +15988,7 @@ msgstr ""
 msgid "Module to Export"
 msgstr ""
 
-#: frappe/modules/utils.py:273
+#: frappe/modules/utils.py:274
 msgid "Module {} not found"
 msgstr ""
 
@@ -15805,10 +16084,12 @@ msgstr ""
 #. Label of a Section Break field in DocType 'Activity Log'
 #. Label of a Section Break field in DocType 'Communication'
 #. Label of a Tab Break field in DocType 'User'
+#. Label of a field in the edit-profile Web Form
 #: frappe/contacts/doctype/contact/contact.json
 #: frappe/core/doctype/activity_log/activity_log.json
 #: frappe/core/doctype/communication/communication.json
 #: frappe/core/doctype/user/user.json
+#: frappe/core/web_form/edit_profile/edit_profile.json
 msgid "More Information"
 msgstr ""
 
@@ -15827,7 +16108,7 @@ msgstr ""
 msgid "Most Used"
 msgstr ""
 
-#: frappe/utils/password.py:65
+#: frappe/utils/password.py:70
 msgid "Most probably your password is too long."
 msgstr ""
 
@@ -15838,7 +16119,7 @@ msgstr ""
 msgid "Move"
 msgstr ""
 
-#: frappe/public/js/frappe/form/grid_row.js:193
+#: frappe/public/js/frappe/form/grid_row.js:194
 msgid "Move To"
 msgstr ""
 
@@ -15874,7 +16155,7 @@ msgstr ""
 msgid "Move the current field and the following fields to a new column"
 msgstr ""
 
-#: frappe/public/js/frappe/form/grid_row.js:168
+#: frappe/public/js/frappe/form/grid_row.js:169
 msgid "Move to Row Number"
 msgstr ""
 
@@ -15901,7 +16182,7 @@ msgstr ""
 msgid "Ms"
 msgstr ""
 
-#: frappe/utils/nestedset.py:335
+#: frappe/utils/nestedset.py:348
 msgid "Multiple root nodes not allowed."
 msgstr ""
 
@@ -15947,7 +16228,7 @@ msgid "Mx"
 msgstr ""
 
 #: frappe/templates/includes/web_sidebar.html:41
-#: frappe/website/doctype/web_form/web_form.py:460
+#: frappe/website/doctype/web_form/web_form.py:488
 #: frappe/website/doctype/website_settings/website_settings.py:181
 #: frappe/www/list.py:20 frappe/www/me.html:4 frappe/www/me.html:8
 #: frappe/www/update_password.py:10
@@ -15994,9 +16275,9 @@ msgstr ""
 #: frappe/custom/doctype/customize_form_field/customize_form_field.json
 #: frappe/desk/doctype/workspace/workspace.json
 #: frappe/integrations/doctype/slack_webhook_url/slack_webhook_url.json
-#: frappe/public/js/frappe/form/layout.js:77
+#: frappe/public/js/frappe/form/layout.js:76
 #: frappe/public/js/frappe/form/multi_select_dialog.js:240
-#: frappe/public/js/frappe/form/save.js:107
+#: frappe/public/js/frappe/form/save.js:159
 #: frappe/public/js/frappe/views/file/file_view.js:97
 #: frappe/website/doctype/website_slideshow/website_slideshow.js:25
 msgid "Name"
@@ -16006,11 +16287,11 @@ msgstr ""
 msgid "Name (Doc Name)"
 msgstr ""
 
-#: frappe/desk/utils.py:22
+#: frappe/desk/utils.py:24
 msgid "Name already taken, please set a new name"
 msgstr ""
 
-#: frappe/model/naming.py:486
+#: frappe/model/naming.py:494
 msgid "Name cannot contain special characters like {0}"
 msgstr ""
 
@@ -16022,7 +16303,7 @@ msgstr ""
 msgid "Name of the new Print Format"
 msgstr ""
 
-#: frappe/model/naming.py:481
+#: frappe/model/naming.py:489
 msgid "Name of {0} cannot be {1}"
 msgstr ""
 
@@ -16067,7 +16348,7 @@ msgstr ""
 msgid "Naming Series"
 msgstr ""
 
-#: frappe/model/naming.py:244
+#: frappe/model/naming.py:252
 msgid "Naming Series mandatory"
 msgstr ""
 
@@ -16125,6 +16406,10 @@ msgstr ""
 msgid "Navigation Settings"
 msgstr ""
 
+#: frappe/public/js/frappe/list/list_view.js:487
+msgid "Need Help?"
+msgstr ""
+
 #: frappe/desk/doctype/workspace/workspace.py:314
 msgid "Need Workspace Manager role to edit private workspace of other users"
 msgstr ""
@@ -16156,7 +16441,7 @@ msgstr ""
 #: frappe/desk/doctype/workspace_shortcut/workspace_shortcut.json
 #: frappe/email/doctype/notification/notification.json
 #: frappe/public/js/frappe/form/success_action.js:77
-#: frappe/public/js/frappe/views/treeview.js:437
+#: frappe/public/js/frappe/views/treeview.js:439
 #: frappe/public/js/frappe/views/workspace/workspace.js:98
 #: frappe/social/doctype/energy_point_rule/energy_point_rule.json
 #: frappe/website/doctype/web_form/templates/web_list.html:15
@@ -16212,7 +16497,7 @@ msgstr ""
 msgid "New Folder"
 msgstr ""
 
-#: frappe/public/js/frappe/views/kanban/kanban_view.js:343
+#: frappe/public/js/frappe/views/kanban/kanban_view.js:357
 msgid "New Kanban Board"
 msgstr ""
 
@@ -16239,7 +16524,7 @@ msgstr ""
 msgid "New Notification"
 msgstr ""
 
-#: frappe/core/doctype/user/user.js:183 frappe/www/update-password.html:19
+#: frappe/core/doctype/user/user.js:188 frappe/www/update-password.html:19
 msgid "New Password"
 msgstr ""
 
@@ -16249,7 +16534,7 @@ msgstr ""
 msgid "New Print Format Name"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1385
+#: frappe/public/js/frappe/views/reports/report_view.js:1387
 msgid "New Report name"
 msgstr ""
 
@@ -16258,8 +16543,8 @@ msgstr ""
 msgid "New Users (Last 30 days)"
 msgstr ""
 
-#: frappe/core/doctype/version/version_view.html:14
-#: frappe/core/doctype/version/version_view.html:76
+#: frappe/core/doctype/version/version_view.html:15
+#: frappe/core/doctype/version/version_view.html:77
 msgid "New Value"
 msgstr ""
 
@@ -16295,30 +16580,30 @@ msgstr ""
 #: frappe/public/js/frappe/form/toolbar.js:36
 #: frappe/public/js/frappe/form/toolbar.js:205
 #: frappe/public/js/frappe/form/toolbar.js:220
-#: frappe/public/js/frappe/form/toolbar.js:514
+#: frappe/public/js/frappe/form/toolbar.js:517
 #: frappe/public/js/frappe/ui/toolbar/search_utils.js:167
 #: frappe/public/js/frappe/ui/toolbar/search_utils.js:168
 #: frappe/public/js/frappe/ui/toolbar/search_utils.js:217
 #: frappe/public/js/frappe/ui/toolbar/search_utils.js:218
 #: frappe/public/js/frappe/views/breadcrumbs.js:192
 #: frappe/public/js/frappe/views/treeview.js:332
-#: frappe/website/doctype/web_form/web_form.py:377
+#: frappe/website/doctype/web_form/web_form.py:403
 msgid "New {0}"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:392
+#: frappe/public/js/frappe/views/reports/query_report.js:393
 msgid "New {0} Created"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:384
+#: frappe/public/js/frappe/views/reports/query_report.js:385
 msgid "New {0} {1} added to Dashboard {2}"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:389
+#: frappe/public/js/frappe/views/reports/query_report.js:390
 msgid "New {0} {1} created"
 msgstr ""
 
-#: frappe/automation/doctype/auto_repeat/auto_repeat.py:385
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:388
 msgid "New {0}: {1}"
 msgstr ""
 
@@ -16326,7 +16611,7 @@ msgstr ""
 msgid "New {} releases for the following apps are available"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:754
+#: frappe/core/doctype/user/user.py:765
 msgid "Newly created user {0} has no roles enabled."
 msgstr ""
 
@@ -16374,7 +16659,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/form/form_tour.js:14
 #: frappe/public/js/frappe/form/form_tour.js:324
-#: frappe/public/js/frappe/web_form/web_form.js:91
+#: frappe/public/js/frappe/web_form/web_form.js:93
 #: frappe/public/js/onboarding_tours/onboarding_tours.js:15
 #: frappe/public/js/onboarding_tours/onboarding_tours.js:240
 #: frappe/templates/includes/slideshow.html:38 frappe/website/utils.py:258
@@ -16413,7 +16698,7 @@ msgstr ""
 msgid "Next Actions HTML"
 msgstr ""
 
-#: frappe/public/js/frappe/form/toolbar.js:321
+#: frappe/public/js/frappe/form/toolbar.js:324
 msgid "Next Document"
 msgstr ""
 
@@ -16490,7 +16775,7 @@ msgstr ""
 #: frappe/public/js/form_builder/utils.js:341
 #: frappe/public/js/frappe/form/controls/link.js:504
 #: frappe/public/js/frappe/list/list_sidebar_group_by.js:223
-#: frappe/public/js/frappe/views/reports/query_report.js:1545
+#: frappe/public/js/frappe/views/reports/query_report.js:1572
 #: frappe/website/doctype/help_article/templates/help_article.html:26
 msgid "No"
 msgstr ""
@@ -16547,6 +16832,10 @@ msgstr ""
 msgid "No Email Accounts Assigned"
 msgstr ""
 
+#: frappe/email/doctype/email_group/email_group.py:50
+msgid "No Email field found in {0}"
+msgstr ""
+
 #: frappe/public/js/frappe/views/inbox/inbox_view.js:183
 msgid "No Emails"
 msgstr ""
@@ -16594,7 +16883,7 @@ msgstr ""
 msgid "No Letterhead"
 msgstr ""
 
-#: frappe/model/naming.py:463
+#: frappe/model/naming.py:471
 msgid "No Name Specified for {0}"
 msgstr ""
 
@@ -16602,7 +16891,7 @@ msgstr ""
 msgid "No New notifications"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1708
+#: frappe/core/doctype/doctype/doctype.py:1721
 msgid "No Permissions Specified"
 msgstr ""
 
@@ -16642,11 +16931,11 @@ msgstr ""
 msgid "No Results found"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:755
+#: frappe/core/doctype/user/user.py:766
 msgid "No Roles Specified"
 msgstr ""
 
-#: frappe/public/js/frappe/views/kanban/kanban_view.js:343
+#: frappe/public/js/frappe/views/kanban/kanban_view.js:357
 msgid "No Select Field Found"
 msgstr ""
 
@@ -16654,7 +16943,7 @@ msgstr ""
 msgid "No Suggestions"
 msgstr ""
 
-#: frappe/desk/reportview.py:648
+#: frappe/desk/reportview.py:678
 msgid "No Tags"
 msgstr ""
 
@@ -16714,11 +17003,11 @@ msgstr ""
 msgid "No contacts added yet."
 msgstr ""
 
-#: frappe/automation/doctype/auto_repeat/auto_repeat.py:438
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:441
 msgid "No contacts linked to document"
 msgstr ""
 
-#: frappe/desk/query_report.py:343
+#: frappe/desk/query_report.py:379
 msgid "No data to export"
 msgstr ""
 
@@ -16734,11 +17023,15 @@ msgstr ""
 msgid "No email account associated with the User. Please add an account under User > Email Inbox."
 msgstr ""
 
+#: frappe/core/api/user_invitation.py:17
+msgid "No email addresses to invite"
+msgstr ""
+
 #: frappe/core/doctype/data_import/data_import.js:483
 msgid "No failed logs"
 msgstr ""
 
-#: frappe/public/js/frappe/views/kanban/kanban_view.js:370
+#: frappe/public/js/frappe/views/kanban/kanban_view.js:384
 msgid "No fields found that can be used as a Kanban Column. Use the Customize Form to add a Custom Field of type \"Select\"."
 msgstr ""
 
@@ -16796,7 +17089,7 @@ msgctxt "{0} = verb, {1} = object"
 msgid "No permission to '{0}' {1}"
 msgstr ""
 
-#: frappe/model/db_query.py:953
+#: frappe/model/db_query.py:955
 msgid "No permission to read {0}"
 msgstr ""
 
@@ -16808,7 +17101,7 @@ msgstr ""
 msgid "No records deleted"
 msgstr ""
 
-#: frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py:116
+#: frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py:115
 msgid "No records present in {0}"
 msgstr ""
 
@@ -16840,7 +17133,7 @@ msgstr ""
 msgid "No {0} found"
 msgstr ""
 
-#: frappe/public/js/frappe/list/list_view.js:499
+#: frappe/public/js/frappe/list/list_view.js:501
 msgid "No {0} found with matching filters. Clear filters to see all {0}."
 msgstr ""
 
@@ -16849,7 +17142,7 @@ msgid "No {0} mail"
 msgstr ""
 
 #: frappe/public/js/form_builder/utils.js:117
-#: frappe/public/js/frappe/form/grid_row.js:256
+#: frappe/public/js/frappe/form/grid_row.js:257
 msgctxt "Title of the 'row number' column"
 msgid "No."
 msgstr ""
@@ -16887,8 +17180,8 @@ msgstr ""
 msgid "Normalized Query"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:964
-#: frappe/templates/includes/login/login.js:258 frappe/utils/oauth.py:270
+#: frappe/core/doctype/user/user.py:975
+#: frappe/templates/includes/login/login.js:258 frappe/utils/oauth.py:269
 msgid "Not Allowed"
 msgstr ""
 
@@ -16908,7 +17201,7 @@ msgstr ""
 msgid "Not Equals"
 msgstr ""
 
-#: frappe/app.py:367 frappe/www/404.html:3
+#: frappe/app.py:365 frappe/www/404.html:3
 msgid "Not Found"
 msgstr ""
 
@@ -16929,17 +17222,17 @@ msgstr ""
 msgid "Not Linked to any record"
 msgstr ""
 
-#: frappe/__init__.py:952 frappe/app.py:358 frappe/desk/calendar.py:26
-#: frappe/desk/treeview.py:19 frappe/geo/utils.py:103
+#: frappe/__init__.py:952 frappe/app.py:356 frappe/desk/calendar.py:26
+#: frappe/desk/treeview.py:18 frappe/geo/utils.py:103
 #: frappe/public/js/frappe/web_form/webform_script.js:15
-#: frappe/website/doctype/web_form/web_form.py:709
+#: frappe/website/doctype/web_form/web_form.py:737
 #: frappe/website/page_renderers/not_permitted_page.py:22
-#: frappe/www/login.py:191 frappe/www/qrcode.py:22 frappe/www/qrcode.py:25
+#: frappe/www/login.py:193 frappe/www/qrcode.py:22 frappe/www/qrcode.py:25
 #: frappe/www/qrcode.py:37
 msgid "Not Permitted"
 msgstr ""
 
-#: frappe/desk/query_report.py:543
+#: frappe/desk/query_report.py:583
 msgid "Not Permitted to read {0}"
 msgstr ""
 
@@ -16949,13 +17242,13 @@ msgstr ""
 msgid "Not Published"
 msgstr ""
 
-#: frappe/public/js/frappe/form/toolbar.js:284
-#: frappe/public/js/frappe/form/toolbar.js:751
+#: frappe/public/js/frappe/form/toolbar.js:286
+#: frappe/public/js/frappe/form/toolbar.js:754
 #: frappe/public/js/frappe/model/indicator.js:28
-#: frappe/public/js/frappe/views/kanban/kanban_view.js:168
-#: frappe/public/js/frappe/views/reports/report_view.js:204
+#: frappe/public/js/frappe/views/kanban/kanban_view.js:182
+#: frappe/public/js/frappe/views/reports/report_view.js:210
 #: frappe/public/js/print_format_builder/print_format_builder.bundle.js:39
-#: frappe/website/doctype/web_form/templates/web_form.html:75
+#: frappe/website/doctype/web_form/templates/web_form.html:82
 msgid "Not Saved"
 msgstr ""
 
@@ -16984,7 +17277,7 @@ msgstr ""
 msgid "Not a valid Comma Separated Value (CSV File)"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:220
+#: frappe/core/doctype/user/user.py:221
 msgid "Not a valid User Image."
 msgstr ""
 
@@ -17008,7 +17301,7 @@ msgstr ""
 msgid "Not allowed to attach {0} document, please enable Allow Print For {0} in Print Settings"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:339
+#: frappe/core/doctype/doctype/doctype.py:341
 msgid "Not allowed to create custom Virtual DocType."
 msgstr ""
 
@@ -17028,21 +17321,21 @@ msgstr ""
 msgid "Not found"
 msgstr ""
 
-#: frappe/core/doctype/page/page.py:62
+#: frappe/core/doctype/page/page.py:61
 msgid "Not in Developer Mode"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:334
+#: frappe/core/doctype/doctype/doctype.py:336
 msgid "Not in Developer Mode! Set in site_config.json or make 'Custom' DocType."
 msgstr ""
 
-#: frappe/api/v1.py:90 frappe/api/v1.py:95
-#: frappe/core/doctype/system_settings/system_settings.py:214
-#: frappe/handler.py:108 frappe/public/js/frappe/request.js:157
+#: frappe/api/v1.py:88 frappe/api/v1.py:93
+#: frappe/core/doctype/system_settings/system_settings.py:215
+#: frappe/handler.py:109 frappe/public/js/frappe/request.js:157
 #: frappe/public/js/frappe/request.js:167
 #: frappe/public/js/frappe/request.js:172
 #: frappe/public/js/frappe/views/kanban/kanban_board.bundle.js:67
-#: frappe/website/doctype/web_form/web_form.py:722
+#: frappe/website/doctype/web_form/web_form.py:750
 #: frappe/website/js/website.js:97
 msgid "Not permitted"
 msgstr ""
@@ -17053,7 +17346,7 @@ msgstr ""
 
 #. Label of a Link in the Tools Workspace
 #. Name of a DocType
-#: frappe/automation/doctype/auto_repeat/auto_repeat.py:407
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:410
 #: frappe/automation/workspace/tools/tools.json
 #: frappe/desk/doctype/note/note.json
 msgid "Note"
@@ -17097,7 +17390,7 @@ msgstr ""
 msgid "Note: Multiple sessions will be allowed in case of mobile device"
 msgstr ""
 
-#: frappe/core/doctype/user/user.js:382
+#: frappe/core/doctype/user/user.js:388
 msgid "Note: This will be shared with user."
 msgstr ""
 
@@ -17225,7 +17518,7 @@ msgstr ""
 msgid "Notify users with a popup when they log in"
 msgstr ""
 
-#: frappe/public/js/frappe/form/controls/datetime.js:25
+#: frappe/public/js/frappe/form/controls/datetime.js:28
 #: frappe/public/js/frappe/form/controls/time.js:37
 msgid "Now"
 msgstr ""
@@ -17289,12 +17582,12 @@ msgstr ""
 msgid "Number of Queries"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:439
+#: frappe/core/doctype/doctype/doctype.py:441
 #: frappe/public/js/frappe/doctype/index.js:59
 msgid "Number of attachment fields are more than {}, limit updated to {}."
 msgstr ""
 
-#: frappe/core/doctype/system_settings/system_settings.py:167
+#: frappe/core/doctype/system_settings/system_settings.py:168
 msgid "Number of backups must be greater than zero."
 msgstr ""
 
@@ -17494,7 +17787,7 @@ msgstr ""
 msgid "On or Before"
 msgstr ""
 
-#: frappe/public/js/frappe/views/communication.js:951
+#: frappe/public/js/frappe/views/communication.js:954
 msgid "On {0}, {1} wrote:"
 msgstr ""
 
@@ -17536,7 +17829,7 @@ msgstr ""
 
 #. Description of the 'Is Submittable' (Check) field in DocType 'DocType'
 #: frappe/core/doctype/doctype/doctype.json
-#: frappe/core/doctype/doctype/doctype_list.js:28
+#: frappe/core/doctype/doctype/doctype_list.js:29
 msgid "Once submitted, submittable documents cannot be changed. They can only be Cancelled and Amended."
 msgstr ""
 
@@ -17568,7 +17861,7 @@ msgstr ""
 msgid "Only Administrator can delete Email Queue"
 msgstr ""
 
-#: frappe/core/doctype/page/page.py:66
+#: frappe/core/doctype/page/page.py:65
 msgid "Only Administrator can edit"
 msgstr ""
 
@@ -17576,7 +17869,7 @@ msgstr ""
 msgid "Only Administrator can save a standard report. Please rename and save."
 msgstr ""
 
-#: frappe/recorder.py:314
+#: frappe/recorder.py:312
 msgid "Only Administrator is allowed to use Recorder"
 msgstr ""
 
@@ -17594,7 +17887,7 @@ msgstr ""
 msgid "Only Send Records Updated in Last X Hours"
 msgstr ""
 
-#: frappe/desk/doctype/workspace/workspace.js:36
+#: frappe/desk/doctype/workspace/workspace.js:34
 msgid "Only Workspace Manager can edit public workspaces"
 msgstr ""
 
@@ -17602,7 +17895,7 @@ msgstr ""
 msgid "Only Workspace Manager can sort or edit this page"
 msgstr ""
 
-#: frappe/modules/utils.py:65
+#: frappe/modules/utils.py:66
 msgid "Only allowed to export customizations in developer mode"
 msgstr ""
 
@@ -17627,15 +17920,15 @@ msgstr ""
 msgid "Only one {0} can be set as primary."
 msgstr ""
 
-#: frappe/desk/reportview.py:336
+#: frappe/desk/reportview.py:332
 msgid "Only reports of type Report Builder can be deleted"
 msgstr ""
 
-#: frappe/desk/reportview.py:307
+#: frappe/desk/reportview.py:303
 msgid "Only reports of type Report Builder can be edited"
 msgstr ""
 
-#: frappe/custom/doctype/customize_form/customize_form.py:126
+#: frappe/custom/doctype/customize_form/customize_form.py:131
 msgid "Only standard DocTypes are allowed to be customized from Customize Form."
 msgstr ""
 
@@ -17753,6 +18046,10 @@ msgstr ""
 msgid "OpenID Configuration"
 msgstr ""
 
+#: frappe/integrations/doctype/connected_app/connected_app.js:15
+msgid "OpenID Configuration fetched successfully!"
+msgstr ""
+
 #. Option for the 'Directory Server' (Select) field in DocType 'LDAP Settings'
 #: frappe/integrations/doctype/ldap_settings/ldap_settings.json
 msgid "OpenLDAP"
@@ -17768,7 +18065,7 @@ msgstr ""
 msgid "Operation"
 msgstr ""
 
-#: frappe/utils/data.py:1884
+#: frappe/utils/data.py:1903
 msgid "Operator must be one of {0}"
 msgstr ""
 
@@ -17878,12 +18175,12 @@ msgstr ""
 msgid "Org History Heading"
 msgstr ""
 
-#: frappe/public/js/frappe/form/print_utils.js:28
+#: frappe/public/js/frappe/form/print_utils.js:21
 msgid "Orientation"
 msgstr ""
 
-#: frappe/core/doctype/version/version_view.html:13
-#: frappe/core/doctype/version/version_view.html:75
+#: frappe/core/doctype/version/version_view.html:14
+#: frappe/core/doctype/version/version_view.html:76
 msgid "Original Value"
 msgstr ""
 
@@ -17956,7 +18253,7 @@ msgstr ""
 
 #: frappe/printing/page/print/print.js:71
 #: frappe/public/js/frappe/form/templates/print_layout.html:44
-#: frappe/public/js/frappe/views/reports/query_report.js:1674
+#: frappe/public/js/frappe/views/reports/query_report.js:1710
 msgid "PDF"
 msgstr ""
 
@@ -18177,7 +18474,7 @@ msgstr ""
 
 #: frappe/public/html/print_template.html:25
 #: frappe/public/js/frappe/views/reports/print_tree.html:89
-#: frappe/public/js/frappe/web_form/web_form.js:264
+#: frappe/public/js/frappe/web_form/web_form.js:288
 #: frappe/templates/print_formats/standard.html:34
 msgid "Page {0} of {1}"
 msgstr ""
@@ -18222,11 +18519,11 @@ msgstr ""
 
 #. Label of a Data field in DocType 'DocType'
 #: frappe/core/doctype/doctype/doctype.json
-#: frappe/core/doctype/doctype/doctype.py:912
+#: frappe/core/doctype/doctype/doctype.py:914
 msgid "Parent Field (Tree)"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:918
+#: frappe/core/doctype/doctype/doctype.py:920
 msgid "Parent Field must be a valid fieldname"
 msgstr ""
 
@@ -18256,8 +18553,8 @@ msgstr ""
 msgid "Parent is the name of the document to which the data will get added to."
 msgstr ""
 
-#: frappe/public/js/frappe/ui/group_by/group_by.js:251
-msgid "Parent-to-child or child-to-parent grouping is not allowed."
+#: frappe/public/js/frappe/ui/group_by/group_by.js:253
+msgid "Parent-to-child or child-to-different-child grouping is not allowed."
 msgstr ""
 
 #: frappe/permissions.py:811
@@ -18308,8 +18605,8 @@ msgstr ""
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: frappe/core/doctype/docfield/docfield.json
 #: frappe/core/doctype/system_settings/system_settings.json
-#: frappe/core/doctype/user/user.js:170 frappe/core/doctype/user/user.js:217
-#: frappe/core/doctype/user/user.js:237
+#: frappe/core/doctype/user/user.js:175 frappe/core/doctype/user/user.js:222
+#: frappe/core/doctype/user/user.js:242
 #: frappe/custom/doctype/custom_field/custom_field.json
 #: frappe/custom/doctype/customize_form_field/customize_form_field.json
 #: frappe/desk/page/setup_wizard/setup_wizard.js:494
@@ -18319,11 +18616,11 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:1027
+#: frappe/core/doctype/user/user.py:1040
 msgid "Password Email Sent"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:400
+#: frappe/core/doctype/user/user.py:401
 msgid "Password Reset"
 msgstr ""
 
@@ -18332,7 +18629,7 @@ msgstr ""
 msgid "Password Reset Link Generation Limit"
 msgstr ""
 
-#: frappe/public/js/frappe/form/grid_row.js:842
+#: frappe/public/js/frappe/form/grid_row.js:864
 msgid "Password cannot be filtered"
 msgstr ""
 
@@ -18353,11 +18650,11 @@ msgstr ""
 msgid "Password missing in Email Account"
 msgstr ""
 
-#: frappe/utils/password.py:42
+#: frappe/utils/password.py:48
 msgid "Password not found for {0} {1} {2}"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:1026
+#: frappe/core/doctype/user/user.py:1039
 msgid "Password reset instructions have been sent to your email"
 msgstr ""
 
@@ -18365,11 +18662,11 @@ msgstr ""
 msgid "Password set"
 msgstr ""
 
-#: frappe/auth.py:249
+#: frappe/auth.py:252
 msgid "Password size exceeded the maximum allowed size"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:818
+#: frappe/core/doctype/user/user.py:829
 msgid "Password size exceeded the maximum allowed size."
 msgstr ""
 
@@ -18377,7 +18674,7 @@ msgstr ""
 msgid "Passwords do not match"
 msgstr ""
 
-#: frappe/core/doctype/user/user.js:203
+#: frappe/core/doctype/user/user.js:208
 msgid "Passwords do not match!"
 msgstr ""
 
@@ -18448,10 +18745,12 @@ msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'Data Import'
 #. Option for the 'Contribution Status' (Select) field in DocType 'Translation'
+#. Option for the 'Status' (Select) field in DocType 'User Invitation'
 #. Option for the 'Status' (Select) field in DocType 'Personal Data Deletion
 #. Step'
 #: frappe/core/doctype/data_import/data_import.json
 #: frappe/core/doctype/translation/translation.json
+#: frappe/core/doctype/user_invitation/user_invitation.json
 #: frappe/website/doctype/personal_data_deletion_step/personal_data_deletion_step.json
 msgid "Pending"
 msgstr ""
@@ -18574,15 +18873,15 @@ msgstr ""
 #: frappe/core/doctype/docperm/docperm.json
 #: frappe/core/doctype/doctype/doctype.json
 #: frappe/core/doctype/system_settings/system_settings.json
-#: frappe/core/doctype/user/user.js:145 frappe/core/doctype/user/user.js:154
+#: frappe/core/doctype/user/user.js:150 frappe/core/doctype/user/user.js:159
 #: frappe/core/page/permission_manager/permission_manager.js:221
 #: frappe/core/workspace/users/users.json
 #: frappe/custom/doctype/customize_form_field/customize_form_field.json
 msgid "Permissions"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1799
-#: frappe/core/doctype/doctype/doctype.py:1809
+#: frappe/core/doctype/doctype/doctype.py:1812
+#: frappe/core/doctype/doctype/doctype.py:1822
 msgid "Permissions Error"
 msgstr ""
 
@@ -18648,15 +18947,18 @@ msgstr ""
 #. Option for the 'Type' (Select) field in DocType 'Communication'
 #. Option for the 'Type' (Select) field in DocType 'DocField'
 #. Label of a Data field in DocType 'User'
+#. Label of a field in the edit-profile Web Form
 #. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #. Label of a Data field in DocType 'Contact Us Settings'
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: frappe/contacts/doctype/address/address.json
 #: frappe/contacts/doctype/contact/contact.json
+#: frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py:47
 #: frappe/core/doctype/communication/communication.json
 #: frappe/core/doctype/docfield/docfield.json
 #: frappe/core/doctype/user/user.json
+#: frappe/core/web_form/edit_profile/edit_profile.json
 #: frappe/custom/doctype/custom_field/custom_field.json
 #: frappe/custom/doctype/customize_form_field/customize_form_field.json
 #: frappe/website/doctype/contact_us_settings/contact_us_settings.json
@@ -18669,13 +18971,13 @@ msgstr ""
 msgid "Phone No."
 msgstr ""
 
-#: frappe/utils/__init__.py:108
+#: frappe/utils/__init__.py:110
 msgid "Phone Number {0} set in field {1} is not valid."
 msgstr ""
 
-#: frappe/public/js/frappe/form/print_utils.js:40
-#: frappe/public/js/frappe/views/reports/report_view.js:1580
-#: frappe/public/js/frappe/views/reports/report_view.js:1583
+#: frappe/public/js/frappe/form/print_utils.js:68
+#: frappe/public/js/frappe/views/reports/report_view.js:1582
+#: frappe/public/js/frappe/views/reports/report_view.js:1585
 msgid "Pick Columns"
 msgstr ""
 
@@ -18727,7 +19029,7 @@ msgstr ""
 msgid "Please Install the ldap3 library via pip to use ldap functionality."
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:307
+#: frappe/public/js/frappe/views/reports/query_report.js:308
 msgid "Please Set Chart"
 msgstr ""
 
@@ -18735,7 +19037,7 @@ msgstr ""
 msgid "Please Update SMS Settings"
 msgstr ""
 
-#: frappe/automation/doctype/auto_repeat/auto_repeat.py:582
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:585
 msgid "Please add a subject to your email"
 msgstr ""
 
@@ -18743,7 +19045,7 @@ msgstr ""
 msgid "Please add a valid comment."
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:1009
+#: frappe/core/doctype/user/user.py:1022
 msgid "Please ask your administrator to verify your sign-up"
 msgstr ""
 
@@ -18763,10 +19065,6 @@ msgstr ""
 msgid "Please attach the package"
 msgstr ""
 
-#: frappe/integrations/doctype/connected_app/connected_app.js:19
-msgid "Please check OpenID Configuration URL"
-msgstr ""
-
 #: frappe/utils/dashboard.py:58
 msgid "Please check the filter values set for Dashboard Chart: {}"
 msgstr ""
@@ -18775,7 +19073,7 @@ msgstr ""
 msgid "Please check the value of \"Fetch From\" set for field {0}"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:1007
+#: frappe/core/doctype/user/user.py:1020
 msgid "Please check your email for verification"
 msgstr ""
 
@@ -18823,11 +19121,11 @@ msgstr ""
 msgid "Please do not change the template headings."
 msgstr ""
 
-#: frappe/printing/doctype/print_format/print_format.js:18
+#: frappe/printing/doctype/print_format/print_format.js:19
 msgid "Please duplicate this to make changes"
 msgstr ""
 
-#: frappe/core/doctype/system_settings/system_settings.py:160
+#: frappe/core/doctype/system_settings/system_settings.py:161
 msgid "Please enable atleast one Social Login Key or LDAP or Login With Email Link before disabling username/password based login."
 msgstr ""
 
@@ -18836,7 +19134,7 @@ msgstr ""
 #: frappe/printing/page/print/print.js:638
 #: frappe/printing/page/print/print.js:668
 #: frappe/public/js/frappe/list/bulk_operations.js:161
-#: frappe/public/js/frappe/utils/utils.js:1438
+#: frappe/public/js/frappe/utils/utils.js:1454
 msgid "Please enable pop-ups"
 msgstr ""
 
@@ -18849,7 +19147,7 @@ msgstr ""
 msgid "Please enable {} before continuing."
 msgstr ""
 
-#: frappe/utils/oauth.py:192
+#: frappe/utils/oauth.py:191
 msgid "Please ensure that your profile has an email address"
 msgstr ""
 
@@ -18873,7 +19171,7 @@ msgstr ""
 msgid "Please enter Client Secret before social login is enabled"
 msgstr ""
 
-#: frappe/integrations/doctype/connected_app/connected_app.js:8
+#: frappe/integrations/doctype/connected_app/connected_app.py:53
 msgid "Please enter OpenID Configuration URL"
 msgstr ""
 
@@ -18910,7 +19208,7 @@ msgstr ""
 msgid "Please enter your old password."
 msgstr ""
 
-#: frappe/automation/doctype/auto_repeat/auto_repeat.py:413
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:416
 msgid "Please find attached {0}: {1}"
 msgstr ""
 
@@ -18926,7 +19224,7 @@ msgstr ""
 msgid "Please make sure the Reference Communication Docs are not circularly linked."
 msgstr ""
 
-#: frappe/model/document.py:866
+#: frappe/model/document.py:870
 msgid "Please refresh to get the latest document."
 msgstr ""
 
@@ -18950,7 +19248,7 @@ msgstr ""
 msgid "Please save the document before removing assignment"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1709
+#: frappe/public/js/frappe/views/reports/report_view.js:1718
 msgid "Please save the report first"
 msgstr ""
 
@@ -18962,7 +19260,7 @@ msgstr ""
 msgid "Please select Company"
 msgstr ""
 
-#: frappe/printing/doctype/print_format/print_format.js:30
+#: frappe/printing/doctype/print_format/print_format.js:31
 msgid "Please select DocType first"
 msgstr ""
 
@@ -18970,15 +19268,15 @@ msgstr ""
 msgid "Please select Entity Type first"
 msgstr ""
 
-#: frappe/core/doctype/system_settings/system_settings.py:110
+#: frappe/core/doctype/system_settings/system_settings.py:112
 msgid "Please select Minimum Password Score"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:1117
+#: frappe/public/js/frappe/views/reports/query_report.js:1118
 msgid "Please select X and Y fields"
 msgstr ""
 
-#: frappe/utils/__init__.py:115
+#: frappe/utils/__init__.py:117
 msgid "Please select a country code for field {1}."
 msgstr ""
 
@@ -18994,7 +19292,7 @@ msgstr ""
 msgid "Please select a valid csv file with data"
 msgstr ""
 
-#: frappe/utils/data.py:257
+#: frappe/utils/data.py:254
 msgid "Please select a valid date filter"
 msgstr ""
 
@@ -19002,7 +19300,7 @@ msgstr ""
 msgid "Please select applicable Doctypes"
 msgstr ""
 
-#: frappe/model/db_query.py:1145
+#: frappe/model/db_query.py:1170
 msgid "Please select atleast 1 column from {0} to sort/group"
 msgstr ""
 
@@ -19036,7 +19334,7 @@ msgstr ""
 msgid "Please set a printer mapping for this print format in the Printer Settings"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:1339
+#: frappe/public/js/frappe/views/reports/query_report.js:1340
 msgid "Please set filters"
 msgstr ""
 
@@ -19044,7 +19342,7 @@ msgstr ""
 msgid "Please set filters value in Report Filter table."
 msgstr ""
 
-#: frappe/model/naming.py:554
+#: frappe/model/naming.py:562
 msgid "Please set the document name"
 msgstr ""
 
@@ -19056,7 +19354,7 @@ msgstr ""
 msgid "Please set the series to be used."
 msgstr ""
 
-#: frappe/core/doctype/system_settings/system_settings.py:123
+#: frappe/core/doctype/system_settings/system_settings.py:125
 msgid "Please setup SMS before setting it as an authentication method, via SMS Settings"
 msgstr ""
 
@@ -19064,7 +19362,7 @@ msgstr ""
 msgid "Please setup a message first"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:365
+#: frappe/core/doctype/user/user.py:366
 msgid "Please setup default outgoing Email Account from Settings > Email Account"
 msgstr ""
 
@@ -19101,11 +19399,15 @@ msgstr ""
 msgid "Please use a valid LDAP search filter"
 msgstr ""
 
+#: frappe/templates/emails/file_backup_notification.html:4
+msgid "Please use following links to download file backup."
+msgstr ""
+
 #: frappe/email/doctype/newsletter/newsletter.py:336
 msgid "Please verify your Email Address"
 msgstr ""
 
-#: frappe/utils/password.py:205
+#: frappe/utils/password.py:210
 msgid "Please visit https://frappecloud.com/docs/sites/migrate-an-existing-site#encryption-key for more information."
 msgstr ""
 
@@ -19173,7 +19475,7 @@ msgstr ""
 msgid "Portal Settings"
 msgstr ""
 
-#: frappe/public/js/frappe/form/print_utils.js:31
+#: frappe/public/js/frappe/form/print_utils.js:24
 msgid "Portrait"
 msgstr ""
 
@@ -19201,6 +19503,7 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Address'
 #: frappe/contacts/doctype/address/address.json
+#: frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py:41
 msgid "Postal Code"
 msgstr ""
 
@@ -19231,6 +19534,10 @@ msgstr ""
 #: frappe/custom/doctype/customize_form_field/customize_form_field.json
 #: frappe/website/doctype/web_form_field/web_form_field.json
 msgid "Precision"
+msgstr ""
+
+#: frappe/core/doctype/doctype/doctype.py:1634
+msgid "Precision ({0}) for {1} cannot be greater than its length ({2})."
 msgstr ""
 
 #: frappe/core/doctype/doctype/doctype.py:1365
@@ -19284,11 +19591,11 @@ msgstr ""
 msgid "Prepared report render failed"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:472
+#: frappe/public/js/frappe/views/reports/query_report.js:473
 msgid "Preparing Report"
 msgstr ""
 
-#: frappe/public/js/frappe/views/communication.js:419
+#: frappe/public/js/frappe/views/communication.js:422
 msgid "Prepend the template to the email message"
 msgstr ""
 
@@ -19353,7 +19660,7 @@ msgid "Preview:"
 msgstr ""
 
 #: frappe/public/js/frappe/form/form_tour.js:15
-#: frappe/public/js/frappe/web_form/web_form.js:95
+#: frappe/public/js/frappe/web_form/web_form.js:97
 #: frappe/public/js/onboarding_tours/onboarding_tours.js:16
 #: frappe/templates/includes/slideshow.html:34
 #: frappe/website/web_template/slideshow/slideshow.html:40
@@ -19365,7 +19672,7 @@ msgctxt "Go to previous slide"
 msgid "Previous"
 msgstr ""
 
-#: frappe/public/js/frappe/form/toolbar.js:313
+#: frappe/public/js/frappe/form/toolbar.js:316
 msgid "Previous Document"
 msgstr ""
 
@@ -19418,12 +19725,12 @@ msgstr ""
 #: frappe/printing/page/print/print.js:65
 #: frappe/public/js/frappe/form/success_action.js:81
 #: frappe/public/js/frappe/form/templates/print_layout.html:46
-#: frappe/public/js/frappe/form/toolbar.js:345
-#: frappe/public/js/frappe/form/toolbar.js:357
+#: frappe/public/js/frappe/form/toolbar.js:348
+#: frappe/public/js/frappe/form/toolbar.js:360
 #: frappe/public/js/frappe/list/bulk_operations.js:95
-#: frappe/public/js/frappe/views/reports/query_report.js:1660
-#: frappe/public/js/frappe/views/reports/report_view.js:1538
-#: frappe/public/js/frappe/views/treeview.js:456 frappe/www/printview.html:18
+#: frappe/public/js/frappe/views/reports/query_report.js:1695
+#: frappe/public/js/frappe/views/reports/report_view.js:1540
+#: frappe/public/js/frappe/views/treeview.js:458 frappe/www/printview.html:18
 msgid "Print"
 msgstr ""
 
@@ -19487,6 +19794,11 @@ msgstr ""
 msgid "Print Format Field Template"
 msgstr ""
 
+#. Label of a Select field in DocType 'Print Format'
+#: frappe/printing/doctype/print_format/print_format.json
+msgid "Print Format For"
+msgstr ""
+
 #. Label of a HTML field in DocType 'Print Format'
 #: frappe/printing/doctype/print_format/print_format.json
 msgid "Print Format Help"
@@ -19495,6 +19807,10 @@ msgstr ""
 #. Label of a Select field in DocType 'Print Format'
 #: frappe/printing/doctype/print_format/print_format.json
 msgid "Print Format Type"
+msgstr ""
+
+#: frappe/public/js/frappe/views/reports/query_report.js:1509
+msgid "Print Format not found"
 msgstr ""
 
 #: frappe/www/printview.py:426
@@ -19536,7 +19852,7 @@ msgstr ""
 msgid "Print Language"
 msgstr ""
 
-#: frappe/public/js/frappe/form/print_utils.js:197
+#: frappe/public/js/frappe/form/print_utils.js:225
 msgid "Print Sent to the printer!"
 msgstr ""
 
@@ -19553,7 +19869,7 @@ msgstr ""
 #: frappe/printing/doctype/print_settings/print_settings.json
 #: frappe/printing/doctype/print_style/print_style.js:6
 #: frappe/printing/page/print/print.js:160
-#: frappe/public/js/frappe/form/print_utils.js:71
+#: frappe/public/js/frappe/form/print_utils.js:99
 #: frappe/public/js/frappe/form/templates/print_layout.html:35
 msgid "Print Settings"
 msgstr ""
@@ -19660,6 +19976,10 @@ msgstr ""
 msgid "Private Files (MB)"
 msgstr ""
 
+#: frappe/templates/emails/file_backup_notification.html:6
+msgid "Private Files Backup:"
+msgstr ""
+
 #. Description of the 'Auto Reply Message' (Text Editor) field in DocType
 #. 'Email Account'
 #: frappe/email/doctype/email_account/email_account.json
@@ -19670,11 +19990,11 @@ msgstr ""
 msgid "Proceed"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:864
+#: frappe/public/js/frappe/views/reports/query_report.js:865
 msgid "Proceed Anyway"
 msgstr ""
 
-#: frappe/public/js/frappe/form/controls/table.js:104
+#: frappe/public/js/frappe/form/controls/table.js:123
 msgid "Processing"
 msgstr ""
 
@@ -19691,18 +20011,28 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
+#. Label of a field in the edit-profile Web Form
+#: frappe/core/web_form/edit_profile/edit_profile.json
+msgid "Profile Picture"
+msgstr ""
+
+#. Success message of the edit-profile Web Form
+#: frappe/core/web_form/edit_profile/edit_profile.json
+msgid "Profile updated successfully."
+msgstr ""
+
 #: frappe/public/js/frappe/socketio_client.js:82
 msgid "Progress"
 msgstr ""
 
-#: frappe/public/js/frappe/views/kanban/kanban_view.js:407
+#: frappe/public/js/frappe/views/kanban/kanban_view.js:421
 msgid "Project"
 msgstr ""
 
 #. Label of a Data field in DocType 'Property Setter'
-#: frappe/core/doctype/version/version_view.html:12
-#: frappe/core/doctype/version/version_view.html:37
-#: frappe/core/doctype/version/version_view.html:74
+#: frappe/core/doctype/version/version_view.html:13
+#: frappe/core/doctype/version/version_view.html:38
+#: frappe/core/doctype/version/version_view.html:75
 #: frappe/custom/doctype/property_setter/property_setter.json
 msgid "Property"
 msgstr ""
@@ -19738,7 +20068,7 @@ msgstr ""
 msgid "Protect Attached Files"
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:499
+#: frappe/core/doctype/file/file.py:511
 msgid "Protected File"
 msgstr ""
 
@@ -19785,9 +20115,13 @@ msgstr ""
 msgid "Public Files (MB)"
 msgstr ""
 
+#: frappe/templates/emails/file_backup_notification.html:5
+msgid "Public Files Backup:"
+msgstr ""
+
 #. Label of a Check field in DocType 'Package Release'
 #: frappe/core/doctype/package_release/package_release.json
-#: frappe/public/js/frappe/form/footer/form_timeline.js:621
+#: frappe/public/js/frappe/form/footer/form_timeline.js:622
 #: frappe/website/doctype/blog_post/blog_post.js:36
 #: frappe/website/doctype/web_form/web_form.js:86
 msgid "Publish"
@@ -19926,7 +20260,7 @@ msgstr ""
 msgid "QR Code for Login Verification"
 msgstr ""
 
-#: frappe/public/js/frappe/form/print_utils.js:206
+#: frappe/public/js/frappe/form/print_utils.js:234
 msgid "QZ Tray Failed: "
 msgstr ""
 
@@ -20041,7 +20375,7 @@ msgstr ""
 
 #: frappe/integrations/doctype/dropbox_settings/dropbox_settings.py:65
 #: frappe/integrations/doctype/google_drive/google_drive.py:155
-#: frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py:82
+#: frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py:87
 msgid "Queued for backup. It may take a few minutes to an hour."
 msgstr ""
 
@@ -20088,7 +20422,7 @@ msgstr ""
 msgid "Quick Lists"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_utils.js:286
+#: frappe/public/js/frappe/views/reports/report_utils.js:291
 msgid "Quoting must be between 0 and 3"
 msgstr ""
 
@@ -20152,7 +20486,7 @@ msgstr ""
 
 #. Label of a Code field in DocType 'Print Format'
 #: frappe/printing/doctype/print_format/print_format.json
-#: frappe/printing/doctype/print_format/print_format.py:90
+#: frappe/printing/doctype/print_format/print_format.py:99
 msgid "Raw Commands"
 msgstr ""
 
@@ -20185,8 +20519,8 @@ msgid "Re:"
 msgstr ""
 
 #: frappe/core/doctype/communication/communication.js:268
-#: frappe/public/js/frappe/form/footer/form_timeline.js:589
-#: frappe/public/js/frappe/views/communication.js:355
+#: frappe/public/js/frappe/form/footer/form_timeline.js:590
+#: frappe/public/js/frappe/views/communication.js:358
 msgid "Re: {0}"
 msgstr ""
 
@@ -20283,11 +20617,11 @@ msgstr ""
 msgid "Reason"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:818
+#: frappe/public/js/frappe/views/reports/query_report.js:819
 msgid "Rebuild"
 msgstr ""
 
-#: frappe/public/js/frappe/views/treeview.js:475
+#: frappe/public/js/frappe/views/treeview.js:477
 msgid "Rebuild Tree"
 msgstr ""
 
@@ -20338,6 +20672,13 @@ msgstr ""
 msgid "Recipient"
 msgstr ""
 
+#. Label of a Data field in DocType 'DocType'
+#. Label of a Data field in DocType 'Customize Form'
+#: frappe/core/doctype/doctype/doctype.json
+#: frappe/custom/doctype/customize_form/customize_form.json
+msgid "Recipient Account Field"
+msgstr ""
+
 #. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: frappe/core/doctype/communication/communication.json
 msgid "Recipient Unsubscribed"
@@ -20386,6 +20727,11 @@ msgstr ""
 msgid "Redirect HTTP Status"
 msgstr ""
 
+#. Label of a Data field in DocType 'User Invitation'
+#: frappe/core/doctype/user_invitation/user_invitation.json
+msgid "Redirect To Path"
+msgstr ""
+
 #. Label of a Data field in DocType 'Connected App'
 #: frappe/integrations/doctype/connected_app/connected_app.json
 msgid "Redirect URI"
@@ -20425,16 +20771,16 @@ msgstr ""
 msgid "Redirects"
 msgstr ""
 
-#: frappe/sessions.py:148
+#: frappe/sessions.py:149
 msgid "Redis cache server not running. Please contact Administrator / Tech support"
 msgstr ""
 
-#: frappe/public/js/frappe/form/toolbar.js:486
+#: frappe/public/js/frappe/form/toolbar.js:489
 msgid "Redo"
 msgstr ""
 
 #: frappe/public/js/frappe/form/form.js:163
-#: frappe/public/js/frappe/form/toolbar.js:494
+#: frappe/public/js/frappe/form/toolbar.js:497
 msgid "Redo last action"
 msgstr ""
 
@@ -20467,6 +20813,11 @@ msgstr ""
 #. Label of a Select field in DocType 'Notification'
 #: frappe/email/doctype/notification/notification.json
 msgid "Reference Date"
+msgstr ""
+
+#. Label of a Dynamic Link field in DocType 'Event'
+#: frappe/desk/doctype/event/event.json
+msgid "Reference Doc"
 msgstr ""
 
 #. Label of a Data field in DocType 'Email Queue'
@@ -20532,6 +20883,7 @@ msgstr ""
 #. Label of a Data field in DocType 'Transaction Log'
 #. Label of a Link field in DocType 'View Log'
 #. Label of a Link field in DocType 'Calendar View'
+#. Label of a Link field in DocType 'Event'
 #. Label of a Link field in DocType 'Event Participants'
 #. Label of a Link field in DocType 'Kanban Board'
 #. Label of a Link field in DocType 'List Filter'
@@ -20554,6 +20906,7 @@ msgstr ""
 #: frappe/core/doctype/transaction_log/transaction_log.json
 #: frappe/core/doctype/view_log/view_log.json
 #: frappe/desk/doctype/calendar_view/calendar_view.json
+#: frappe/desk/doctype/event/event.json
 #: frappe/desk/doctype/event_participants/event_participants.json
 #: frappe/desk/doctype/kanban_board/kanban_board.json
 #: frappe/desk/doctype/list_filter/list_filter.json
@@ -20635,14 +20988,14 @@ msgid "Referrer"
 msgstr ""
 
 #: frappe/printing/page/print/print.js:73 frappe/public/js/frappe/desk.js:134
-#: frappe/public/js/frappe/desk.js:537
+#: frappe/public/js/frappe/desk.js:541
 #: frappe/public/js/frappe/form/form.js:1124
 #: frappe/public/js/frappe/form/templates/print_layout.html:6
 #: frappe/public/js/frappe/list/base_list.js:65
-#: frappe/public/js/frappe/views/reports/query_report.js:1649
-#: frappe/public/js/frappe/views/treeview.js:462
+#: frappe/public/js/frappe/views/reports/query_report.js:1684
+#: frappe/public/js/frappe/views/treeview.js:464
 #: frappe/public/js/frappe/widgets/chart_widget.js:291
-#: frappe/public/js/frappe/widgets/number_card_widget.js:333
+#: frappe/public/js/frappe/widgets/number_card_widget.js:336
 #: frappe/public/js/print_format_builder/Preview.vue:24
 msgid "Refresh"
 msgstr ""
@@ -20669,18 +21022,18 @@ msgstr ""
 msgid "Refresh Token"
 msgstr ""
 
-#: frappe/public/js/frappe/list/list_view.js:537
+#: frappe/public/js/frappe/list/list_view.js:539
 msgctxt "Document count in list view"
 msgid "Refreshing"
 msgstr ""
 
 #: frappe/core/doctype/system_settings/system_settings.js:57
-#: frappe/core/doctype/user/user.js:361
+#: frappe/core/doctype/user/user.js:367
 #: frappe/desk/page/setup_wizard/setup_wizard.js:211
 msgid "Refreshing..."
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:971
+#: frappe/core/doctype/user/user.py:982
 msgid "Registered but disabled"
 msgstr ""
 
@@ -20729,7 +21082,7 @@ msgstr ""
 #. Label of a standard navbar item
 #. Type: Action
 #: frappe/custom/doctype/customize_form/customize_form.js:120 frappe/hooks.py
-#: frappe/public/js/frappe/form/toolbar.js:432
+#: frappe/public/js/frappe/form/toolbar.js:435
 msgid "Reload"
 msgstr ""
 
@@ -20758,7 +21111,7 @@ msgstr ""
 msgid "Remind At"
 msgstr ""
 
-#: frappe/public/js/frappe/form/toolbar.js:460
+#: frappe/public/js/frappe/form/toolbar.js:463
 msgid "Remind Me"
 msgstr ""
 
@@ -20835,7 +21188,7 @@ msgstr ""
 #: frappe/custom/doctype/custom_field/custom_field.js:137
 #: frappe/public/js/frappe/form/toolbar.js:253
 #: frappe/public/js/frappe/form/toolbar.js:257
-#: frappe/public/js/frappe/form/toolbar.js:422
+#: frappe/public/js/frappe/form/toolbar.js:425
 #: frappe/public/js/frappe/model/model.js:752
 #: frappe/public/js/frappe/views/treeview.js:277
 msgid "Rename"
@@ -20850,7 +21203,7 @@ msgstr ""
 msgid "Rename {0}"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:687
+#: frappe/core/doctype/doctype/doctype.py:689
 msgid "Renamed files and replaced code in controllers, please check!"
 msgstr ""
 
@@ -20863,7 +21216,7 @@ msgstr ""
 msgid "Reopen"
 msgstr ""
 
-#: frappe/public/js/frappe/form/toolbar.js:503
+#: frappe/public/js/frappe/form/toolbar.js:506
 msgid "Repeat"
 msgstr ""
 
@@ -20949,6 +21302,8 @@ msgstr ""
 #. Option for the 'Link Type' (Select) field in DocType 'Workspace Link'
 #. Option for the 'Type' (Select) field in DocType 'Workspace Shortcut'
 #. Label of a Link field in DocType 'Auto Email Report'
+#. Option for the 'Print Format For' (Select) field in DocType 'Print Format'
+#. Label of a Link field in DocType 'Print Format'
 #: frappe/core/doctype/custom_docperm/custom_docperm.json
 #: frappe/core/doctype/custom_role/custom_role.json
 #: frappe/core/doctype/docperm/docperm.json
@@ -20964,6 +21319,9 @@ msgstr ""
 #: frappe/desk/doctype/workspace_link/workspace_link.json
 #: frappe/desk/doctype/workspace_shortcut/workspace_shortcut.json
 #: frappe/email/doctype/auto_email_report/auto_email_report.json
+#: frappe/printing/doctype/print_format/print_format.json
+#: frappe/printing/doctype/print_format/print_format.py:105
+#: frappe/public/js/frappe/form/print_utils.js:31
 #: frappe/public/js/frappe/request.js:612
 msgid "Report"
 msgstr ""
@@ -21031,7 +21389,7 @@ msgstr ""
 #: frappe/core/report/prepared_report_analytics/prepared_report_analytics.py:39
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
 #: frappe/desk/doctype/number_card/number_card.json
-#: frappe/public/js/frappe/views/reports/query_report.js:1834
+#: frappe/public/js/frappe/views/reports/query_report.js:1871
 msgid "Report Name"
 msgstr ""
 
@@ -21064,7 +21422,7 @@ msgstr ""
 msgid "Report View"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1774
+#: frappe/core/doctype/doctype/doctype.py:1787
 msgid "Report cannot be set for Single types"
 msgstr ""
 
@@ -21078,7 +21436,7 @@ msgstr ""
 msgid "Report has no numeric fields, please change the Report Name"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:945
+#: frappe/public/js/frappe/views/reports/query_report.js:946
 msgid "Report initiated, click to view status"
 msgstr ""
 
@@ -21090,15 +21448,15 @@ msgstr ""
 msgid "Report timed out."
 msgstr ""
 
-#: frappe/desk/query_report.py:598
+#: frappe/desk/query_report.py:638
 msgid "Report updated successfully"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1358
+#: frappe/public/js/frappe/views/reports/report_view.js:1360
 msgid "Report was not saved (there were errors)"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:1872
+#: frappe/public/js/frappe/views/reports/query_report.js:1909
 msgid "Report with more than 10 columns looks better in Landscape mode."
 msgstr ""
 
@@ -21107,7 +21465,7 @@ msgstr ""
 msgid "Report {0}"
 msgstr ""
 
-#: frappe/desk/reportview.py:343
+#: frappe/desk/reportview.py:339
 msgid "Report {0} deleted"
 msgstr ""
 
@@ -21115,7 +21473,7 @@ msgstr ""
 msgid "Report {0} is disabled"
 msgstr ""
 
-#: frappe/desk/reportview.py:320
+#: frappe/desk/reportview.py:316
 msgid "Report {0} saved"
 msgstr ""
 
@@ -21133,7 +21491,7 @@ msgstr ""
 msgid "Reports & Masters"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:861
+#: frappe/public/js/frappe/views/reports/query_report.js:862
 msgid "Reports already in Queue"
 msgstr ""
 
@@ -21157,7 +21515,10 @@ msgid "Request Body"
 msgstr ""
 
 #. Label of a Code field in DocType 'Integration Request'
+#. Title of the request-data Web Form
+#. Button label of the request-data Web Form
 #: frappe/integrations/doctype/integration_request/integration_request.json
+#: frappe/website/web_form/request_data/request_data.json
 msgid "Request Data"
 msgstr ""
 
@@ -21206,6 +21567,11 @@ msgstr ""
 #. Label of a Small Text field in DocType 'Webhook'
 #: frappe/integrations/doctype/webhook/webhook.json
 msgid "Request URL"
+msgstr ""
+
+#. Title of the request-to-delete-data Web Form
+#: frappe/website/web_form/request_to_delete_data/request_to_delete_data.json
+msgid "Request for Account Deletion"
 msgstr ""
 
 #. Label of a Select field in DocType 'LDAP Settings'
@@ -21257,7 +21623,7 @@ msgstr ""
 msgid "Reset Fields"
 msgstr ""
 
-#: frappe/core/doctype/user/user.js:177 frappe/core/doctype/user/user.js:180
+#: frappe/core/doctype/user/user.js:182 frappe/core/doctype/user/user.js:185
 msgid "Reset LDAP Password"
 msgstr ""
 
@@ -21265,11 +21631,11 @@ msgstr ""
 msgid "Reset Layout"
 msgstr ""
 
-#: frappe/core/doctype/user/user.js:228
+#: frappe/core/doctype/user/user.js:233
 msgid "Reset OTP Secret"
 msgstr ""
 
-#: frappe/core/doctype/user/user.js:161 frappe/www/login.html:198
+#: frappe/core/doctype/user/user.js:166 frappe/www/login.html:198
 #: frappe/www/me.html:35 frappe/www/me.html:44
 #: frappe/www/update-password.html:3 frappe/www/update-password.html:9
 msgid "Reset Password"
@@ -21306,7 +21672,7 @@ msgstr ""
 msgid "Reset the password for your account"
 msgstr ""
 
-#: frappe/public/js/frappe/form/grid_row.js:414
+#: frappe/public/js/frappe/form/grid_row.js:431
 msgid "Reset to default"
 msgstr ""
 
@@ -21441,7 +21807,7 @@ msgstr ""
 msgid "Reverted"
 msgstr ""
 
-#: frappe/database/schema.py:158
+#: frappe/database/schema.py:162
 msgid "Reverting length to {0} for '{1}' in '{2}'. Setting the length as {3} will cause truncation of data."
 msgstr ""
 
@@ -21529,6 +21895,7 @@ msgstr ""
 #. Label of a Link field in DocType 'DocPerm'
 #. Label of a Link field in DocType 'Has Role'
 #. Name of a DocType
+#. Label of a Link field in DocType 'User Role'
 #. Label of a Link field in DocType 'User Type'
 #. Label of a Link in the Users Workspace
 #. Label of a shortcut in the Users Workspace
@@ -21543,6 +21910,7 @@ msgstr ""
 #: frappe/core/doctype/docperm/docperm.json
 #: frappe/core/doctype/has_role/has_role.json
 #: frappe/core/doctype/role/role.json
+#: frappe/core/doctype/user_role/user_role.json
 #: frappe/core/doctype/user_type/user_type.json
 #: frappe/core/doctype/user_type/user_type.py:109
 #: frappe/core/page/permission_manager/permission_manager.js:219
@@ -21611,7 +21979,7 @@ msgstr ""
 msgid "Role and Level"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:306
+#: frappe/core/doctype/user/user.py:307
 msgid "Role has been set as per the user type {0}"
 msgstr ""
 
@@ -21619,6 +21987,7 @@ msgstr ""
 #. Label of a Table field in DocType 'Report'
 #. Label of a Table field in DocType 'Role Permission for Page and Report'
 #. Label of a Section Break field in DocType 'User'
+#. Label of a Table MultiSelect field in DocType 'User Invitation'
 #. Label of a Section Break field in DocType 'Custom HTML Block'
 #. Label of a Table field in DocType 'Custom HTML Block'
 #. Label of a Table field in DocType 'Dashboard Chart'
@@ -21627,6 +21996,7 @@ msgstr ""
 #: frappe/core/doctype/page/page.json frappe/core/doctype/report/report.json
 #: frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.json
 #: frappe/core/doctype/user/user.json
+#: frappe/core/doctype/user_invitation/user_invitation.json
 #: frappe/core/page/permission_manager/permission_manager.js:66
 #: frappe/desk/doctype/custom_html_block/custom_html_block.json
 #: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -21662,7 +22032,7 @@ msgstr ""
 msgid "Roles can be set for users from their User page."
 msgstr ""
 
-#: frappe/utils/nestedset.py:284
+#: frappe/utils/nestedset.py:297
 msgid "Root {0} cannot be deleted"
 msgstr ""
 
@@ -21730,12 +22100,12 @@ msgstr ""
 msgid "Row"
 msgstr ""
 
-#: frappe/core/doctype/version/version_view.html:73
+#: frappe/core/doctype/version/version_view.html:74
 msgid "Row #"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1796
-#: frappe/core/doctype/doctype/doctype.py:1806
+#: frappe/core/doctype/doctype/doctype.py:1809
+#: frappe/core/doctype/doctype/doctype.py:1819
 msgid "Row # {0}: Non administrator user can not set the role {1} to the custom doctype"
 msgstr ""
 
@@ -21743,7 +22113,7 @@ msgstr ""
 msgid "Row #{0}:"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:488
+#: frappe/core/doctype/doctype/doctype.py:490
 msgid "Row #{}: Fieldname is required"
 msgstr ""
 
@@ -21771,7 +22141,7 @@ msgstr ""
 msgid "Row Number"
 msgstr ""
 
-#: frappe/core/doctype/version/version_view.html:68
+#: frappe/core/doctype/version/version_view.html:69
 msgid "Row Values Changed"
 msgstr ""
 
@@ -21779,24 +22149,31 @@ msgstr ""
 msgid "Row {0}"
 msgstr ""
 
-#: frappe/custom/doctype/customize_form/customize_form.py:350
+#: frappe/custom/doctype/customize_form/customize_form.py:357
 msgid "Row {0}: Not allowed to disable Mandatory for standard fields"
 msgstr ""
 
-#: frappe/custom/doctype/customize_form/customize_form.py:339
+#: frappe/custom/doctype/customize_form/customize_form.py:346
 msgid "Row {0}: Not allowed to enable Allow on Submit for standard fields"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Audit Trail'
 #: frappe/core/doctype/audit_trail/audit_trail.json
-#: frappe/core/doctype/version/version_view.html:32
+#: frappe/core/doctype/version/version_view.html:33
 msgid "Rows Added"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Audit Trail'
 #: frappe/core/doctype/audit_trail/audit_trail.json
-#: frappe/core/doctype/version/version_view.html:32
+#: frappe/core/doctype/version/version_view.html:33
 msgid "Rows Removed"
+msgstr ""
+
+#. Label of a Int field in DocType 'DocType'
+#. Label of a Int field in DocType 'Customize Form'
+#: frappe/core/doctype/doctype/doctype.json
+#: frappe/custom/doctype/customize_form/customize_form.json
+msgid "Rows Threshold for Grid Search"
 msgstr ""
 
 #. Label of a Select field in DocType 'Assignment Rule'
@@ -22016,7 +22393,7 @@ msgstr ""
 #: frappe/email/doctype/notification/notification.json
 #: frappe/printing/page/print/print.js:858
 #: frappe/printing/page/print_format_builder/print_format_builder.js:160
-#: frappe/public/js/frappe/form/footer/form_timeline.js:665
+#: frappe/public/js/frappe/form/footer/form_timeline.js:666
 #: frappe/public/js/frappe/form/quick_entry.js:161
 #: frappe/public/js/frappe/list/list_settings.js:36
 #: frappe/public/js/frappe/list/list_settings.js:247
@@ -22025,9 +22402,9 @@ msgstr ""
 #: frappe/public/js/frappe/utils/common.js:443
 #: frappe/public/js/frappe/views/kanban/kanban_settings.js:45
 #: frappe/public/js/frappe/views/kanban/kanban_settings.js:189
-#: frappe/public/js/frappe/views/kanban/kanban_view.js:342
-#: frappe/public/js/frappe/views/reports/query_report.js:1826
-#: frappe/public/js/frappe/views/reports/report_view.js:1726
+#: frappe/public/js/frappe/views/kanban/kanban_view.js:356
+#: frappe/public/js/frappe/views/reports/query_report.js:1863
+#: frappe/public/js/frappe/views/reports/report_view.js:1735
 #: frappe/public/js/frappe/views/workspace/workspace.js:532
 #: frappe/public/js/frappe/widgets/base_widget.js:142
 #: frappe/public/js/frappe/widgets/quick_list_widget.js:119
@@ -22036,16 +22413,12 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: frappe/core/doctype/user/user.js:332
-msgid "Save API Secret: {0}"
-msgstr ""
-
 #: frappe/workflow/doctype/workflow/workflow.js:143
 msgid "Save Anyway"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1389
-#: frappe/public/js/frappe/views/reports/report_view.js:1733
+#: frappe/public/js/frappe/views/reports/report_view.js:1391
+#: frappe/public/js/frappe/views/reports/report_view.js:1742
 msgid "Save As"
 msgstr ""
 
@@ -22057,11 +22430,11 @@ msgstr ""
 msgid "Save Filter"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:1829
+#: frappe/public/js/frappe/views/reports/query_report.js:1866
 msgid "Save Report"
 msgstr ""
 
-#: frappe/public/js/frappe/views/kanban/kanban_view.js:96
+#: frappe/public/js/frappe/views/kanban/kanban_view.js:106
 msgid "Save filters"
 msgstr ""
 
@@ -22076,7 +22449,7 @@ msgstr ""
 
 #: frappe/model/rename_doc.py:106
 #: frappe/printing/page/print_format_builder/print_format_builder.js:845
-#: frappe/public/js/frappe/form/toolbar.js:284
+#: frappe/public/js/frappe/form/toolbar.js:285
 #: frappe/public/js/frappe/views/kanban/kanban_board.bundle.js:912
 msgid "Saved"
 msgstr ""
@@ -22451,7 +22824,7 @@ msgstr ""
 msgid "See all Activity"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:787
+#: frappe/public/js/frappe/views/reports/query_report.js:788
 msgid "See all past reports."
 msgstr ""
 
@@ -22460,7 +22833,7 @@ msgstr ""
 msgid "See on Website"
 msgstr ""
 
-#: frappe/website/doctype/web_form/templates/web_form.html:150
+#: frappe/website/doctype/web_form/templates/web_form.html:157
 msgctxt "Button in web form"
 msgid "See previous responses"
 msgstr ""
@@ -22517,12 +22890,12 @@ msgstr ""
 
 #: frappe/public/js/frappe/data_import/data_exporter.js:149
 #: frappe/public/js/frappe/form/controls/multicheck.js:166
-#: frappe/public/js/frappe/form/grid_row.js:474
+#: frappe/public/js/frappe/form/grid_row.js:491
 msgid "Select All"
 msgstr ""
 
 #: frappe/public/js/frappe/views/communication.js:165
-#: frappe/public/js/frappe/views/communication.js:586
+#: frappe/public/js/frappe/views/communication.js:589
 #: frappe/public/js/frappe/views/interaction.js:93
 #: frappe/public/js/frappe/views/interaction.js:155
 msgid "Select Attachments"
@@ -22533,12 +22906,12 @@ msgstr ""
 msgid "Select Child Table"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:384
+#: frappe/public/js/frappe/views/reports/report_view.js:389
 msgid "Select Column"
 msgstr ""
 
 #: frappe/printing/page/print_format_builder/print_format_builder_field.html:41
-#: frappe/public/js/frappe/form/print_utils.js:45
+#: frappe/public/js/frappe/form/print_utils.js:73
 msgid "Select Columns"
 msgstr ""
 
@@ -22593,7 +22966,7 @@ msgstr ""
 
 #: frappe/public/js/form_builder/components/controls/FetchFromControl.vue:33
 #: frappe/public/js/frappe/doctype/index.js:199
-#: frappe/public/js/frappe/form/toolbar.js:773
+#: frappe/public/js/frappe/form/toolbar.js:776
 msgid "Select Field"
 msgstr ""
 
@@ -22602,7 +22975,7 @@ msgstr ""
 msgid "Select Field..."
 msgstr ""
 
-#: frappe/public/js/frappe/form/grid_row.js:466
+#: frappe/public/js/frappe/form/grid_row.js:483
 #: frappe/public/js/frappe/list/list_settings.js:236
 #: frappe/public/js/frappe/views/kanban/kanban_settings.js:181
 msgid "Select Fields"
@@ -22620,7 +22993,7 @@ msgstr ""
 msgid "Select Filters"
 msgstr ""
 
-#: frappe/desk/doctype/event/event.py:100
+#: frappe/desk/doctype/event/event.py:104
 msgid "Select Google Calendar to which event should be synced."
 msgstr ""
 
@@ -22720,14 +23093,14 @@ msgid "Select a field to edit its properties."
 msgstr ""
 
 #: frappe/public/js/frappe/views/treeview.js:324
-msgid "Select a group node first."
+msgid "Select a group {0} first."
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1907
+#: frappe/core/doctype/doctype/doctype.py:1920
 msgid "Select a valid Sender Field for creating documents from Email"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1891
+#: frappe/core/doctype/doctype/doctype.py:1904
 msgid "Select a valid Subject field for creating documents from Email"
 msgstr ""
 
@@ -23031,7 +23404,7 @@ msgstr ""
 msgid "Sender Email Field"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1910
+#: frappe/core/doctype/doctype/doctype.py:1923
 msgid "Sender Field should have Email in options"
 msgstr ""
 
@@ -23125,7 +23498,7 @@ msgstr ""
 msgid "Series counter for {} updated to {} successfully"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1088
+#: frappe/core/doctype/doctype/doctype.py:1090
 #: frappe/core/doctype/document_naming_settings/document_naming_settings.py:170
 msgid "Series {0} already used in {1}"
 msgstr ""
@@ -23203,7 +23576,7 @@ msgstr ""
 msgid "Session Defaults Saved"
 msgstr ""
 
-#: frappe/app.py:349
+#: frappe/app.py:347
 msgid "Session Expired"
 msgstr ""
 
@@ -23212,7 +23585,7 @@ msgstr ""
 msgid "Session Expiry (idle timeout)"
 msgstr ""
 
-#: frappe/core/doctype/system_settings/system_settings.py:117
+#: frappe/core/doctype/system_settings/system_settings.py:119
 msgid "Session Expiry must be in format {0}"
 msgstr ""
 
@@ -23234,7 +23607,7 @@ msgstr ""
 msgid "Set Banner from Image"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:199
+#: frappe/public/js/frappe/views/reports/query_report.js:200
 msgid "Set Chart"
 msgstr ""
 
@@ -23307,7 +23680,7 @@ msgstr ""
 msgid "Set Role For"
 msgstr ""
 
-#: frappe/core/doctype/user/user.js:138
+#: frappe/core/doctype/user/user.js:143
 #: frappe/core/page/permission_manager/permission_manager.js:72
 msgid "Set User Permissions"
 msgstr ""
@@ -23326,7 +23699,7 @@ msgstr ""
 msgid "Set all public"
 msgstr ""
 
-#: frappe/printing/doctype/print_format/print_format.js:49
+#: frappe/printing/doctype/print_format/print_format.js:50
 msgid "Set as Default"
 msgstr ""
 
@@ -23345,16 +23718,19 @@ msgstr ""
 msgid "Set dynamic filter values in JavaScript for the required fields here."
 msgstr ""
 
-#. Description of the 'Precision' (Select) field in DocType 'DocField'
 #. Description of the 'Precision' (Select) field in DocType 'Custom Field'
 #. Description of the 'Precision' (Select) field in DocType 'Customize Form
 #. Field'
 #. Description of the 'Precision' (Select) field in DocType 'Web Form Field'
-#: frappe/core/doctype/docfield/docfield.json
 #: frappe/custom/doctype/custom_field/custom_field.json
 #: frappe/custom/doctype/customize_form_field/customize_form_field.json
 #: frappe/website/doctype/web_form_field/web_form_field.json
 msgid "Set non-standard precision for a Float or Currency field"
+msgstr ""
+
+#. Description of the 'Precision' (Select) field in DocType 'DocField'
+#: frappe/core/doctype/docfield/docfield.json
+msgid "Set non-standard precision for a Float, Currency or Percent field"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocField'
@@ -23478,8 +23854,8 @@ msgstr ""
 msgid "Setup Approval Workflows"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:1695
-#: frappe/public/js/frappe/views/reports/report_view.js:1704
+#: frappe/public/js/frappe/views/reports/query_report.js:1732
+#: frappe/public/js/frappe/views/reports/report_view.js:1713
 msgid "Setup Auto Email"
 msgstr ""
 
@@ -23586,6 +23962,11 @@ msgstr ""
 msgid "Show \"Call to Action\" in Blog"
 msgstr ""
 
+#. Label of a Check field in DocType 'System Settings'
+#: frappe/core/doctype/system_settings/system_settings.json
+msgid "Show Absolute Datetime in Timeline"
+msgstr ""
+
 #. Label of a Check field in DocType 'Print Format'
 #: frappe/printing/doctype/print_format/print_format.json
 msgid "Show Absolute Values"
@@ -23628,7 +24009,7 @@ msgstr ""
 msgid "Show Error"
 msgstr ""
 
-#: frappe/public/js/frappe/form/layout.js:571
+#: frappe/public/js/frappe/form/layout.js:570
 msgid "Show Fieldname (click to copy on clipboard)"
 msgstr ""
 
@@ -23760,7 +24141,7 @@ msgstr ""
 msgid "Show Title in Link Fields"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1528
+#: frappe/public/js/frappe/views/reports/report_view.js:1530
 msgid "Show Totals"
 msgstr ""
 
@@ -23770,6 +24151,11 @@ msgstr ""
 
 #: frappe/core/doctype/data_import/data_import.js:453
 msgid "Show Traceback"
+msgstr ""
+
+#. Label of a Check field in DocType 'Dashboard Chart'
+#: frappe/desk/doctype/dashboard_chart/dashboard_chart.json
+msgid "Show Values over Chart"
 msgstr ""
 
 #: frappe/public/js/frappe/data_import/import_preview.js:204
@@ -23828,8 +24214,8 @@ msgstr ""
 msgid "Show link to document"
 msgstr ""
 
-#: frappe/public/js/frappe/form/layout.js:273
-#: frappe/public/js/frappe/form/layout.js:291
+#: frappe/public/js/frappe/form/layout.js:272
+#: frappe/public/js/frappe/form/layout.js:290
 msgid "Show more details"
 msgstr ""
 
@@ -23853,7 +24239,7 @@ msgstr ""
 msgid "Show {0} List"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:502
+#: frappe/public/js/frappe/views/reports/report_view.js:507
 msgid "Showing only Numeric fields from Report"
 msgstr ""
 
@@ -23886,7 +24272,7 @@ msgstr ""
 msgid "Sign Up and Confirmation"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:964
+#: frappe/core/doctype/user/user.py:975
 msgid "Sign Up is disabled"
 msgstr ""
 
@@ -23945,13 +24331,13 @@ msgstr ""
 msgid "Simultaneous Sessions"
 msgstr ""
 
-#: frappe/custom/doctype/customize_form/customize_form.py:123
+#: frappe/custom/doctype/customize_form/customize_form.py:128
 msgid "Single DocTypes cannot be customized."
 msgstr ""
 
 #. Description of the 'Is Single' (Check) field in DocType 'DocType'
 #: frappe/core/doctype/doctype/doctype.json
-#: frappe/core/doctype/doctype/doctype_list.js:51
+#: frappe/core/doctype/doctype/doctype_list.js:52
 msgid "Single Types have only one record no tables associated. Values are stored in tabSingles"
 msgstr ""
 
@@ -24001,7 +24387,7 @@ msgstr ""
 msgid "Skipping column {0}"
 msgstr ""
 
-#: frappe/modules/utils.py:176
+#: frappe/modules/utils.py:177
 msgid "Skipping fixture syncing for doctype {0} from file {1}"
 msgstr ""
 
@@ -24193,7 +24579,7 @@ msgstr ""
 #. Label of a Data field in DocType 'Web Page View'
 #. Label of a Small Text field in DocType 'Website Route Redirect'
 #: frappe/public/js/frappe/ui/toolbar/about.js:8
-#: frappe/public/js/frappe/utils/utils.js:1724
+#: frappe/public/js/frappe/utils/utils.js:1740
 #: frappe/website/doctype/web_page_view/web_page_view.json
 #: frappe/website/doctype/website_route_redirect/website_route_redirect.json
 #: frappe/website/report/website_analytics/website_analytics.js:38
@@ -24250,7 +24636,7 @@ msgstr ""
 msgid "Splash Image"
 msgstr ""
 
-#: frappe/desk/reportview.py:398
+#: frappe/desk/reportview.py:429
 #: frappe/public/js/frappe/web_form/web_form_list.js:175
 #: frappe/templates/print_formats/standard_macros.html:44
 msgid "Sr"
@@ -24283,11 +24669,11 @@ msgstr ""
 msgid "Standard"
 msgstr ""
 
-#: frappe/model/delete_doc.py:78
+#: frappe/model/delete_doc.py:79
 msgid "Standard DocType can not be deleted."
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:228
+#: frappe/core/doctype/doctype/doctype.py:230
 msgid "Standard DocType cannot have default print format, use Customize Form"
 msgstr ""
 
@@ -24299,7 +24685,7 @@ msgstr ""
 msgid "Standard Permissions"
 msgstr ""
 
-#: frappe/printing/doctype/print_format/print_format.py:76
+#: frappe/printing/doctype/print_format/print_format.py:83
 msgid "Standard Print Format cannot be updated"
 msgstr ""
 
@@ -24307,11 +24693,11 @@ msgstr ""
 msgid "Standard Print Style cannot be changed. Please duplicate to edit."
 msgstr ""
 
-#: frappe/desk/reportview.py:333
+#: frappe/desk/reportview.py:329
 msgid "Standard Reports cannot be deleted"
 msgstr ""
 
-#: frappe/desk/reportview.py:304
+#: frappe/desk/reportview.py:300
 msgid "Standard Reports cannot be edited"
 msgstr ""
 
@@ -24358,7 +24744,7 @@ msgstr ""
 #. Label of a Date field in DocType 'Auto Repeat'
 #. Label of a Datetime field in DocType 'Web Page'
 #: frappe/automation/doctype/auto_repeat/auto_repeat.json
-#: frappe/automation/doctype/auto_repeat/auto_repeat.py:142
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:145
 #: frappe/public/js/frappe/utils/common.js:409
 #: frappe/website/doctype/web_page/web_page.json
 msgid "Start Date"
@@ -24422,6 +24808,7 @@ msgstr ""
 #. Label of a Link field in DocType 'Workflow Document State'
 #. Label of a Data field in DocType 'Workflow State'
 #. Label of a Link field in DocType 'Workflow Transition'
+#: frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py:40
 #: frappe/integrations/doctype/token_cache/token_cache.json
 #: frappe/workflow/doctype/workflow/workflow.js:162
 #: frappe/workflow/doctype/workflow_document_state/workflow_document_state.json
@@ -24492,6 +24879,7 @@ msgstr ""
 #. Label of a Select field in DocType 'Scheduled Job Log'
 #. Label of a Section Break field in DocType 'Scheduled Job Type'
 #. Label of a Select field in DocType 'Submission Queue'
+#. Label of a Select field in DocType 'User Invitation'
 #. Label of a Select field in DocType 'Event'
 #. Label of a Select field in DocType 'Kanban Board Column'
 #. Label of a Select field in DocType 'ToDo'
@@ -24515,6 +24903,7 @@ msgstr ""
 #: frappe/core/doctype/scheduled_job_log/scheduled_job_log.json
 #: frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
 #: frappe/core/doctype/submission_queue/submission_queue.json
+#: frappe/core/doctype/user_invitation/user_invitation.json
 #: frappe/desk/doctype/event/event.json
 #: frappe/desk/doctype/kanban_board_column/kanban_board_column.json
 #: frappe/desk/doctype/todo/todo.json
@@ -24524,7 +24913,7 @@ msgstr ""
 #: frappe/integrations/doctype/integration_request/integration_request.json
 #: frappe/integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
 #: frappe/public/js/frappe/list/list_settings.js:359
-#: frappe/public/js/frappe/views/reports/report_view.js:976
+#: frappe/public/js/frappe/views/reports/report_view.js:981
 #: frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.json
 #: frappe/website/doctype/personal_data_deletion_step/personal_data_deletion_step.json
 #: frappe/workflow/doctype/workflow_action/workflow_action.json
@@ -24577,6 +24966,10 @@ msgstr ""
 #. Label of a Check field in DocType 'System Settings'
 #: frappe/core/doctype/system_settings/system_settings.json
 msgid "Store Attached PDF Document"
+msgstr ""
+
+#: frappe/core/doctype/user/user.js:479
+msgid "Store the API secret securely. It won't be displayed again."
 msgstr ""
 
 #. Description of the 'Last Known Versions' (Text) field in DocType 'User'
@@ -24674,7 +25067,7 @@ msgstr ""
 msgid "Subject Field"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1900
+#: frappe/core/doctype/doctype/doctype.py:1913
 msgid "Subject Field type should be Data, Text, Long Text, Small Text, Text Editor"
 msgstr ""
 
@@ -24690,6 +25083,7 @@ msgstr ""
 #. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
 #. Option for the 'For Document Event' (Select) field in DocType 'Energy Point
 #. Rule'
+#. Button label of the request-to-delete-data Web Form
 #: frappe/core/doctype/custom_docperm/custom_docperm.json
 #: frappe/core/doctype/docperm/docperm.json
 #: frappe/core/doctype/docshare/docshare.json
@@ -24702,6 +25096,7 @@ msgstr ""
 #: frappe/social/doctype/energy_point_log/energy_point_log.js:39
 #: frappe/social/doctype/energy_point_rule/energy_point_rule.json
 #: frappe/social/doctype/energy_point_settings/energy_point_settings.js:47
+#: frappe/website/web_form/request_to_delete_data/request_to_delete_data.json
 msgid "Submit"
 msgstr ""
 
@@ -24739,7 +25134,7 @@ msgstr ""
 msgid "Submit an Issue"
 msgstr ""
 
-#: frappe/website/doctype/web_form/templates/web_form.html:153
+#: frappe/website/doctype/web_form/templates/web_form.html:160
 msgctxt "Button in web form"
 msgid "Submit another response"
 msgstr ""
@@ -24751,7 +25146,7 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Auto Repeat'
 #: frappe/automation/doctype/auto_repeat/auto_repeat.json
-#: frappe/automation/doctype/auto_repeat/auto_repeat.py:128
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:127
 msgid "Submit on Creation"
 msgstr ""
 
@@ -24774,7 +25169,7 @@ msgstr ""
 #: frappe/core/doctype/communication/communication.json
 #: frappe/public/js/frappe/model/indicator.js:95
 #: frappe/public/js/frappe/ui/filters/filter.js:537
-#: frappe/website/doctype/web_form/templates/web_form.html:133
+#: frappe/website/doctype/web_form/templates/web_form.html:140
 msgid "Submitted"
 msgstr ""
 
@@ -24817,7 +25212,7 @@ msgstr ""
 #: frappe/core/doctype/data_import_log/data_import_log.json
 #: frappe/desk/doctype/bulk_update/bulk_update.js:31
 #: frappe/desk/doctype/desktop_icon/desktop_icon.py:446
-#: frappe/public/js/frappe/form/grid.js:1152
+#: frappe/public/js/frappe/form/grid.js:1153
 #: frappe/public/js/frappe/views/translation_manager.js:21
 #: frappe/templates/includes/login/login.js:231
 #: frappe/templates/includes/login/login.js:237
@@ -24926,7 +25321,7 @@ msgstr ""
 msgid "Suggested Indexes"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:671
+#: frappe/core/doctype/user/user.py:682
 msgid "Suggested Username: {0}"
 msgstr ""
 
@@ -24939,7 +25334,7 @@ msgstr ""
 msgid "Sum"
 msgstr ""
 
-#: frappe/public/js/frappe/ui/group_by/group_by.js:337
+#: frappe/public/js/frappe/ui/group_by/group_by.js:340
 msgid "Sum of {0}"
 msgstr ""
 
@@ -25046,7 +25441,7 @@ msgstr ""
 msgid "Syncing {0} of {1}"
 msgstr ""
 
-#: frappe/utils/data.py:2228
+#: frappe/utils/data.py:2247
 msgid "Syntax Error"
 msgstr ""
 
@@ -25158,6 +25553,7 @@ msgstr ""
 #: frappe/core/doctype/translation/translation.json
 #: frappe/core/doctype/user/user.json
 #: frappe/core/doctype/user_group/user_group.json
+#: frappe/core/doctype/user_invitation/user_invitation.json
 #: frappe/core/doctype/user_permission/user_permission.json
 #: frappe/core/doctype/user_type/user_type.json
 #: frappe/core/doctype/version/version.json
@@ -25317,7 +25713,7 @@ msgstr ""
 msgid "Table Break"
 msgstr ""
 
-#: frappe/core/doctype/version/version_view.html:72
+#: frappe/core/doctype/version/version_view.html:73
 msgid "Table Field"
 msgstr ""
 
@@ -25348,11 +25744,11 @@ msgstr ""
 msgid "Table Trimmed"
 msgstr ""
 
-#: frappe/public/js/frappe/form/grid.js:1151
+#: frappe/public/js/frappe/form/grid.js:1152
 msgid "Table updated"
 msgstr ""
 
-#: frappe/model/document.py:1415
+#: frappe/model/document.py:1419
 msgid "Table {0} cannot be empty"
 msgstr ""
 
@@ -25371,7 +25767,7 @@ msgstr ""
 msgid "Tag Link"
 msgstr ""
 
-#: frappe/model/meta.py:52
+#: frappe/model/meta.py:53
 #: frappe/public/js/frappe/form/templates/form_sidebar.html:100
 #: frappe/public/js/frappe/list/bulk_operations.js:430
 #: frappe/public/js/frappe/list/list_sidebar.html:50
@@ -25464,7 +25860,7 @@ msgstr ""
 msgid "Templates"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:975
+#: frappe/core/doctype/user/user.py:988
 msgid "Temporarily Disabled"
 msgstr ""
 
@@ -25544,7 +25940,7 @@ msgid ""
 "{0}"
 msgstr ""
 
-#: frappe/website/doctype/web_form/templates/web_form.html:137
+#: frappe/website/doctype/web_form/templates/web_form.html:144
 msgid "Thank you for spending your valuable time to fill this form"
 msgstr ""
 
@@ -25572,7 +25968,7 @@ msgstr ""
 msgid "The Auto Repeat for this document has been disabled."
 msgstr ""
 
-#: frappe/public/js/frappe/form/grid.js:1174
+#: frappe/public/js/frappe/form/grid.js:1175
 msgid "The CSV format is case sensitive"
 msgstr ""
 
@@ -25588,11 +25984,11 @@ msgstr ""
 msgid "The Condition '{0}' is invalid"
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:206
+#: frappe/core/doctype/file/file.py:211
 msgid "The File URL you've entered is incorrect"
 msgstr ""
 
-#: frappe/automation/doctype/auto_repeat/auto_repeat.py:108
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:107
 msgid "The Next Scheduled Date cannot be later than the End Date."
 msgstr ""
 
@@ -25626,7 +26022,7 @@ msgid ""
 "</a>"
 msgstr ""
 
-#: frappe/database/database.py:431
+#: frappe/database/database.py:430
 msgid "The changes have been reverted."
 msgstr ""
 
@@ -25642,7 +26038,7 @@ msgstr ""
 msgid "The contents of this email are strictly confidential. Please do not forward this email to anyone."
 msgstr ""
 
-#: frappe/public/js/frappe/list/list_view.js:665
+#: frappe/public/js/frappe/list/list_view.js:667
 msgid "The count shown is an estimated count. Click here to see the accurate count."
 msgstr ""
 
@@ -25667,7 +26063,7 @@ msgstr ""
 msgid "The field {0} is mandatory"
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:143
+#: frappe/core/doctype/file/file.py:148
 msgid "The fieldname you've specified in Attached To Field is invalid"
 msgstr ""
 
@@ -25679,11 +26075,11 @@ msgstr ""
 msgid "The following Header Script will add the current date to an element in 'Header HTML' with class 'header-content'"
 msgstr ""
 
-#: frappe/core/doctype/data_import/importer.py:1042
+#: frappe/core/doctype/data_import/importer.py:1045
 msgid "The following values are invalid: {0}. Values must be one of {1}"
 msgstr ""
 
-#: frappe/core/doctype/data_import/importer.py:1005
+#: frappe/core/doctype/data_import/importer.py:1008
 msgid "The following values do not exist for {0}: {1}"
 msgstr ""
 
@@ -25695,7 +26091,7 @@ msgstr ""
 msgid "The link will expire in {0} minutes"
 msgstr ""
 
-#: frappe/www/login.py:192
+#: frappe/www/login.py:194
 msgid "The link you trying to login is invalid or expired."
 msgstr ""
 
@@ -25742,15 +26138,19 @@ msgid ""
 "</a>"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:935
+#: frappe/desk/utils.py:88
+msgid "The report you requested has been generated.<br><br>Click here to download:<br><a href='{0}'>{0}</a><br><br>This link will expire in {1} hours."
+msgstr ""
+
+#: frappe/core/doctype/user/user.py:946
 msgid "The reset password link has been expired"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:937
+#: frappe/core/doctype/user/user.py:948
 msgid "The reset password link has either been used before or is invalid"
 msgstr ""
 
-#: frappe/app.py:368 frappe/public/js/frappe/request.js:147
+#: frappe/app.py:366 frappe/public/js/frappe/request.js:147
 msgid "The resource you are looking for is not available"
 msgstr ""
 
@@ -25758,7 +26158,7 @@ msgstr ""
 msgid "The role {0} should be a custom role."
 msgstr ""
 
-#: frappe/utils/response.py:321
+#: frappe/utils/response.py:319
 msgid "The system is being updated. Please refresh again after a few moments."
 msgstr ""
 
@@ -25766,7 +26166,7 @@ msgstr ""
 msgid "The system provides many pre-defined roles. You can add new roles to set finer permissions."
 msgstr ""
 
-#: frappe/public/js/frappe/form/grid_row.js:653
+#: frappe/public/js/frappe/form/grid_row.js:670
 msgid "The total column width cannot be more than 10."
 msgstr ""
 
@@ -25789,7 +26189,7 @@ msgstr ""
 msgid "The webhook will be triggered if this expression is true"
 msgstr ""
 
-#: frappe/automation/doctype/auto_repeat/auto_repeat.py:175
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:178
 msgid "The {0} is already on auto repeat {1}"
 msgstr ""
 
@@ -25827,7 +26227,7 @@ msgstr ""
 msgid "There are no {0} for this {1}, why don't you start one!"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:897
+#: frappe/public/js/frappe/views/reports/query_report.js:898
 msgid "There are {0} with the same filters already in the queue:"
 msgstr ""
 
@@ -25852,11 +26252,11 @@ msgstr ""
 msgid "There is nothing new to show you right now."
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:610 frappe/utils/file_manager.py:375
+#: frappe/core/doctype/file/file.py:622 frappe/utils/file_manager.py:375
 msgid "There is some problem with the file url: {0}"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:894
+#: frappe/public/js/frappe/views/reports/query_report.js:895
 msgid "There is {0} with the same filters already in the queue:"
 msgstr ""
 
@@ -25868,7 +26268,7 @@ msgstr ""
 msgid "There was an error building this page"
 msgstr ""
 
-#: frappe/public/js/frappe/views/kanban/kanban_view.js:181
+#: frappe/public/js/frappe/views/kanban/kanban_view.js:195
 msgid "There was an error saving filters"
 msgstr ""
 
@@ -25880,11 +26280,11 @@ msgstr ""
 msgid "There were errors while creating the document. Please try again."
 msgstr ""
 
-#: frappe/public/js/frappe/views/communication.js:828
+#: frappe/public/js/frappe/views/communication.js:831
 msgid "There were errors while sending email. Please try again."
 msgstr ""
 
-#: frappe/model/naming.py:476
+#: frappe/model/naming.py:484
 msgid "There were some errors setting the name, please contact the administrator"
 msgstr ""
 
@@ -25930,12 +26330,16 @@ msgstr ""
 msgid "This Doctype does not contain location fields"
 msgstr ""
 
-#: frappe/public/js/frappe/views/kanban/kanban_view.js:390
+#: frappe/public/js/frappe/views/kanban/kanban_view.js:404
 msgid "This Kanban Board will be private"
 msgstr ""
 
 #: frappe/public/js/frappe/ui/filters/filter.js:664
 msgid "This Month"
+msgstr ""
+
+#: frappe/core/doctype/file/file.py:382
+msgid "This PDF cannot be uploaded as it contains unsafe content."
 msgstr ""
 
 #: frappe/public/js/frappe/ui/filters/filter.js:668
@@ -25977,7 +26381,7 @@ msgstr ""
 msgid "This doctype has no orphan fields to trim"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1033
+#: frappe/core/doctype/doctype/doctype.py:1035
 msgid "This doctype has pending migrations, run 'bench migrate' before modifying the doctype to avoid losing changes."
 msgstr ""
 
@@ -25985,7 +26389,7 @@ msgstr ""
 msgid "This document allows you to edit limited fields. For all kinds of workspace customization, use the Edit button located on the workspace page"
 msgstr ""
 
-#: frappe/model/delete_doc.py:112
+#: frappe/model/delete_doc.py:113
 msgid "This document can not be deleted right now as it's being modified by another user. Please try again after some time."
 msgstr ""
 
@@ -26037,7 +26441,7 @@ msgid ""
 "eval:doc.age&gt;18"
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:498
+#: frappe/core/doctype/file/file.py:510
 msgid "This file is attached to a protected document and cannot be deleted."
 msgstr ""
 
@@ -26064,7 +26468,7 @@ msgstr ""
 msgid "This goes above the slideshow."
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:2024
+#: frappe/public/js/frappe/views/reports/query_report.js:2061
 msgid "This is a background report. Please set the appropriate filters and then generate a new one."
 msgstr ""
 
@@ -26128,7 +26532,7 @@ msgstr ""
 msgid "This newsletter was scheduled to send on a later date. Are you sure you want to send it now?"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:969
+#: frappe/public/js/frappe/views/reports/query_report.js:970
 msgid "This report contains {0} rows and is too big to display in browser, you can {1} this report instead."
 msgstr ""
 
@@ -26136,7 +26540,7 @@ msgstr ""
 msgid "This report was generated on {0}"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:785
+#: frappe/public/js/frappe/views/reports/query_report.js:786
 msgid "This report was generated {0}."
 msgstr ""
 
@@ -26198,7 +26602,7 @@ msgstr ""
 msgid "This will terminate the job immediately and might be dangerous, are you sure? "
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:1187
+#: frappe/core/doctype/user/user.py:1200
 msgid "Throttled"
 msgstr ""
 
@@ -26271,9 +26675,11 @@ msgstr ""
 
 #. Label of a Select field in DocType 'System Settings'
 #. Label of a Autocomplete field in DocType 'User'
+#. Label of a field in the edit-profile Web Form
 #. Label of a Data field in DocType 'Web Page View'
 #: frappe/core/doctype/system_settings/system_settings.json
 #: frappe/core/doctype/user/user.json
+#: frappe/core/web_form/edit_profile/edit_profile.json
 #: frappe/desk/page/setup_wizard/setup_wizard.js:407
 #: frappe/website/doctype/web_page_view/web_page_view.json
 msgid "Time Zone"
@@ -26545,7 +26951,7 @@ msgstr ""
 msgid "To export this step as JSON, link it in a Onboarding document and save the document."
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:786
+#: frappe/public/js/frappe/views/reports/query_report.js:787
 msgid "To get the updated report, click on {0}."
 msgstr ""
 
@@ -26606,7 +27012,7 @@ msgstr ""
 msgid "Today"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1571
+#: frappe/public/js/frappe/views/reports/report_view.js:1573
 msgid "Toggle Chart"
 msgstr ""
 
@@ -26626,7 +27032,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/ui/page.js:194
 #: frappe/public/js/frappe/ui/page.js:196
-#: frappe/public/js/frappe/views/reports/report_view.js:1575
+#: frappe/public/js/frappe/views/reports/report_view.js:1577
 msgid "Toggle Sidebar"
 msgstr ""
 
@@ -26665,7 +27071,7 @@ msgstr ""
 msgid "Token URI"
 msgstr ""
 
-#: frappe/utils/oauth.py:185
+#: frappe/utils/oauth.py:184
 msgid "Token is missing"
 msgstr ""
 
@@ -26682,7 +27088,7 @@ msgstr ""
 msgid "Too Many Requests"
 msgstr ""
 
-#: frappe/database/database.py:430
+#: frappe/database/database.py:429
 msgid "Too many changes to database in single action."
 msgstr ""
 
@@ -26690,7 +27096,7 @@ msgstr ""
 msgid "Too many queued background jobs ({0}). Please retry after some time."
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:976
+#: frappe/core/doctype/user/user.py:989
 msgid "Too many users signed up recently, so the registration is disabled. Please try back in an hour"
 msgstr ""
 
@@ -26764,10 +27170,10 @@ msgstr ""
 msgid "Topic"
 msgstr ""
 
-#: frappe/desk/query_report.py:534
+#: frappe/desk/query_report.py:574
 #: frappe/public/js/frappe/views/reports/print_grid.html:45
-#: frappe/public/js/frappe/views/reports/query_report.js:1256
-#: frappe/public/js/frappe/views/reports/report_view.js:1552
+#: frappe/public/js/frappe/views/reports/query_report.js:1257
+#: frappe/public/js/frappe/views/reports/report_view.js:1554
 msgid "Total"
 msgstr ""
 
@@ -26827,11 +27233,11 @@ msgstr ""
 msgid "Total:"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1257
+#: frappe/public/js/frappe/views/reports/report_view.js:1259
 msgid "Totals"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1232
+#: frappe/public/js/frappe/views/reports/report_view.js:1234
 msgid "Totals Row"
 msgstr ""
 
@@ -26893,7 +27299,7 @@ msgstr ""
 msgid "Track milestones for any document"
 msgstr ""
 
-#: frappe/public/js/frappe/utils/utils.js:1763
+#: frappe/public/js/frappe/utils/utils.js:1779
 msgid "Tracking URL generated and copied to clipboard"
 msgstr ""
 
@@ -26939,7 +27345,7 @@ msgstr ""
 msgid "Translatable"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:2079
+#: frappe/public/js/frappe/views/reports/query_report.js:2116
 msgid "Translate Data"
 msgstr ""
 
@@ -26950,7 +27356,7 @@ msgstr ""
 msgid "Translate Link Fields"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1657
+#: frappe/public/js/frappe/views/reports/report_view.js:1659
 msgid "Translate values"
 msgstr ""
 
@@ -26970,6 +27376,11 @@ msgstr ""
 
 #: frappe/public/js/frappe/views/translation_manager.js:46
 msgid "Translations"
+msgstr ""
+
+#. Name of a role
+#: frappe/core/doctype/translation/translation.json
+msgid "Translator"
 msgstr ""
 
 #. Option for the 'Email Status' (Select) field in DocType 'Communication'
@@ -27186,7 +27597,7 @@ msgstr ""
 msgid "URL for documentation or help"
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:217
+#: frappe/core/doctype/file/file.py:222
 msgid "URL must start with http:// or https://"
 msgstr ""
 
@@ -27227,7 +27638,7 @@ msgstr ""
 msgid "Unable to update event"
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:462
+#: frappe/core/doctype/file/file.py:474
 msgid "Unable to write file format for {0}"
 msgstr ""
 
@@ -27244,11 +27655,11 @@ msgstr ""
 msgid "Unchanged"
 msgstr ""
 
-#: frappe/public/js/frappe/form/toolbar.js:474
+#: frappe/public/js/frappe/form/toolbar.js:477
 msgid "Undo"
 msgstr ""
 
-#: frappe/public/js/frappe/form/toolbar.js:482
+#: frappe/public/js/frappe/form/toolbar.js:485
 msgid "Undo last action"
 msgstr ""
 
@@ -27288,11 +27699,11 @@ msgstr ""
 msgid "Unknown Column: {0}"
 msgstr ""
 
-#: frappe/utils/data.py:1094
+#: frappe/utils/data.py:1085
 msgid "Unknown Rounding Method: {}"
 msgstr ""
 
-#: frappe/auth.py:309
+#: frappe/auth.py:312
 msgid "Unknown User"
 msgstr ""
 
@@ -27304,7 +27715,7 @@ msgstr ""
 msgid "Unlock Reference Document"
 msgstr ""
 
-#: frappe/public/js/frappe/form/footer/form_timeline.js:621
+#: frappe/public/js/frappe/form/footer/form_timeline.js:622
 #: frappe/website/doctype/blog_post/blog_post.js:36
 #: frappe/website/doctype/web_form/web_form.js:86
 msgid "Unpublish"
@@ -27336,7 +27747,7 @@ msgstr ""
 msgid "Unshared"
 msgstr ""
 
-#: frappe/email/queue.py:66
+#: frappe/email/queue.py:67
 msgid "Unsubscribe"
 msgstr ""
 
@@ -27356,7 +27767,7 @@ msgstr ""
 #: frappe/contacts/doctype/contact/contact.json
 #: frappe/core/doctype/user/user.json
 #: frappe/email/doctype/email_group_member/email_group_member.json
-#: frappe/email/queue.py:122
+#: frappe/email/queue.py:123
 msgid "Unsubscribed"
 msgstr ""
 
@@ -27376,7 +27787,7 @@ msgstr ""
 msgid "Unzipping files..."
 msgstr ""
 
-#: frappe/desk/doctype/event/event.py:263
+#: frappe/desk/doctype/event/event.py:267
 msgid "Upcoming Events for Today"
 msgstr ""
 
@@ -27390,7 +27801,7 @@ msgstr ""
 #: frappe/printing/page/print_format_builder/print_format_builder.js:501
 #: frappe/printing/page/print_format_builder/print_format_builder.js:670
 #: frappe/printing/page/print_format_builder/print_format_builder.js:757
-#: frappe/public/js/frappe/form/grid_row.js:407
+#: frappe/public/js/frappe/form/grid_row.js:424
 #: frappe/public/js/frappe/views/workspace/workspace.js:692
 msgid "Update"
 msgstr ""
@@ -27425,6 +27836,11 @@ msgstr ""
 
 #: frappe/desk/page/setup_wizard/setup_wizard.js:495
 msgid "Update Password"
+msgstr ""
+
+#. Title of the edit-profile Web Form
+#: frappe/core/web_form/edit_profile/edit_profile.json
+msgid "Update Profile"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Document Naming Settings'
@@ -27466,7 +27882,7 @@ msgstr ""
 #: frappe/core/doctype/comment/comment.json
 #: frappe/core/doctype/communication/communication.json
 #: frappe/desk/doctype/desktop_icon/desktop_icon.py:446
-#: frappe/public/js/frappe/web_form/web_form.js:427
+#: frappe/public/js/frappe/web_form/web_form.js:451
 msgid "Updated"
 msgstr ""
 
@@ -27474,7 +27890,7 @@ msgstr ""
 msgid "Updated Successfully"
 msgstr ""
 
-#: frappe/public/js/frappe/desk.js:427
+#: frappe/public/js/frappe/desk.js:429
 msgid "Updated To A New Version 🎉"
 msgstr ""
 
@@ -27487,7 +27903,7 @@ msgstr ""
 msgid "Updates"
 msgstr ""
 
-#: frappe/utils/response.py:320
+#: frappe/utils/response.py:318
 msgid "Updating"
 msgstr ""
 
@@ -27647,11 +28063,7 @@ msgstr ""
 msgid "Use different Email ID"
 msgstr ""
 
-#: frappe/model/db_query.py:426
-msgid "Use of function {0} in field is restricted"
-msgstr ""
-
-#: frappe/model/db_query.py:403
+#: frappe/model/db_query.py:402
 msgid "Use of sub-query or function is restricted"
 msgstr ""
 
@@ -27686,6 +28098,7 @@ msgstr ""
 #. Linked DocType in Role Profile's connections
 #. Name of a DocType
 #. Label of a Link field in DocType 'User Group Member'
+#. Label of a Link field in DocType 'User Invitation'
 #. Label of a Link field in DocType 'User Permission'
 #. Label of a Link in the Users Workspace
 #. Label of a shortcut in the Users Workspace
@@ -27715,6 +28128,7 @@ msgstr ""
 #: frappe/core/doctype/role_profile/role_profile.json
 #: frappe/core/doctype/user/user.json
 #: frappe/core/doctype/user_group_member/user_group_member.json
+#: frappe/core/doctype/user_invitation/user_invitation.json
 #: frappe/core/doctype/user_permission/user_permission.json
 #: frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.js:8
 #: frappe/core/workspace/users/users.json
@@ -27773,7 +28187,7 @@ msgstr ""
 msgid "User Cannot Search"
 msgstr ""
 
-#: frappe/public/js/frappe/desk.js:535
+#: frappe/public/js/frappe/desk.js:539
 msgid "User Changed"
 msgstr ""
 
@@ -27860,6 +28274,11 @@ msgstr ""
 msgid "User Image"
 msgstr ""
 
+#. Name of a DocType
+#: frappe/core/doctype/user_invitation/user_invitation.json
+msgid "User Invitation"
+msgstr ""
+
 #: frappe/public/js/frappe/ui/toolbar/navbar.html:115
 msgid "User Menu"
 msgstr ""
@@ -27879,8 +28298,8 @@ msgstr ""
 #. Label of a Link in the Users Workspace
 #: frappe/core/page/permission_manager/permission_manager_help.html:30
 #: frappe/core/workspace/users/users.json
-#: frappe/public/js/frappe/views/reports/query_report.js:1813
-#: frappe/public/js/frappe/views/reports/report_view.js:1752
+#: frappe/public/js/frappe/views/reports/query_report.js:1850
+#: frappe/public/js/frappe/views/reports/report_view.js:1761
 msgid "User Permissions"
 msgstr ""
 
@@ -27902,7 +28321,9 @@ msgstr ""
 msgid "User Profile"
 msgstr ""
 
+#. Name of a DocType
 #. Label of a Link field in DocType 'LDAP Group Mapping'
+#: frappe/core/doctype/user_role/user_role.json
 #: frappe/integrations/doctype/ldap_group_mapping/ldap_group_mapping.json
 msgid "User Role"
 msgstr ""
@@ -27967,6 +28388,10 @@ msgstr ""
 msgid "User does not have permission to create the new {0}"
 msgstr ""
 
+#: frappe/core/doctype/user_invitation/user_invitation.py:102
+msgid "User is disabled"
+msgstr ""
+
 #: frappe/core/doctype/docshare/docshare.py:55
 msgid "User is mandatory for Share"
 msgstr ""
@@ -27976,7 +28401,7 @@ msgstr ""
 msgid "User must always select"
 msgstr ""
 
-#: frappe/model/delete_doc.py:246
+#: frappe/model/delete_doc.py:247
 msgid "User not allowed to delete {0}: {1}"
 msgstr ""
 
@@ -27984,7 +28409,7 @@ msgstr ""
 msgid "User permission already exists"
 msgstr ""
 
-#: frappe/www/login.py:169
+#: frappe/www/login.py:171
 msgid "User with email address {0} does not exist"
 msgstr ""
 
@@ -27992,15 +28417,15 @@ msgstr ""
 msgid "User with email: {0} does not exist in the system. Please ask 'System Administrator' to create the user for you."
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:479
+#: frappe/core/doctype/user/user.py:480
 msgid "User {0} cannot be deleted"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:270
+#: frappe/core/doctype/user/user.py:271
 msgid "User {0} cannot be disabled"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:559
+#: frappe/core/doctype/user/user.py:567
 msgid "User {0} cannot be renamed"
 msgstr ""
 
@@ -28021,15 +28446,15 @@ msgstr ""
 msgid "User {0} has requested for data deletion"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:1321
+#: frappe/core/doctype/user/user.py:1334
 msgid "User {0} impersonated as {1}"
 msgstr ""
 
-#: frappe/utils/oauth.py:270
+#: frappe/utils/oauth.py:269
 msgid "User {0} is disabled"
 msgstr ""
 
-#: frappe/sessions.py:240
+#: frappe/sessions.py:241
 msgid "User {0} is disabled. Please contact your System Manager."
 msgstr ""
 
@@ -28046,11 +28471,11 @@ msgstr ""
 #. Label of a Data field in DocType 'User Social Login'
 #: frappe/core/doctype/user/user.json
 #: frappe/core/doctype/user_social_login/user_social_login.json
-#: frappe/www/login.py:108
+#: frappe/www/login.py:110
 msgid "Username"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:638
+#: frappe/core/doctype/user/user.py:649
 msgid "Username {0} already exists"
 msgstr ""
 
@@ -28121,7 +28546,7 @@ msgstr ""
 msgid "Validate Field"
 msgstr ""
 
-#: frappe/public/js/frappe/web_form/web_form.js:360
+#: frappe/public/js/frappe/web_form/web_form.js:384
 msgid "Validation Error"
 msgstr ""
 
@@ -28180,7 +28605,7 @@ msgstr ""
 msgid "Value To Be Set"
 msgstr ""
 
-#: frappe/model/base_document.py:971 frappe/model/document.py:714
+#: frappe/model/base_document.py:974 frappe/model/document.py:714
 msgid "Value cannot be changed for {0}"
 msgstr ""
 
@@ -28196,7 +28621,7 @@ msgstr ""
 msgid "Value for a check field can be either 0 or 1"
 msgstr ""
 
-#: frappe/custom/doctype/customize_form/customize_form.py:609
+#: frappe/custom/doctype/customize_form/customize_form.py:616
 msgid "Value for field {0} is too long in {1}. Length should be lesser than {2} characters"
 msgstr ""
 
@@ -28223,7 +28648,7 @@ msgstr ""
 msgid "Value to Validate"
 msgstr ""
 
-#: frappe/model/base_document.py:1041
+#: frappe/model/base_document.py:1044
 msgid "Value too big"
 msgstr ""
 
@@ -28231,7 +28656,7 @@ msgstr ""
 msgid "Value {0} missing for {1}"
 msgstr ""
 
-#: frappe/core/doctype/data_import/importer.py:751 frappe/utils/data.py:713
+#: frappe/core/doctype/data_import/importer.py:751 frappe/utils/data.py:706
 msgid "Value {0} must be in the valid duration format: d h m s"
 msgstr ""
 
@@ -28239,7 +28664,7 @@ msgstr ""
 msgid "Value {0} must in {1} format"
 msgstr ""
 
-#: frappe/core/doctype/version/version_view.html:8
+#: frappe/core/doctype/version/version_view.html:9
 msgid "Values Changed"
 msgstr ""
 
@@ -28326,7 +28751,7 @@ msgstr ""
 msgid "View Full Log"
 msgstr ""
 
-#: frappe/public/js/frappe/views/treeview.js:450
+#: frappe/public/js/frappe/views/treeview.js:452
 #: frappe/public/js/frappe/widgets/quick_list_widget.js:252
 msgid "View List"
 msgstr ""
@@ -28336,7 +28761,7 @@ msgstr ""
 msgid "View Log"
 msgstr ""
 
-#: frappe/core/doctype/user/user.js:149
+#: frappe/core/doctype/user/user.js:154
 #: frappe/core/doctype/user_permission/user_permission.js:24
 msgid "View Permitted Documents"
 msgstr ""
@@ -28386,7 +28811,7 @@ msgstr ""
 msgid "View this in your browser"
 msgstr ""
 
-#: frappe/public/js/frappe/web_form/web_form.js:454
+#: frappe/public/js/frappe/web_form/web_form.js:478
 msgctxt "Button in web form"
 msgid "View your response"
 msgstr ""
@@ -28485,7 +28910,7 @@ msgstr ""
 msgid "Watch Video"
 msgstr ""
 
-#: frappe/desk/doctype/workspace/workspace.js:38
+#: frappe/desk/doctype/workspace/workspace.js:36
 msgid "We do not allow editing of this document. Simply click the Edit button on the workspace page to make your workspace editable and customize it as you wish"
 msgstr ""
 
@@ -28547,7 +28972,7 @@ msgstr ""
 msgid "Web Page Block"
 msgstr ""
 
-#: frappe/public/js/frappe/utils/utils.js:1716
+#: frappe/public/js/frappe/utils/utils.js:1732
 msgid "Web Page URL"
 msgstr ""
 
@@ -28870,11 +29295,11 @@ msgstr ""
 msgid "Welcome Workspace"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:357
+#: frappe/core/doctype/user/user.py:358
 msgid "Welcome email sent"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:418
+#: frappe/core/doctype/user/user.py:419
 msgid "Welcome to {0}"
 msgstr ""
 
@@ -28960,7 +29385,7 @@ msgstr ""
 msgid "Will run scheduled jobs only once a day for inactive sites. Set it to 0 to avoid automatically disabling the scheduler."
 msgstr ""
 
-#: frappe/public/js/frappe/form/print_utils.js:15
+#: frappe/public/js/frappe/form/print_utils.js:45
 msgid "With Letter head"
 msgstr ""
 
@@ -29112,7 +29537,7 @@ msgstr ""
 msgid "Workspace"
 msgstr ""
 
-#: frappe/public/js/frappe/router.js:200
+#: frappe/public/js/frappe/router.js:196
 msgid "Workspace <b>{0}</b> does not exist"
 msgstr ""
 
@@ -29173,11 +29598,11 @@ msgstr ""
 msgid "Workspaces"
 msgstr ""
 
-#: frappe/public/js/frappe/form/footer/form_timeline.js:738
+#: frappe/public/js/frappe/form/footer/form_timeline.js:739
 msgid "Would you like to publish this comment? This means it will become visible to website/portal users."
 msgstr ""
 
-#: frappe/public/js/frappe/form/footer/form_timeline.js:742
+#: frappe/public/js/frappe/form/footer/form_timeline.js:743
 msgid "Would you like to unpublish this comment? This means it will no longer be visible to website/portal users."
 msgstr ""
 
@@ -29200,7 +29625,7 @@ msgstr ""
 msgid "Wrong Fetch From value"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:491
+#: frappe/public/js/frappe/views/reports/report_view.js:496
 msgid "X Axis Field"
 msgstr ""
 
@@ -29219,13 +29644,13 @@ msgstr ""
 msgid "Y Axis"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:498
+#: frappe/public/js/frappe/views/reports/report_view.js:503
 msgid "Y Axis Fields"
 msgstr ""
 
 #. Label of a Select field in DocType 'Dashboard Chart Field'
 #: frappe/desk/doctype/dashboard_chart_field/dashboard_chart_field.json
-#: frappe/public/js/frappe/views/reports/query_report.js:1157
+#: frappe/public/js/frappe/views/reports/query_report.js:1158
 msgid "Y Field"
 msgstr ""
 
@@ -29284,7 +29709,7 @@ msgstr ""
 #: frappe/public/js/form_builder/utils.js:336
 #: frappe/public/js/frappe/form/controls/link.js:504
 #: frappe/public/js/frappe/list/list_sidebar_group_by.js:223
-#: frappe/public/js/frappe/views/reports/query_report.js:1545
+#: frappe/public/js/frappe/views/reports/query_report.js:1572
 #: frappe/website/doctype/help_article/templates/help_article.html:25
 msgid "Yes"
 msgstr ""
@@ -29350,20 +29775,20 @@ msgstr ""
 
 #: frappe/core/doctype/data_import/exporter.py:121
 #: frappe/core/doctype/data_import/exporter.py:125
-#: frappe/desk/reportview.py:387 frappe/desk/reportview.py:390
+#: frappe/desk/reportview.py:418 frappe/desk/reportview.py:421
 #: frappe/permissions.py:615
 msgid "You are not allowed to export {} doctype"
 msgstr ""
 
-#: frappe/public/js/frappe/views/treeview.js:414
+#: frappe/public/js/frappe/views/treeview.js:416
 msgid "You are not allowed to print this report"
 msgstr ""
 
-#: frappe/public/js/frappe/views/communication.js:772
+#: frappe/public/js/frappe/views/communication.js:775
 msgid "You are not allowed to send emails related to this document"
 msgstr ""
 
-#: frappe/website/doctype/web_form/web_form.py:567
+#: frappe/website/doctype/web_form/web_form.py:595
 msgid "You are not allowed to update this Web Form Document"
 msgstr ""
 
@@ -29387,7 +29812,7 @@ msgstr ""
 msgid "You are now following this document. You will receive daily updates via email. You can change this in User Settings."
 msgstr ""
 
-#: frappe/core/doctype/installed_applications/installed_applications.py:82
+#: frappe/core/doctype/installed_applications/installed_applications.py:117
 msgid "You are only allowed to update order, do not remove or add apps."
 msgstr ""
 
@@ -29420,6 +29845,10 @@ msgstr ""
 msgid "You can also copy-paste this {0} to your browser"
 msgstr ""
 
+#: frappe/templates/emails/user_invitation_expired.html:8
+msgid "You can ask your team to resend the invitation if you'd still like to join."
+msgstr ""
+
 #: frappe/core/page/permission_manager/permission_manager_help.html:17
 msgid "You can change Submitted documents by cancelling them and then, amending them."
 msgstr ""
@@ -29432,11 +29861,11 @@ msgstr ""
 msgid "You can continue with the onboarding after exploring this page"
 msgstr ""
 
-#: frappe/model/delete_doc.py:136
+#: frappe/model/delete_doc.py:137
 msgid "You can disable this {0} instead of deleting it."
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:728
+#: frappe/core/doctype/file/file.py:740
 msgid "You can increase the limit from System Settings."
 msgstr ""
 
@@ -29456,7 +29885,7 @@ msgstr ""
 msgid "You can only set the 3 custom doctypes in the Document Types table."
 msgstr ""
 
-#: frappe/handler.py:228
+#: frappe/handler.py:229
 msgid "You can only upload JPG, PNG, PDF, TXT, CSV or Microsoft documents."
 msgstr ""
 
@@ -29474,7 +29903,7 @@ msgstr ""
 msgid "You can set a high value here if multiple users will be logging in from the same network."
 msgstr ""
 
-#: frappe/desk/query_report.py:344
+#: frappe/desk/query_report.py:380
 msgid "You can try changing the filters of your report."
 msgstr ""
 
@@ -29486,11 +29915,11 @@ msgstr ""
 msgid "You can use wildcard %"
 msgstr ""
 
-#: frappe/custom/doctype/customize_form/customize_form.py:387
+#: frappe/custom/doctype/customize_form/customize_form.py:394
 msgid "You can't set 'Options' for field {0}"
 msgstr ""
 
-#: frappe/custom/doctype/customize_form/customize_form.py:391
+#: frappe/custom/doctype/customize_form/customize_form.py:398
 msgid "You can't set 'Translatable' for field {0}"
 msgstr ""
 
@@ -29512,7 +29941,7 @@ msgstr ""
 msgid "You cannot give review points to yourself"
 msgstr ""
 
-#: frappe/custom/doctype/customize_form/customize_form.py:383
+#: frappe/custom/doctype/customize_form/customize_form.py:390
 msgid "You cannot unset 'Read Only' for field {0}"
 msgstr ""
 
@@ -29555,7 +29984,7 @@ msgstr ""
 msgid "You do not have enough permissions to access this resource. Please contact your manager to get access."
 msgstr ""
 
-#: frappe/app.py:359
+#: frappe/app.py:357
 msgid "You do not have enough permissions to complete the action"
 msgstr ""
 
@@ -29568,7 +29997,7 @@ msgstr ""
 msgid "You do not have enough review points"
 msgstr ""
 
-#: frappe/desk/query_report.py:860
+#: frappe/desk/query_report.py:900
 msgid "You do not have permission to access {0}: {1}."
 msgstr ""
 
@@ -29580,11 +30009,11 @@ msgstr ""
 msgid "You don't have access to Report: {0}"
 msgstr ""
 
-#: frappe/website/doctype/web_form/web_form.py:770
+#: frappe/website/doctype/web_form/web_form.py:798
 msgid "You don't have permission to access the {0} DocType."
 msgstr ""
 
-#: frappe/utils/response.py:273 frappe/utils/response.py:277
+#: frappe/utils/response.py:272 frappe/utils/response.py:276
 msgid "You don't have permission to access this file"
 msgstr ""
 
@@ -29592,7 +30021,7 @@ msgstr ""
 msgid "You don't have permission to get a report on: {0}"
 msgstr ""
 
-#: frappe/website/doctype/web_form/web_form.py:173
+#: frappe/website/doctype/web_form/web_form.py:176
 msgid "You don't have the permissions to access this document"
 msgstr ""
 
@@ -29608,11 +30037,11 @@ msgstr ""
 msgid "You have a new message from: "
 msgstr ""
 
-#: frappe/handler.py:122
+#: frappe/handler.py:123
 msgid "You have been successfully logged out"
 msgstr ""
 
-#: frappe/custom/doctype/customize_form/customize_form.py:242
+#: frappe/custom/doctype/customize_form/customize_form.py:247
 msgid "You have hit the row size limit on database table: {0}"
 msgstr ""
 
@@ -29636,7 +30065,7 @@ msgstr ""
 msgid "You have unseen notifications"
 msgstr ""
 
-#: frappe/core/doctype/log_settings/log_settings.py:126
+#: frappe/core/doctype/log_settings/log_settings.py:125
 msgid "You have unseen {0}"
 msgstr ""
 
@@ -29644,7 +30073,7 @@ msgstr ""
 msgid "You haven't added any Dashboard Charts or Number Cards yet."
 msgstr ""
 
-#: frappe/public/js/frappe/list/list_view.js:503
+#: frappe/public/js/frappe/list/list_view.js:505
 msgid "You haven't created a {0} yet"
 msgstr ""
 
@@ -29661,11 +30090,11 @@ msgstr ""
 msgid "You must add atleast one link."
 msgstr ""
 
-#: frappe/website/doctype/web_form/web_form.py:766
+#: frappe/website/doctype/web_form/web_form.py:794
 msgid "You must be logged in to use this form."
 msgstr ""
 
-#: frappe/website/doctype/web_form/web_form.py:607
+#: frappe/website/doctype/web_form/web_form.py:635
 msgid "You must login to submit this form"
 msgstr ""
 
@@ -29685,7 +30114,7 @@ msgstr ""
 msgid "You need to be in developer mode to edit a Standard Web Form"
 msgstr ""
 
-#: frappe/utils/response.py:262
+#: frappe/utils/response.py:261
 msgid "You need to be logged in and have System Manager Role to be able to access backups."
 msgstr ""
 
@@ -29693,7 +30122,7 @@ msgstr ""
 msgid "You need to be logged in to access this page"
 msgstr ""
 
-#: frappe/website/doctype/web_form/web_form.py:162
+#: frappe/website/doctype/web_form/web_form.py:165
 msgid "You need to be logged in to access this {0}."
 msgstr ""
 
@@ -29768,7 +30197,15 @@ msgstr ""
 msgid "You viewed this"
 msgstr ""
 
-#: frappe/public/js/frappe/desk.js:532
+#: frappe/core/doctype/user_invitation/user_invitation.py:113
+msgid "You've been invited to join {0}"
+msgstr ""
+
+#: frappe/templates/emails/user_invitation.html:5
+msgid "You've been invited to join {0}."
+msgstr ""
+
+#: frappe/public/js/frappe/desk.js:536
 msgid "You've logged in as another user from another tab. Refresh this page to continue using system."
 msgstr ""
 
@@ -29801,7 +30238,7 @@ msgstr ""
 msgid "Your account has been deleted"
 msgstr ""
 
-#: frappe/auth.py:505
+#: frappe/auth.py:508
 msgid "Your account has been locked and will resume after {0} seconds"
 msgstr ""
 
@@ -29825,8 +30262,20 @@ msgstr ""
 msgid "Your email address"
 msgstr ""
 
-#: frappe/public/js/frappe/web_form/web_form.js:428
+#: frappe/desk/utils.py:87
+msgid "Your exported report: {0}"
+msgstr ""
+
+#: frappe/public/js/frappe/web_form/web_form.js:452
 msgid "Your form has been successfully updated"
+msgstr ""
+
+#: frappe/templates/emails/user_invitation_cancelled.html:5
+msgid "Your invitation to join {0} has been cancelled by the site administrator."
+msgstr ""
+
+#: frappe/templates/emails/user_invitation_expired.html:5
+msgid "Your invitation to join {0} has expired."
 msgstr ""
 
 #: frappe/templates/emails/new_user.html:6
@@ -29851,7 +30300,11 @@ msgstr ""
 msgid "Your query has been received. We will reply back shortly. If you have any additional information, please reply to this mail."
 msgstr ""
 
-#: frappe/app.py:350
+#: frappe/desk/query_report.py:341 frappe/desk/reportview.py:370
+msgid "Your report is being generated in the background. You will receive an email on {0} with a download link once it is ready."
+msgstr ""
+
+#: frappe/app.py:348
 msgid "Your session has expired, please login again to continue."
 msgstr ""
 
@@ -29868,7 +30321,7 @@ msgstr ""
 msgid "Your website is all set up!"
 msgstr ""
 
-#: frappe/utils/data.py:1394
+#: frappe/utils/data.py:1385
 msgid "Zero"
 msgstr ""
 
@@ -29892,7 +30345,7 @@ msgstr ""
 msgid "_report"
 msgstr ""
 
-#: frappe/database/database.py:320
+#: frappe/database/database.py:319
 msgid "`as_iterator` only works with `as_list=True` or `as_dict=True`"
 msgstr ""
 
@@ -29940,7 +30393,7 @@ msgstr ""
 msgid "amend"
 msgstr ""
 
-#: frappe/public/js/frappe/utils/utils.js:406 frappe/utils/data.py:1402
+#: frappe/public/js/frappe/utils/utils.js:406 frappe/utils/data.py:1393
 msgid "and"
 msgstr ""
 
@@ -30134,7 +30587,7 @@ msgstr ""
 msgid "cyan"
 msgstr ""
 
-#: frappe/public/js/frappe/utils/utils.js:1124
+#: frappe/public/js/frappe/utils/utils.js:1127
 msgctxt "Days (Field: Duration)"
 msgid "d"
 msgstr ""
@@ -30413,7 +30866,7 @@ msgstr ""
 msgid "gzip not found in PATH! This is required to take a backup."
 msgstr ""
 
-#: frappe/public/js/frappe/utils/utils.js:1128
+#: frappe/public/js/frappe/utils/utils.js:1131
 msgctxt "Hours (Field: Duration)"
 msgid "h"
 msgstr ""
@@ -30568,7 +31021,7 @@ msgstr ""
 msgid "long"
 msgstr ""
 
-#: frappe/public/js/frappe/utils/utils.js:1132
+#: frappe/public/js/frappe/utils/utils.js:1135
 msgctxt "Minutes (Field: Duration)"
 msgid "m"
 msgstr ""
@@ -30717,12 +31170,12 @@ msgstr ""
 msgid "on_update_after_submit"
 msgstr ""
 
-#: frappe/utils/data.py:1405
+#: frappe/utils/data.py:1396
 msgid "only."
 msgstr ""
 
 #: frappe/public/js/frappe/utils/utils.js:403 frappe/www/login.html:89
-#: frappe/www/login.py:110
+#: frappe/www/login.py:112
 msgid "or"
 msgstr ""
 
@@ -30919,7 +31372,7 @@ msgstr ""
 msgid "road"
 msgstr ""
 
-#: frappe/public/js/frappe/utils/utils.js:1136
+#: frappe/public/js/frappe/utils/utils.js:1139
 msgctxt "Seconds (Field: Duration)"
 msgid "s"
 msgstr ""
@@ -30981,19 +31434,19 @@ msgstr ""
 msgid "signal"
 msgstr ""
 
-#: frappe/public/js/frappe/widgets/number_card_widget.js:291
+#: frappe/public/js/frappe/widgets/number_card_widget.js:294
 msgid "since last month"
 msgstr ""
 
-#: frappe/public/js/frappe/widgets/number_card_widget.js:290
+#: frappe/public/js/frappe/widgets/number_card_widget.js:293
 msgid "since last week"
 msgstr ""
 
-#: frappe/public/js/frappe/widgets/number_card_widget.js:292
+#: frappe/public/js/frappe/widgets/number_card_widget.js:295
 msgid "since last year"
 msgstr ""
 
-#: frappe/public/js/frappe/widgets/number_card_widget.js:289
+#: frappe/public/js/frappe/widgets/number_card_widget.js:292
 msgid "since yesterday"
 msgstr ""
 
@@ -31173,7 +31626,7 @@ msgstr ""
 msgid "via Assignment Rule"
 msgstr ""
 
-#: frappe/automation/doctype/auto_repeat/auto_repeat.py:242
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:245
 msgid "via Auto Repeat"
 msgstr ""
 
@@ -31307,19 +31760,19 @@ msgstr ""
 msgid "{0} Calendar"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:571
+#: frappe/public/js/frappe/views/reports/report_view.js:576
 msgid "{0} Chart"
 msgstr ""
 
 #: frappe/core/page/dashboard_view/dashboard_view.js:67
 #: frappe/public/js/frappe/ui/toolbar/search_utils.js:347
 #: frappe/public/js/frappe/ui/toolbar/search_utils.js:348
-#: frappe/public/js/frappe/utils/utils.js:940
+#: frappe/public/js/frappe/utils/utils.js:943
 #: frappe/public/js/frappe/views/dashboard/dashboard_view.js:12
 msgid "{0} Dashboard"
 msgstr ""
 
-#: frappe/public/js/frappe/form/grid_row.js:463
+#: frappe/public/js/frappe/form/grid_row.js:480
 #: frappe/public/js/frappe/list/list_settings.js:227
 #: frappe/public/js/frappe/views/kanban/kanban_settings.js:178
 msgid "{0} Fields"
@@ -31339,7 +31792,7 @@ msgstr ""
 
 #: frappe/public/js/frappe/ui/toolbar/search_utils.js:83
 #: frappe/public/js/frappe/ui/toolbar/search_utils.js:84
-#: frappe/public/js/frappe/utils/utils.js:934
+#: frappe/public/js/frappe/utils/utils.js:937
 #: frappe/public/js/frappe/widgets/chart_widget.js:318 frappe/www/list.html:4
 #: frappe/www/list.html:8
 msgid "{0} List"
@@ -31353,7 +31806,7 @@ msgstr ""
 msgid "{0} Map"
 msgstr ""
 
-#: frappe/public/js/frappe/utils/utils.js:937
+#: frappe/public/js/frappe/utils/utils.js:940
 msgid "{0} Modules"
 msgstr ""
 
@@ -31361,18 +31814,18 @@ msgstr ""
 msgid "{0} Name"
 msgstr ""
 
-#: frappe/model/base_document.py:1071
+#: frappe/model/base_document.py:1074
 msgid "{0} Not allowed to change {1} after submission from {2} to {3}"
 msgstr ""
 
 #: frappe/public/js/frappe/ui/toolbar/search_utils.js:95
 #: frappe/public/js/frappe/ui/toolbar/search_utils.js:96
-#: frappe/public/js/frappe/utils/utils.js:931
+#: frappe/public/js/frappe/utils/utils.js:934
 #: frappe/public/js/frappe/widgets/chart_widget.js:326
 msgid "{0} Report"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:888
+#: frappe/public/js/frappe/views/reports/query_report.js:889
 msgid "{0} Reports"
 msgstr ""
 
@@ -31401,7 +31854,7 @@ msgstr ""
 msgid "{0} added"
 msgstr ""
 
-#: frappe/public/js/frappe/form/controls/data.js:203
+#: frappe/public/js/frappe/form/controls/data.js:214
 msgid "{0} already exists. Select another name"
 msgstr ""
 
@@ -31413,7 +31866,7 @@ msgstr ""
 msgid "{0} already unsubscribed for {1} {2}"
 msgstr ""
 
-#: frappe/utils/data.py:1556
+#: frappe/utils/data.py:1547
 msgid "{0} and {1}"
 msgstr ""
 
@@ -31447,7 +31900,7 @@ msgstr ""
 msgid "{0} are currently {1}"
 msgstr ""
 
-#: frappe/printing/doctype/print_format/print_format.py:90
+#: frappe/printing/doctype/print_format/print_format.py:99
 msgid "{0} are required"
 msgstr ""
 
@@ -31464,7 +31917,7 @@ msgctxt "Form timeline"
 msgid "{0} attached {1}"
 msgstr ""
 
-#: frappe/core/doctype/system_settings/system_settings.py:147
+#: frappe/core/doctype/system_settings/system_settings.py:149
 msgid "{0} can not be more than {1}"
 msgstr ""
 
@@ -31571,7 +32024,7 @@ msgstr ""
 msgid "{0} field cannot be set as unique in {1}, as there are non-unique existing values"
 msgstr ""
 
-#: frappe/core/doctype/data_import/importer.py:1024
+#: frappe/core/doctype/data_import/importer.py:1027
 msgid "{0} format could not be determined from the values in this column. Defaulting to {1}."
 msgstr ""
 
@@ -31611,11 +32064,11 @@ msgstr ""
 msgid "{0} has been successfully added to the Email Group."
 msgstr ""
 
-#: frappe/email/queue.py:123
+#: frappe/email/queue.py:124
 msgid "{0} has left the conversation in {1} {2}"
 msgstr ""
 
-#: frappe/__init__.py:2401
+#: frappe/__init__.py:2416
 msgid "{0} has no versions tracked."
 msgstr ""
 
@@ -31623,7 +32076,7 @@ msgstr ""
 msgid "{0} hours ago"
 msgstr ""
 
-#: frappe/website/doctype/web_form/templates/web_form.html:145
+#: frappe/website/doctype/web_form/templates/web_form.html:152
 msgid "{0} if you are not redirected within {1} seconds"
 msgstr ""
 
@@ -31632,11 +32085,11 @@ msgstr ""
 msgid "{0} in row {1} cannot have both URL and child items"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:913
+#: frappe/core/doctype/doctype/doctype.py:915
 msgid "{0} is a mandatory field"
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:542
+#: frappe/core/doctype/file/file.py:554
 msgid "{0} is a not a valid zip file"
 msgstr ""
 
@@ -31644,11 +32097,11 @@ msgstr ""
 msgid "{0} is an invalid Data field."
 msgstr ""
 
-#: frappe/automation/doctype/auto_repeat/auto_repeat.py:154
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:157
 msgid "{0} is an invalid email address in 'Recipients'"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1469
+#: frappe/public/js/frappe/views/reports/report_view.js:1471
 msgid "{0} is between {1} and {2}"
 msgstr ""
 
@@ -31657,27 +32110,27 @@ msgstr ""
 msgid "{0} is currently {1}"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1438
+#: frappe/public/js/frappe/views/reports/report_view.js:1440
 msgid "{0} is equal to {1}"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1458
+#: frappe/public/js/frappe/views/reports/report_view.js:1460
 msgid "{0} is greater than or equal to {1}"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1448
+#: frappe/public/js/frappe/views/reports/report_view.js:1450
 msgid "{0} is greater than {1}"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1463
+#: frappe/public/js/frappe/views/reports/report_view.js:1465
 msgid "{0} is less than or equal to {1}"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1453
+#: frappe/public/js/frappe/views/reports/report_view.js:1455
 msgid "{0} is less than {1}"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1488
+#: frappe/public/js/frappe/views/reports/report_view.js:1490
 msgid "{0} is like {1}"
 msgstr ""
 
@@ -31705,16 +32158,16 @@ msgstr ""
 msgid "{0} is not a valid DocType for Dynamic Link"
 msgstr ""
 
-#: frappe/email/doctype/email_group/email_group.py:131
-#: frappe/utils/__init__.py:188
+#: frappe/email/doctype/email_group/email_group.py:140
+#: frappe/utils/__init__.py:193
 msgid "{0} is not a valid Email Address"
 msgstr ""
 
-#: frappe/utils/__init__.py:156
+#: frappe/utils/__init__.py:161
 msgid "{0} is not a valid Name"
 msgstr ""
 
-#: frappe/utils/__init__.py:136
+#: frappe/utils/__init__.py:141
 msgid "{0} is not a valid Phone Number"
 msgstr ""
 
@@ -31734,46 +32187,51 @@ msgstr ""
 msgid "{0} is not a valid report format. Report format should one of the following {1}"
 msgstr ""
 
-#: frappe/core/doctype/file/file.py:522
+#: frappe/core/doctype/file/file.py:534
 msgid "{0} is not a zip file"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1443
+#: frappe/core/doctype/user_invitation/user_invitation.py:182
+msgid "{0} is not an allowed role for {1}"
+msgstr ""
+
+#: frappe/public/js/frappe/views/reports/report_view.js:1445
 msgid "{0} is not equal to {1}"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1490
+#: frappe/public/js/frappe/views/reports/report_view.js:1492
 msgid "{0} is not like {1}"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1484
+#: frappe/public/js/frappe/views/reports/report_view.js:1486
 msgid "{0} is not one of {1}"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1494
+#: frappe/public/js/frappe/views/reports/report_view.js:1496
 msgid "{0} is not set"
 msgstr ""
 
-#: frappe/printing/doctype/print_format/print_format.py:165
+#: frappe/printing/doctype/print_format/print_format.py:177
 msgid "{0} is now default print format for {1} doctype"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1477
+#: frappe/public/js/frappe/views/reports/report_view.js:1479
 msgid "{0} is one of {1}"
 msgstr ""
 
 #: frappe/email/doctype/email_account/email_account.py:273
-#: frappe/model/naming.py:202
-#: frappe/printing/doctype/print_format/print_format.py:93
+#: frappe/model/naming.py:210
+#: frappe/printing/doctype/print_format/print_format.py:102
+#: frappe/printing/doctype/print_format/print_format.py:105
 #: frappe/utils/csvutils.py:131
 msgid "{0} is required"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1493
+#: frappe/public/js/frappe/views/reports/report_view.js:1495
 msgid "{0} is set"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/report_view.js:1472
+#: frappe/public/js/frappe/views/reports/report_view.js:1474
 msgid "{0} is within {1}"
 msgstr ""
 
@@ -31781,7 +32239,7 @@ msgstr ""
 msgid "{0} items selected"
 msgstr ""
 
-#: frappe/core/doctype/user/user.py:1330
+#: frappe/core/doctype/user/user.py:1343
 msgid "{0} just impersonated as you. They gave this reason: {1}"
 msgstr ""
 
@@ -31814,23 +32272,23 @@ msgstr ""
 msgid "{0} months ago"
 msgstr ""
 
-#: frappe/model/document.py:1636
+#: frappe/model/document.py:1640
 msgid "{0} must be after {1}"
 msgstr ""
 
-#: frappe/model/document.py:1401
+#: frappe/model/document.py:1405
 msgid "{0} must be beginning with '{1}'"
 msgstr ""
 
-#: frappe/model/document.py:1403
+#: frappe/model/document.py:1407
 msgid "{0} must be equal to '{1}'"
 msgstr ""
 
-#: frappe/model/document.py:1399
+#: frappe/model/document.py:1403
 msgid "{0} must be none of {1}"
 msgstr ""
 
-#: frappe/model/document.py:1397 frappe/utils/csvutils.py:136
+#: frappe/model/document.py:1401 frappe/utils/csvutils.py:136
 msgid "{0} must be one of {1}"
 msgstr ""
 
@@ -31842,7 +32300,7 @@ msgstr ""
 msgid "{0} must be unique"
 msgstr ""
 
-#: frappe/model/document.py:1405
+#: frappe/model/document.py:1409
 msgid "{0} must be {1} {2}"
 msgstr ""
 
@@ -31865,11 +32323,11 @@ msgid "{0} not found"
 msgstr ""
 
 #: frappe/core/doctype/report/report.py:424
-#: frappe/public/js/frappe/list/list_view.js:1017
+#: frappe/public/js/frappe/list/list_view.js:1019
 msgid "{0} of {1}"
 msgstr ""
 
-#: frappe/public/js/frappe/list/list_view.js:1019
+#: frappe/public/js/frappe/list/list_view.js:1021
 msgid "{0} of {1} ({2} rows with children)"
 msgstr ""
 
@@ -31877,7 +32335,7 @@ msgstr ""
 msgid "{0} of {1} sent"
 msgstr ""
 
-#: frappe/utils/data.py:1552
+#: frappe/utils/data.py:1543
 msgid "{0} or {1}"
 msgstr ""
 
@@ -31929,11 +32387,11 @@ msgstr ""
 msgid "{0} role does not have permission on any doctype"
 msgstr ""
 
-#: frappe/model/document.py:1629
+#: frappe/model/document.py:1633
 msgid "{0} row #{1}: "
 msgstr ""
 
-#: frappe/desk/query_report.py:613
+#: frappe/desk/query_report.py:653
 msgid "{0} saved successfully"
 msgstr ""
 
@@ -31953,11 +32411,11 @@ msgstr ""
 msgid "{0} shared this document with {1}"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:320
+#: frappe/core/doctype/doctype/doctype.py:322
 msgid "{0} should be indexed because it's referred in dashboard connections"
 msgstr ""
 
-#: frappe/automation/doctype/auto_repeat/auto_repeat.py:141
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:144
 msgid "{0} should not be same as {1}"
 msgstr ""
 
@@ -31970,18 +32428,18 @@ msgctxt "Form timeline"
 msgid "{0} submitted this document {1}"
 msgstr ""
 
-#: frappe/email/doctype/email_group/email_group.py:62
-#: frappe/email/doctype/email_group/email_group.py:133
+#: frappe/email/doctype/email_group/email_group.py:71
+#: frappe/email/doctype/email_group/email_group.py:142
 msgid "{0} subscribers added"
 msgstr ""
 
-#: frappe/email/queue.py:68
+#: frappe/email/queue.py:69
 msgid "{0} to stop receiving emails of this type"
 msgstr ""
 
 #: frappe/public/js/frappe/form/controls/date_range.js:48
 #: frappe/public/js/frappe/form/controls/date_range.js:64
-#: frappe/public/js/frappe/form/formatters.js:234
+#: frappe/public/js/frappe/form/formatters.js:238
 msgid "{0} to {1}"
 msgstr ""
 
@@ -31989,7 +32447,7 @@ msgstr ""
 msgid "{0} un-shared this document with {1}"
 msgstr ""
 
-#: frappe/custom/doctype/customize_form/customize_form.py:251
+#: frappe/custom/doctype/customize_form/customize_form.py:256
 msgid "{0} updated"
 msgstr ""
 
@@ -32033,7 +32491,7 @@ msgstr ""
 msgid "{0} {1} cannot be \"{2}\". It should be one of \"{3}\""
 msgstr ""
 
-#: frappe/utils/nestedset.py:344
+#: frappe/utils/nestedset.py:357
 msgid "{0} {1} cannot be a leaf node as it has children"
 msgstr ""
 
@@ -32049,11 +32507,11 @@ msgstr ""
 msgid "{0} {1} not found"
 msgstr ""
 
-#: frappe/model/delete_doc.py:253
+#: frappe/model/delete_doc.py:254
 msgid "{0} {1}: Submitted Record cannot be deleted. You must {2} Cancel {3} it first."
 msgstr ""
 
-#: frappe/model/base_document.py:1032
+#: frappe/model/base_document.py:1035
 msgid "{0}, Row {1}"
 msgstr ""
 
@@ -32061,39 +32519,39 @@ msgstr ""
 msgid "{0}/{1} complete | Please leave this tab open until completion."
 msgstr ""
 
-#: frappe/model/base_document.py:1037
+#: frappe/model/base_document.py:1040
 msgid "{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1765
+#: frappe/core/doctype/doctype/doctype.py:1778
 msgid "{0}: Cannot set Amend without Cancel"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1783
+#: frappe/core/doctype/doctype/doctype.py:1796
 msgid "{0}: Cannot set Assign Amend if not Submittable"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1781
+#: frappe/core/doctype/doctype/doctype.py:1794
 msgid "{0}: Cannot set Assign Submit if not Submittable"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1760
+#: frappe/core/doctype/doctype/doctype.py:1773
 msgid "{0}: Cannot set Cancel without Submit"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1767
+#: frappe/core/doctype/doctype/doctype.py:1780
 msgid "{0}: Cannot set Import without Create"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1763
+#: frappe/core/doctype/doctype/doctype.py:1776
 msgid "{0}: Cannot set Submit, Cancel, Amend without Write"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1787
+#: frappe/core/doctype/doctype/doctype.py:1800
 msgid "{0}: Cannot set import as {1} is not importable"
 msgstr ""
 
-#: frappe/automation/doctype/auto_repeat/auto_repeat.py:405
+#: frappe/automation/doctype/auto_repeat/auto_repeat.py:408
 msgid "{0}: Failed to attach new recurring document. To enable attaching document in the auto repeat notification email, enable {1} in Print Settings"
 msgstr ""
 
@@ -32117,11 +32575,11 @@ msgstr ""
 msgid "{0}: Fieldtype {1} for {2} cannot be unique"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1720
+#: frappe/core/doctype/doctype/doctype.py:1733
 msgid "{0}: No basic permissions set"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1734
+#: frappe/core/doctype/doctype/doctype.py:1747
 msgid "{0}: Only one rule allowed with the same Role, Level and {1}"
 msgstr ""
 
@@ -32141,7 +32599,7 @@ msgstr ""
 msgid "{0}: Other permission rules may also apply"
 msgstr ""
 
-#: frappe/core/doctype/doctype/doctype.py:1749
+#: frappe/core/doctype/doctype/doctype.py:1762
 msgid "{0}: Permission at level 0 must be set before higher levels are set"
 msgstr ""
 
@@ -32162,7 +32620,7 @@ msgstr ""
 msgid "{0}: {1} is set to state {2}"
 msgstr ""
 
-#: frappe/public/js/frappe/views/reports/query_report.js:1215
+#: frappe/public/js/frappe/views/reports/query_report.js:1216
 msgid "{0}: {1} vs {2}"
 msgstr ""
 
@@ -32199,11 +32657,11 @@ msgstr ""
 msgid "{} Complete"
 msgstr ""
 
-#: frappe/utils/data.py:2222
+#: frappe/utils/data.py:2241
 msgid "{} Invalid python code on line {}"
 msgstr ""
 
-#: frappe/utils/data.py:2231
+#: frappe/utils/data.py:2250
 msgid "{} Possibly invalid python code. <br>{}"
 msgstr ""
 
@@ -32212,7 +32670,7 @@ msgstr ""
 msgid "{} Published"
 msgstr ""
 
-#: frappe/core/doctype/log_settings/log_settings.py:55
+#: frappe/core/doctype/log_settings/log_settings.py:54
 msgid "{} does not support automated log clearing."
 msgstr ""
 
@@ -32230,7 +32688,7 @@ msgstr ""
 msgid "{} is not a valid date string."
 msgstr ""
 
-#: frappe/commands/utils.py:528
+#: frappe/commands/utils.py:527
 msgid "{} not found in PATH! This is required to access the console."
 msgstr ""
 

--- a/frappe/middlewares.py
+++ b/frappe/middlewares.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import os
+from pathlib import Path
 
 from werkzeug.exceptions import NotFound
 from werkzeug.middleware.shared_data import SharedDataMiddleware
@@ -18,11 +18,12 @@ class StaticDataMiddleware(SharedDataMiddleware):
 	def get_directory_loader(self, directory):
 		def loader(path):
 			site = get_site_name(frappe.app._site or self.environ.get("HTTP_HOST"))
-			path = os.path.join(directory, site, "public", "files", cstr(path))
-			if os.path.isfile(path):
-				return os.path.basename(path), self._opener(path)
-			else:
+			files_path = Path(directory) / site / "public" / "files"
+			requested_path = Path(cstr(path))
+			path = (files_path / requested_path).resolve()
+			if not path.is_relative_to(files_path) or not path.is_file():
 				raise NotFound
-				# return None, None
+
+			return path.name, self._opener(path)
 
 		return loader

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -1226,13 +1226,18 @@ from {tables}
 		if ORDER_GROUP_PATTERN.match(_lower):
 			frappe.throw(_("Illegal SQL Query"))
 
+		# NEW: strip backticked identifiers so words inside table/field names
+		# (e.g. `tabTrade Union`) don't trigger 'union' / 'select ... from' checks
+		sanitized = re.sub(r"`[^`]*`", "", _lower)
+
 		subquery_indicators = {
 			r"union",
 			r"intersect",
 			r"select\b.*\bfrom",
 		}
 
-		if any(re.search(r"\b" + pattern + r"\b", _lower) for pattern in subquery_indicators):
+		# run the subquery checks against the sanitized string
+		if any(re.search(r"\b" + pattern + r"\b", sanitized) for pattern in subquery_indicators):
 			frappe.throw(_("Cannot use sub-query here."))
 
 		blacklisted_sql_functions = {

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -7,6 +7,11 @@ import datetime
 import json
 import re
 from collections import Counter
+from functools import lru_cache
+
+import sqlparse
+from sqlparse import tokens
+from sqlparse.sql import Function, Parenthesis, Statement
 
 import frappe
 import frappe.defaults
@@ -30,6 +35,22 @@ from frappe.utils import (
 	make_filter_tuple,
 )
 from frappe.utils.data import DateTimeLikeObject, get_datetime, getdate, sbool
+
+
+@lru_cache(maxsize=128)
+def _parse_sql(field: str) -> Statement | None:
+	"""
+	Parse a given SQL statement using `sqlparse`.
+
+	Args:
+		field (str): The SQL statement string to parse.
+
+	Returns:
+		Statement | None: A `sqlparse.sql.Statement` object if parsing succeeds, otherwise `None`.
+	"""
+	if parsed := sqlparse.parse(field):
+		return parsed[0]
+
 
 LOCATE_PATTERN = re.compile(r"locate\([^,]+,\s*[`\"]?name[`\"]?\s*\)", flags=re.IGNORECASE)
 LOCATE_CAST_PATTERN = re.compile(r"locate\(([^,]+),\s*([`\"]?name[`\"]?)\s*\)", flags=re.IGNORECASE)
@@ -434,6 +455,46 @@ from {tables}
 			"sleep",
 		]
 
+		def _find_subqueries(parsed: Statement) -> list:
+			"""
+			Recursively find all subqueries in a parsed SQL statement.
+			"""
+			subqueries = []
+
+			for token in parsed.tokens:
+				if isinstance(token, Parenthesis):
+					# Check for DML token for subquery check
+					is_subquery = False
+					for sub_token in token.tokens:
+						if sub_token.ttype is tokens.DML:
+							is_subquery = True
+							break
+					if is_subquery:
+						subqueries.append(token)
+					# Recursively check for nested subqueries
+					subqueries.extend(_find_subqueries(token))
+				elif token.is_group:
+					subqueries.extend(_find_subqueries(token))
+
+			return subqueries
+
+		def _check_sql_token(statement: Statement) -> None:
+			"""
+			Checks the output of `sqlparse.parse()` to detect blocked functions and subqueries.
+			"""
+			if _find_subqueries(statement):
+				_raise_exception()
+
+			for token in statement.tokens:
+				if isinstance(token, Function):
+					if (name := (token.get_name())) and name.lower() in blacklisted_functions:
+						_raise_exception()
+				if token.ttype == tokens.Keyword:
+					if token.value.lower() in blacklisted_keywords:
+						_raise_exception()
+				if token.is_group:
+					_check_sql_token(token)
+
 		def _raise_exception():
 			frappe.throw(_("Use of sub-query or function is restricted"), frappe.DataError)
 
@@ -448,21 +509,8 @@ from {tables}
 			lower_field = field.lower().strip()
 
 			if SUB_QUERY_PATTERN.match(field):
-				# Check for subquery anywhere in the field, not just at the beginning
-				if "(" in lower_field:
-					# Check all parentheses pairs, not just the first one
-					paren_start = 0
-					while True:
-						location = lower_field.find("(", paren_start)
-						if location == -1:
-							break
-						token = lower_field[location + 1 :].lstrip().split(" ", 1)[0]
-						if any(
-							re.search(r"\b" + re.escape(keyword) + r"\b", token)
-							for keyword in blacklisted_keywords + blacklisted_functions
-						):
-							_raise_exception()
-						paren_start = location + 1
+				# Check all tokens for subquery detection
+				_check_sql_token(_parse_sql(field))
 
 				if "@" in lower_field:
 					# prevent access to global variables

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -1226,17 +1226,17 @@ from {tables}
 		if ORDER_GROUP_PATTERN.match(_lower):
 			frappe.throw(_("Illegal SQL Query"))
 
-		# NEW: strip backticked identifiers so words inside table/field names
-		# (e.g. `tabTrade Union`) don't trigger 'union' / 'select ... from' checks
-		sanitized = re.sub(r"`[^`]*`", "", _lower)
-
 		subquery_indicators = {
 			r"union",
 			r"intersect",
 			r"select\b.*\bfrom",
 		}
 
-		# run the subquery checks against the sanitized string
+		# Replace doctype names with a hardcoded string "doc"
+		# This is to avoid false positives based on doctype name
+		sanitized = re.sub(r"`tab[^`]*`", " doc ", _lower)
+
+		# Run the subquery checks against the sanitized string
 		if any(re.search(r"\b" + pattern + r"\b", sanitized) for pattern in subquery_indicators):
 			frappe.throw(_("Cannot use sub-query here."))
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1517,10 +1517,14 @@ class Document(BaseDocument):
 
 			return view_log
 
-	def log_error(self, title=None, message=None):
+	def log_error(self, title=None, message=None, *, defer_insert=False):
 		"""Helper function to create an Error Log"""
 		return frappe.log_error(
-			message=message, title=title, reference_doctype=self.doctype, reference_name=self.name
+			message=message,
+			title=title,
+			reference_doctype=self.doctype,
+			reference_name=self.name,
+			defer_insert=defer_insert,
 		)
 
 	def get_signature(self):

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -131,7 +131,7 @@ class NamingSeries:
 
 	def get_current_value(self) -> int:
 		prefix = self.get_prefix()
-		return cint(frappe.db.get_value("Series", prefix, "current", order_by="name"))
+		return cint(frappe.db.get_value("Series", prefix, "current", order_by="name", for_update=True))
 
 
 def set_new_name(doc):

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -215,7 +215,7 @@ def rename_doc(
 		new_doc.add_comment("Edit", _("renamed from {0} to {1}").format(frappe.bold(old), frappe.bold(new)))
 
 	if merge:
-		frappe.delete_doc(doctype, old)
+		frappe.delete_doc(doctype, old, ignore_permissions=ignore_permissions)
 
 	new_doc.clear_cache()
 	frappe.clear_cache()

--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -7,10 +7,11 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 	make_input() {
 		if (this.$input) return;
 
-		let { html_element, input_type } = this.constructor;
+		let { html_element, input_type, input_mode } = this.constructor;
 
 		this.$input = $("<" + html_element + ">")
 			.attr("type", input_type)
+			.attr("inputmode", input_mode)
 			.attr("autocomplete", "off")
 			.addClass("input-with-feedback form-control")
 			.prependTo(this.input_area);

--- a/frappe/public/js/frappe/form/controls/int.js
+++ b/frappe/public/js/frappe/form/controls/int.js
@@ -1,5 +1,6 @@
 frappe.ui.form.ControlInt = class ControlInt extends frappe.ui.form.ControlData {
 	static trigger_change_on_input_event = false;
+	static input_mode = "numeric";
 	make() {
 		super.make();
 	}

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -743,6 +743,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					"Float",
 					"Int",
 					"Date",
+					"Datetime",
 					"Select",
 					"Duration",
 					"Time",

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -509,10 +509,16 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 				filter[3].push("...");
 			}
 
-			let value =
-				filter[3] == null || filter[3] === "" ? __("empty") : String(__(filter[3]));
+			let value;
+			if (filter[3] && Array.isArray(filter[3])) {
+				value = filter[3].map((v) => String(__(v)).bold()).join(", ");
+			} else if (filter[3] == null || filter[3] === "") {
+				value = __("empty").bold();
+			} else {
+				value = String(__(filter[3])).bold();
+			}
 
-			return [__(label).bold(), __(filter[2]), value.bold()].join(" ");
+			return [__(label).bold(), __(filter[2]), value].join(" ");
 		}
 
 		let filter_string = filter_array.map(get_filter_description).join(", ");

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -447,7 +447,9 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			if (newArr.length === 0) return [currElem];
 			let element_with_same_value = newArr.find((e) => e.value === currElem.value);
 			if (element_with_same_value) {
-				element_with_same_value.description += `, ${currElem.description}`;
+				if (currElem.description) {
+					element_with_same_value.description += `, ${currElem.description}`;
+				}
 				return [...newArr];
 			}
 			return [...newArr, currElem];

--- a/frappe/public/js/frappe/form/controls/multicheck.js
+++ b/frappe/public/js/frappe/form/controls/multicheck.js
@@ -21,6 +21,7 @@ frappe.ui.form.ControlMultiCheck = class ControlMultiCheck extends frappe.ui.for
 		const columns = this.df.columns;
 		this.$checkbox_area = $('<div class="checkbox-options"></div>').appendTo(this.wrapper);
 		this.$checkbox_area.get(0).style.setProperty("--checkbox-options-columns", columns);
+		this.$checkbox_area.get(0).style.setProperty("padding", "1em");
 	}
 
 	refresh() {
@@ -154,8 +155,8 @@ frappe.ui.form.ControlMultiCheck = class ControlMultiCheck extends frappe.ui.for
 	get_checkbox_element(option) {
 		return $(`
 			<div class="checkbox unit-checkbox">
-				<label title="${option.description || ""}">
-					<input type="checkbox" data-unit="${option.value}"></input>
+				<label title="${option.description || ""}" style="display: flex; align-items: center;">
+					<input type="checkbox" data-unit="${option.value}" style="flex-shrink: 0;">
 					<span class="label-area" data-unit="${option.value}">${option.label}</span>
 				</label>
 			</div>

--- a/frappe/public/js/frappe/form/controls/multiselect_list.js
+++ b/frappe/public/js/frappe/form/controls/multiselect_list.js
@@ -244,6 +244,22 @@ frappe.ui.form.ControlMultiSelectList = class ControlMultiSelectList extends (
 		this.$list_wrapper.find(".selectable-items").html(html);
 
 		this.highlighted = -1;
+		this.adjust_dropdown_right_position();
+	}
+
+	adjust_dropdown_right_position() {
+		const $dropdown = $(this.$list_wrapper).find("ul.dropdown-menu");
+
+		const dropdownEl = $dropdown[0];
+		const parentEl = dropdownEl.parentElement;
+
+		const dropdownRect = dropdownEl.getBoundingClientRect();
+		const parentRect = parentEl.getBoundingClientRect();
+		const rightDiff = parentRect.right - dropdownRect.right;
+
+		setTimeout(() => {
+			dropdownEl.style.left = `${rightDiff}px`;
+		}, 10);
 	}
 
 	get_value() {

--- a/frappe/public/js/frappe/form/controls/multiselect_list.js
+++ b/frappe/public/js/frappe/form/controls/multiselect_list.js
@@ -250,15 +250,15 @@ frappe.ui.form.ControlMultiSelectList = class ControlMultiSelectList extends (
 	adjust_dropdown_right_position() {
 		const $dropdown = $(this.$list_wrapper).find("ul.dropdown-menu");
 
-		const dropdownEl = $dropdown[0];
-		const parentEl = dropdownEl.parentElement;
+		const dropdown_el = $dropdown[0];
+		const parent_el = dropdown_el.parentElement;
 
-		const dropdownRect = dropdownEl.getBoundingClientRect();
-		const parentRect = parentEl.getBoundingClientRect();
-		const rightDiff = parentRect.right - dropdownRect.right;
+		const dropdown_rect = dropdown_el.getBoundingClientRect();
+		const parent_rect = parent_el.getBoundingClientRect();
+		const right_diff = parent_rect.right - dropdown_rect.right;
 
 		setTimeout(() => {
-			dropdownEl.style.left = `${rightDiff}px`;
+			dropdown_el.style.left = `${right_diff}px`;
 		}, 10);
 	}
 

--- a/frappe/public/js/frappe/form/controls/multiselect_list.js
+++ b/frappe/public/js/frappe/form/controls/multiselect_list.js
@@ -252,8 +252,13 @@ frappe.ui.form.ControlMultiSelectList = class ControlMultiSelectList extends (
 
 		const dropdown_el = $dropdown[0];
 		const parent_el = dropdown_el.parentElement;
-
 		const dropdown_rect = dropdown_el.getBoundingClientRect();
+
+		const page_left_position =
+			parent_el?.parentElement?.parentElement?.getBoundingClientRect()?.left;
+
+		if (page_left_position && dropdown_rect.left - page_left_position <= 100) return;
+
 		const parent_rect = parent_el.getBoundingClientRect();
 		const right_diff = parent_rect.right - dropdown_rect.right;
 

--- a/frappe/public/js/frappe/form/controls/table.js
+++ b/frappe/public/js/frappe/form/controls/table.js
@@ -16,21 +16,6 @@ frappe.ui.form.ControlTable = class ControlTable extends frappe.ui.form.Control 
 			this.frm.grids[this.frm.grids.length] = this;
 		}
 		const me = this;
-		this.$wrapper.on("keydown", (e) => {
-			if (e.which == 9) {
-				if (e.shiftKey) {
-					let row_idx = me.set_current_row(e.target);
-					if (row_idx) {
-						this.grid.grid_rows[row_idx - 1].toggle_editable_row(true);
-					}
-				} else {
-					if (this.grid.grid_rows.length > 0)
-						this.grid.grid_rows[this.grid.grid_rows.length - 1].toggle_editable_row(
-							true
-						);
-				}
-			}
-		});
 		this.$wrapper.on("paste", ":text", (e) => {
 			const table_field = this.df.fieldname;
 			const grid = this.grid;
@@ -168,14 +153,5 @@ frappe.ui.form.ControlTable = class ControlTable extends frappe.ui.form.Control 
 	}
 	check_all_rows() {
 		this.$wrapper.find(".grid-row-check")[0].click();
-	}
-	set_current_row(target) {
-		let current_row = null;
-		for (let i = 0; i < this.grid.grid_rows.length; i++) {
-			if (this.grid.grid_rows[i].wrapper.get(0).contains(target)) {
-				current_row = i + 1;
-			}
-		}
-		return current_row;
 	}
 };

--- a/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
+++ b/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
@@ -226,15 +226,28 @@ function get_version_timeline_content(version_doc, frm) {
 				return p;
 			});
 			if (parts.length) {
-				let message = "";
+				let messages = [];
 
-				if (key === "added") {
-					message = __("added rows for {0}", [parts.join(", ")]);
-				} else if (key === "removed") {
-					message = __("removed rows for {0}", [parts.join(", ")]);
+				const count_map = parts.reduce((acc, item) => {
+					acc[item] = (acc[item] || 0) + 1;
+					return acc;
+				}, {});
+
+				for (const item in count_map) {
+					messages.push(
+						__("{0} row{1} {2} {3}", [
+							count_map[item],
+							count_map[item] > 1 ? "s" : "",
+							key === "added" ? "to" : "from",
+							item,
+						])
+					);
 				}
 
-				let version_comment = get_version_comment(version_doc, message);
+				let version_comment = get_version_comment(
+					version_doc,
+					key + " " + messages.join(", ")
+				);
 				let user_link = get_user_link(version_doc.owner);
 				out.push(`${user_link} ${version_comment}`);
 			}

--- a/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
+++ b/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
@@ -228,28 +228,108 @@ function get_version_timeline_content(version_doc, frm) {
 			if (parts.length) {
 				let messages = [];
 
-				const count_map = parts.reduce((acc, item) => {
+				const countMap = parts.reduce((acc, item) => {
 					acc[item] = (acc[item] || 0) + 1;
 					return acc;
 				}, {});
 
-				for (const item in count_map) {
-					messages.push(
-						__("{0} row{1} {2} {3}", [
-							count_map[item],
-							count_map[item] > 1 ? "s" : "",
-							key === "added" ? "to" : "from",
-							item,
-						])
-					);
+				let isFirst = true;
+				for (const [table_name, count] of Object.entries(countMap)) {
+					if (key === "added") {
+						if (count > 1) {
+							if (isFirst) {
+								messages.push(
+									get_user_message(
+										version_doc.owner,
+										__("You added {0} rows to {1}", [count, table_name]),
+										__("{0} added {1} rows to {2}", [
+											get_user_link(version_doc.owner),
+											count,
+											table_name,
+										])
+									)
+								);
+							} else {
+								messages.push(
+									__(
+										"{0} rows to {1}",
+										[count, table_name],
+										"User added rows to child table"
+									)
+								);
+							}
+						} else {
+							if (isFirst) {
+								messages.push(
+									get_user_message(
+										version_doc.owner,
+										__("You added 1 row to {0}", [table_name]),
+										__("{0} added 1 row to {1}", [
+											get_user_link(version_doc.owner),
+											table_name,
+										])
+									)
+								);
+							} else {
+								messages.push(
+									__(
+										"1 row to {0}",
+										[table_name],
+										"User added row to child table"
+									)
+								);
+							}
+						}
+					} else {
+						if (count > 1) {
+							if (isFirst) {
+								messages.push(
+									get_user_message(
+										version_doc.owner,
+										__("You removed {0} rows from {1}", [count, table_name]),
+										__("{0} removed {1} rows from {2}", [
+											get_user_link(version_doc.owner),
+											count,
+											table_name,
+										])
+									)
+								);
+							} else {
+								messages.push(
+									__(
+										"{0} rows from {1}",
+										[count, table_name],
+										"User removed rows from child table"
+									)
+								);
+							}
+						} else {
+							if (isFirst) {
+								messages.push(
+									get_user_message(
+										version_doc.owner,
+										__("You removed 1 row from {0}", [table_name]),
+										__("{0} removed 1 row from {1}", [
+											get_user_link(version_doc.owner),
+											table_name,
+										])
+									)
+								);
+							} else {
+								messages.push(
+									__(
+										"1 row from {0}",
+										[table_name],
+										"User removed row from child table"
+									)
+								);
+							}
+						}
+					}
+					isFirst = false;
 				}
 
-				let version_comment = get_version_comment(
-					version_doc,
-					key + " " + messages.join(", ")
-				);
-				let user_link = get_user_link(version_doc.owner);
-				out.push(`${user_link} ${version_comment}`);
+				out.push(get_version_comment(version_doc, frappe.utils.comma_and(messages)));
 			}
 		}
 	});

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -95,7 +95,7 @@ frappe.form.formatters = {
 			docfield.precision ||
 			cint(frappe.boot.sysdefaults && frappe.boot.sysdefaults.float_precision) ||
 			2;
-		return frappe.form.formatters._right(flt(value, precision) + "%", options);
+		return frappe.form.formatters._right(format_number(value, null, precision) + "%", options);
 	},
 	Rating: function (value, docfield) {
 		let rating_html = "";

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -909,6 +909,7 @@ export default class Grid {
 		}
 
 		setTimeout(() => {
+			this.grid_rows[idx].toggle_editable_row(true);
 			this.grid_rows[idx].row
 				.find('input[type="checkbox"],input[type="Text"],textarea,select')
 				.filter(":visible:first")
@@ -1246,5 +1247,15 @@ export default class Grid {
 		}
 
 		this.debounced_refresh();
+	}
+
+	get_current_row(target) {
+		let current_row = null;
+		for (let i = 0; i < this.grid_rows.length; i++) {
+			if (this.grid_rows[i].wrapper.get(0).contains(target)) {
+				current_row = i;
+			}
+		}
+		return current_row;
 	}
 }

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1419,7 +1419,10 @@ export default class GridRow {
 			this.grid_form.wrapper.css("display", "none");
 		}
 		this.wrapper.removeClass("grid-row-open");
-		this.open_form_button.parent().focus();
+
+		if (this.grid.meta.editable_grid) {
+			this.open_form_button.parent().focus();
+		}
 	}
 	open_prev() {
 		if (!this.doc) return;

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1420,8 +1420,8 @@ export default class GridRow {
 		}
 		this.wrapper.removeClass("grid-row-open");
 
-		if (this.grid.meta.editable_grid) {
-			this.open_form_button.parent().focus();
+		if (this.grid.meta?.editable_grid) {
+			this.open_form_button?.parent().focus();
 		}
 	}
 	open_prev() {

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1249,7 +1249,28 @@ export default class GridRow {
 				};
 
 				// TAB
-				if (e.which === UP_ARROW) {
+				if (e.which === TAB && !e.shiftKey) {
+					var last_column = me.wrapper.find("input:enabled:last").get(0);
+					var is_last_column = $(this).attr("data-last-input") || last_column === this;
+
+					if (is_last_column) {
+						// last row
+						if (me.doc.idx === values.length) {
+							setTimeout(function () {
+								me.grid.add_new_row(null, null, true);
+								me.grid.grid_rows[
+									me.grid.grid_rows.length - 1
+								].toggle_editable_row();
+								me.grid.set_focus_on_row();
+							}, 100);
+						} else {
+							// last column before last row
+							me.grid.grid_rows[me.doc.idx].toggle_editable_row();
+							me.grid.set_focus_on_row(me.doc.idx);
+							return false;
+						}
+					}
+				} else if (e.which === UP_ARROW) {
 					if (me.doc.idx > 1) {
 						var prev = me.grid.grid_rows[me.doc.idx - 2];
 						if (move_up_down(prev)) {

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1089,7 +1089,17 @@ export default class GridRow {
 
 		this.columns[df.fieldname] = $col;
 		this.columns_list.push($col);
-
+		if (ci == 0 && !this.header_row) {
+			$col.attr("tabIndex", 0);
+			$col.on("focus", function () {
+				if (me.grid.grid_rows.length == 0) {
+					me.grid.add_new_row();
+				}
+				me.grid.grid_rows[me.grid.grid_rows.length - 1].toggle_editable_row(true);
+				me.grid.set_focus_on_row();
+				$col.attr("tabIndex", "");
+			});
+		}
 		return $col;
 	}
 
@@ -1187,6 +1197,8 @@ export default class GridRow {
 			// flag list input
 			if (this.columns_list && this.columns_list.slice(-1)[0] === column) {
 				field.$input.attr("data-last-input", 1);
+			} else if (this.columns_list && this.columns_list.slice(0)[0] === column) {
+				field.$input.attr("data-first-input", 1);
 			}
 		}
 
@@ -1250,6 +1262,18 @@ export default class GridRow {
 						if (move_up_down(next)) {
 							return false;
 						}
+					}
+				} else if (e.which === TAB && e.shiftKey) {
+					var first_column = me.wrapper
+						.find("input:enabled:not([type='checkbox'])")
+						.first()
+						.get(0);
+					var is_first_column =
+						$(this).attr("data-first-input") || first_column === this;
+					if (is_first_column) {
+						let ri = me.grid.get_current_row(e.target);
+						if (ri == 0) return;
+						me.grid.grid_rows[ri - 1].toggle_editable_row(true);
 					}
 				}
 			});

--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -18,7 +18,7 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 	var save = function () {
 
 		$(frm.wrapper).addClass("validated-form");
-		if ((action !== "Save" || frm.is_dirty()) && check_mandatory()) {
+		if ((action !== "Save" || frm.is_dirty()) && frappe.ui.form.check_mandatory(frm)) {
 			_call({
 				method: "frappe.desk.form.save.savedocs",
 				args: { doc: frm.doc, action: action },
@@ -64,116 +64,6 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 			btn: btn,
 			freeze_message: freeze_message,
 		});
-	};
-
-	var check_mandatory = function () {
-		var has_errors = false;
-		frm.scroll_set = false;
-
-		if (frm.doc.docstatus == 2) return true; // don't check for cancel
-
-		$.each(frappe.model.get_all_docs(frm.doc), function (i, doc) {
-			var error_fields = [];
-			var folded = false;
-
-			$.each(frappe.meta.docfield_list[doc.doctype] || [], function (i, docfield) {
-				if (docfield.fieldname) {
-					const df = frappe.meta.get_docfield(doc.doctype, docfield.fieldname, doc.name);
-
-					if (df.fieldtype === "Fold") {
-						folded = frm.layout.folded;
-					}
-
-					if (
-						is_docfield_mandatory(doc, df) &&
-						!frappe.model.has_value(doc.doctype, doc.name, df.fieldname)
-					) {
-						has_errors = true;
-						error_fields[error_fields.length] = __(df.label, null, df.parent);
-						// scroll to field
-						if (!frm.scroll_set) {
-							scroll_to(doc.parentfield || df.fieldname);
-						}
-
-						if (folded) {
-							frm.layout.unfold();
-							folded = false;
-						}
-					}
-				}
-			});
-
-			if (frm.is_new() && frm.meta.autoname === "Prompt" && !frm.doc.__newname) {
-				has_errors = true;
-				error_fields = [__("Name"), ...error_fields];
-			}
-
-			if (error_fields.length) {
-				let meta = frappe.get_meta(doc.doctype);
-				let message;
-				if (meta.istable) {
-					const table_field = frappe.meta.docfield_map[doc.parenttype][doc.parentfield];
-
-					const table_label = __(
-						table_field.label || frappe.unscrub(table_field.fieldname)
-					).bold();
-
-					message = __("Mandatory fields required in table {0}, Row {1}", [
-						table_label,
-						doc.idx,
-					]);
-				} else {
-					message = __("Mandatory fields required in {0}", [__(doc.doctype)]);
-				}
-				message = message + "<br><br><ul><li>" + error_fields.join("</li><li>") + "</ul>";
-				frappe.msgprint({
-					message: message,
-					indicator: "red",
-					title: __("Missing Fields"),
-				});
-				frm.refresh();
-			}
-		});
-
-		return !has_errors;
-	};
-
-	let is_docfield_mandatory = function (doc, df) {
-		if (df.reqd) return true;
-		if (!df.mandatory_depends_on || !doc) return;
-
-		let out = null;
-		let expression = df.mandatory_depends_on;
-		let parent = frappe.get_meta(df.parent);
-
-		if (typeof expression === "boolean") {
-			out = expression;
-		} else if (typeof expression === "function") {
-			out = expression(doc);
-		} else if (expression.substr(0, 5) == "eval:") {
-			try {
-				out = frappe.utils.eval(expression.substr(5), { doc, parent });
-				if (parent && parent.istable && expression.includes("is_submittable")) {
-					out = true;
-				}
-			} catch (e) {
-				frappe.throw(__('Invalid "mandatory_depends_on" expression'));
-			}
-		} else {
-			var value = doc[expression];
-			if ($.isArray(value)) {
-				out = !!value.length;
-			} else {
-				out = !!value;
-			}
-		}
-
-		return out;
-	};
-
-	const scroll_to = (fieldname) => {
-		frm.scroll_to_field(fieldname);
-		frm.scroll_set = true;
 	};
 
 	var _call = function (opts) {
@@ -225,6 +115,116 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 		cancel();
 	} else {
 		save();
+	}
+};
+
+frappe.ui.form.check_mandatory = function (frm) {
+	var has_errors = false;
+	frm.scroll_set = false;
+
+	if (frm.doc.docstatus == 2) return true; // don't check for cancel
+
+	$.each(frappe.model.get_all_docs(frm.doc), function (i, doc) {
+		var error_fields = [];
+		var folded = false;
+
+		$.each(frappe.meta.docfield_list[doc.doctype] || [], function (i, docfield) {
+			if (docfield.fieldname) {
+				const df = frappe.meta.get_docfield(doc.doctype, docfield.fieldname, doc.name);
+
+				if (df.fieldtype === "Fold") {
+					folded = frm.layout.folded;
+				}
+
+				if (
+					is_docfield_mandatory(doc, df) &&
+					!frappe.model.has_value(doc.doctype, doc.name, df.fieldname)
+				) {
+					has_errors = true;
+					error_fields[error_fields.length] = __(df.label, null, df.parent);
+					// scroll to field
+					if (!frm.scroll_set) {
+						scroll_to(doc.parentfield || df.fieldname);
+					}
+
+					if (folded) {
+						frm.layout.unfold();
+						folded = false;
+					}
+				}
+			}
+		});
+
+		if (frm.is_new() && frm.meta.autoname === "Prompt" && !frm.doc.__newname) {
+			has_errors = true;
+			error_fields = [__("Name"), ...error_fields];
+		}
+
+		if (error_fields.length) {
+			let meta = frappe.get_meta(doc.doctype);
+			let message;
+			if (meta.istable) {
+				const table_field = frappe.meta.docfield_map[doc.parenttype][doc.parentfield];
+
+				const table_label = __(
+					table_field.label || frappe.unscrub(table_field.fieldname)
+				).bold();
+
+				message = __("Mandatory fields required in table {0}, Row {1}", [
+					table_label,
+					doc.idx,
+				]);
+			} else {
+				message = __("Mandatory fields required in {0}", [__(doc.doctype)]);
+			}
+			message = message + "<br><br><ul><li>" + error_fields.join("</li><li>") + "</ul>";
+			frappe.msgprint({
+				message: message,
+				indicator: "red",
+				title: __("Missing Fields"),
+			});
+			frm.refresh();
+		}
+	});
+
+	return !has_errors;
+
+	function is_docfield_mandatory(doc, df) {
+		if (df.reqd) return true;
+		if (!df.mandatory_depends_on || !doc) return;
+
+		let out = null;
+		let expression = df.mandatory_depends_on;
+		let parent = frappe.get_meta(df.parent);
+
+		if (typeof expression === "boolean") {
+			out = expression;
+		} else if (typeof expression === "function") {
+			out = expression(doc);
+		} else if (expression.substr(0, 5) == "eval:") {
+			try {
+				out = frappe.utils.eval(expression.substr(5), { doc, parent });
+				if (parent && parent.istable && expression.includes("is_submittable")) {
+					out = true;
+				}
+			} catch (e) {
+				frappe.throw(__('Invalid "mandatory_depends_on" expression'));
+			}
+		} else {
+			var value = doc[expression];
+			if ($.isArray(value)) {
+				out = !!value.length;
+			} else {
+				out = !!value;
+			}
+		}
+
+		return out;
+	}
+
+	function scroll_to(fieldname) {
+		frm.scroll_to_field(fieldname);
+		frm.scroll_set = true;
 	}
 };
 

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -25,7 +25,11 @@ frappe.ui.form.Toolbar = class Toolbar {
 				this.page.hide_menu();
 				this.print_icon && this.print_icon.addClass("hide");
 			} else {
-				this.page.show_menu();
+				if (this.page.menu.children().length > 0) {
+					this.page.show_menu();
+				} else {
+					this.page.hide_menu();
+				}
 				this.print_icon && this.print_icon.removeClass("hide");
 			}
 		}

--- a/frappe/public/js/frappe/form/workflow.js
+++ b/frappe/public/js/frappe/form/workflow.js
@@ -98,6 +98,7 @@ frappe.ui.form.States = class FormStates {
 
 		frappe.workflow.get_transitions(this.frm.doc).then((transitions) => {
 			this.frm.page.clear_actions_menu();
+			const frm = this.frm;
 			transitions.forEach((d) => {
 				if (frappe.user_roles.includes(d.allowed) && has_approval_access(d)) {
 					added = true;
@@ -105,6 +106,7 @@ frappe.ui.form.States = class FormStates {
 						// set the workflow_action for use in form scripts
 						frappe.dom.freeze();
 						me.frm.selected_workflow_action = d.action;
+						if (!frappe.ui.form.check_mandatory(frm)) return frappe.dom.unfreeze();
 						me.frm.script_manager.trigger("before_workflow_action").then(() => {
 							frappe
 								.xcall("frappe.model.workflow.apply_workflow", {

--- a/frappe/public/js/frappe/model/perm.js
+++ b/frappe/public/js/frappe/model/perm.js
@@ -60,8 +60,12 @@ $.extend(frappe.perm, {
 			perm[0].read = 1;
 		}
 
-		if (!meta) return perm;
-
+		if (!meta) {
+			if (frappe.boot.user.can_read.includes(doctype)) {
+				perm[0].read = 1;
+			}
+			return perm;
+		}
 		perm = frappe.perm.get_role_permissions(meta);
 		const base_perm = perm[0];
 

--- a/frappe/public/js/frappe/ui/filters/field_select.js
+++ b/frappe/public/js/frappe/ui/filters/field_select.js
@@ -117,6 +117,10 @@ frappe.ui.FieldSelect = class FieldSelect {
 		// main table
 		var main_table_fields = std_filters.concat(frappe.meta.docfield_list[me.doctype]);
 		$.each(frappe.utils.sort(main_table_fields, "label", "string"), function (i, df) {
+			if (df.is_virtual) {
+				return;
+			}
+
 			let doctype =
 				frappe.get_meta(me.doctype).istable && me.parent_doctype
 					? me.parent_doctype
@@ -128,7 +132,7 @@ frappe.ui.FieldSelect = class FieldSelect {
 
 		// child tables
 		$.each(me.table_fields, function (i, table_df) {
-			if (table_df.options) {
+			if (table_df.options && !table_df.is_virtual) {
 				let child_table_fields = [].concat(frappe.meta.docfield_list[table_df.options]);
 
 				if (table_df.fieldtype === "Table MultiSelect") {

--- a/frappe/public/js/frappe/ui/toolbar/about.js
+++ b/frappe/public/js/frappe/ui/toolbar/about.js
@@ -1,71 +1,156 @@
 frappe.provide("frappe.ui.misc");
 frappe.ui.misc.about = function () {
-	if (!frappe.ui.misc.about_dialog) {
-		var d = new frappe.ui.Dialog({ title: __("Frappe Framework") });
-
-		$(d.body).html(
-			repl(
-				`<div>
-					<p>${__("Open Source Applications for the Web")}</p>
-					<p><i class='fa fa-globe fa-fw'></i>
-						${__("Website")}:
-						<a href='https://frappeframework.com' target='_blank'>https://frappeframework.com</a></p>
-					<p><i class='fa fa-github fa-fw'></i>
-						${__("Source")}:
-						<a href='https://github.com/frappe' target='_blank'>https://github.com/frappe</a></p>
-					<p><i class='fa fa-graduation-cap fa-fw'></i>
-						Frappe School: <a href='https://frappe.school' target='_blank'>https://frappe.school</a></p>
-					<p><i class='fa fa-linkedin fa-fw'></i>
-						Linkedin: <a href='https://linkedin.com/company/frappe-tech' target='_blank'>https://linkedin.com/company/frappe-tech</a></p>
-					<p><i class='fa fa-twitter fa-fw'></i>
-						Twitter: <a href='https://twitter.com/frappetech' target='_blank'>https://twitter.com/frappetech</a></p>
-					<p><i class='fa fa-youtube fa-fw'></i>
-						YouTube: <a href='https://www.youtube.com/@frappetech' target='_blank'>https://www.youtube.com/@frappetech</a></p>
-					<hr>
-					<h4>${__("Installed Apps")}</h4>
-					<div id='about-app-versions'>${__("Loading versions...")}</div>
-					<hr>
-					<p class='text-muted'>${__("&copy; Frappe Technologies Pvt. Ltd. and contributors")} </p>
-					</div>`,
-				frappe.app
-			)
-		);
-
-		frappe.ui.misc.about_dialog = d;
-
-		frappe.ui.misc.about_dialog.on_page_show = function () {
-			if (!frappe.versions) {
-				frappe.call({
-					method: "frappe.utils.change_log.get_versions",
-					callback: function (r) {
-						show_versions(r.message);
-					},
-				});
-			} else {
-				show_versions(frappe.versions);
-			}
-		};
-
-		var show_versions = function (versions) {
-			var $wrap = $("#about-app-versions").empty();
-			$.each(Object.keys(versions).sort(), function (i, key) {
-				var v = versions[key];
-				let text;
-				if (v.branch) {
-					text = $.format("<p><b>{0}:</b> v{1} ({2})<br></p>", [
-						v.title,
-						v.branch_version || v.version,
-						v.branch,
-					]);
-				} else {
-					text = $.format("<p><b>{0}:</b> v{1}<br></p>", [v.title, v.version]);
-				}
-				$(text).appendTo($wrap);
-			});
-
-			frappe.versions = versions;
-		};
+	if (frappe.ui.misc.about_dialog) {
+		frappe.ui.misc.about_dialog.show();
+		return;
 	}
+
+	const dialog = new frappe.ui.Dialog({ title: __("Frappe Framework") });
+
+	$(dialog.body).html(
+		`<div>
+				<p>${__("Open Source Applications for the Web")}</p>
+
+				<p>
+					<i class='fa fa-globe fa-fw'></i>
+					${__("Website")}:
+					<a href='https://frappe.io/' target='_blank'>https://frappe.io/</a>
+				</p>
+
+				<p>
+					<i class='fa fa-github fa-fw'></i>
+					${__("Source Code")}:
+					<a href='https://github.com/frappe' target='_blank'>https://github.com/frappe</a>
+				</p>
+
+				<p>
+					<i class='fa fa-file-text fa-fw'></i>
+					${__("Frappe Blog")}:
+					<a href='https://frappe.io/blog' target='_blank'>https://frappe.io/blog</a>
+				</p>
+
+				<p>
+					<i class='fa fa-users fa-fw'></i>
+					${__("Frappe Forum")}:
+					<a href='https://discuss.frappe.io' target='_blank'>https://discuss.frappe.io</a>
+				</p>
+
+				<p>
+					<i class='fa fa-linkedin fa-fw'></i>
+					${__("LinkedIn")}:
+					<a href='https://linkedin.com/company/frappe-tech' target='_blank'>https://linkedin.com/company/frappe-tech</a>
+				</p>
+
+				<p>
+					<svg xmlns="http://www.w3.org/2000/svg" width="18" height="14" fill="currentColor" class="bi bi-twitter-x" viewBox="0 0 18 16">
+						<path d="M12.6.75h2.454l-5.36 6.142L16 15.25h-4.937l-3.867-5.07-4.425 5.07H.316l5.733-6.57L0 .75h5.063l3.495 4.633L12.601.75Zm-.86 13.028h1.36L4.323 2.145H2.865z"/>
+					</svg>
+					X:
+					<a href='https://x.com/frappetech' target='_blank'>https://x.com/frappetech</a>
+				</p>
+
+				<p>
+					<i class='fa fa-youtube-play fa-fw'></i>
+					${__("YouTube")}:
+					<a href='https://www.youtube.com/@frappetech' target='_blank'>https://www.youtube.com/@frappetech</a>
+				</p>
+
+				<p>
+					<i class='fa fa-instagram fa-fw'></i>
+					${__("Instagram")}:
+					<a href='https://www.instagram.com/frappetech' target='_blank'>https://www.instagram.com/frappetech</a>
+				</p>
+
+				<hr>
+
+				<div class="d-flex align-items-center justify-content-between">
+					<h4>${__("Installed Apps")}</h4>
+					<button class="btn action-btn hidden" id="copy-apps-info"
+					title="${__("Copy Apps Version")}"
+					style="margin-bottom: var(--margin-md);">
+						${frappe.utils.icon("clipboard")}
+					</button>
+				</div>
+
+				<div id='about-app-versions'>${__("Loading versions...")}</div>
+				<p>
+					<b>
+						<a href="/attribution" target="_blank" class="text-muted">
+							${__("Dependencies & Licenses")}
+						</a>
+					</b>
+				</p>
+
+				<hr>
+
+				<p class='text-muted'>${__("&copy; Frappe Technologies Pvt. Ltd. and contributors")} </p>
+			</div>`
+	);
+
+	frappe.ui.misc.about_dialog = dialog;
+
+	frappe.ui.misc.about_dialog.on_page_show = function () {
+		if (!frappe.versions) {
+			frappe.call({
+				method: "frappe.utils.change_log.get_versions",
+				callback: function (r) {
+					show_versions(r.message);
+				},
+			});
+		} else {
+			show_versions(frappe.versions);
+		}
+	};
+
+	const show_versions = function (versions) {
+		const $wrap = $("#about-app-versions").empty();
+		let app = {};
+
+		function get_version_text(app) {
+			if (app.branch) {
+				return `v${app.branch_version || app.version} (${app.branch})`;
+			} else {
+				return `v${app.version}`;
+			}
+		}
+
+		for (const app_name in versions) {
+			app = versions[app_name];
+			const title = `${app_name}: ${app.branch_version || app.version}`;
+			const text = `<p class='app-version' role='button' title='${title}'>
+							<b>${app.title}:</b> ${get_version_text(app)}
+						</p>`;
+			$(text).appendTo($wrap);
+		}
+
+		frappe.versions = versions;
+
+		if (frappe.versions) {
+			$(dialog.body).find("#copy-apps-info").removeClass("hidden");
+		}
+	};
+
+	const code_block = (snippet, lang = "") => "```" + lang + "\n" + snippet + "\n```";
+
+	// Listener for copying installed apps info
+	$(dialog.body).on("click", "#copy-apps-info", function () {
+		if (!frappe.versions) return;
+
+		const versions = Object.entries(frappe.versions).reduce((acc, [key, app]) => {
+			acc[key] = app.branch_version || app.version;
+			return acc;
+		}, {});
+
+		frappe.utils.copy_to_clipboard(code_block(JSON.stringify(versions, null, "\t"), "json"));
+	});
+
+	// Listener for copy app version
+	$(dialog.body).on("click", ".app-version", function () {
+		const title = $(this).attr("title");
+		if (title) {
+			frappe.utils.copy_to_clipboard(title);
+		}
+	});
 
 	frappe.ui.misc.about_dialog.show();
 };

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -66,6 +66,7 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			"input",
 			frappe.utils.debounce(function (e) {
 				var value = e.target.value;
+				value = frappe.utils.xss_sanitise(value);
 				var txt = value.trim().replace(/\s\s+/g, " ");
 				var last_space = txt.lastIndexOf(" ");
 				me.global_results = [];

--- a/frappe/public/js/frappe/views/file/file_view.js
+++ b/frappe/public/js/frappe/views/file/file_view.js
@@ -203,6 +203,7 @@ frappe.views.FileView = class FileView extends frappe.views.ListView {
 		}
 
 		let title = d.file_name || d.file_url;
+		title = frappe.utils.escape_html(title);
 		title = title.slice(0, 60);
 		d._title = title;
 		d.icon_class = icon_class;

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -451,7 +451,7 @@ frappe.views.TreeView = class TreeView {
 			{
 				label: __("View List"),
 				action: function () {
-					frappe.set_route("List", me.doctype);
+					frappe.set_route(["List", me.doctype, "List"]);
 				},
 			},
 			{

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -321,7 +321,7 @@ frappe.views.TreeView = class TreeView {
 		var node = me.tree.get_selected_node();
 
 		if (!(node && node.expandable)) {
-			frappe.msgprint(__("Select a group node first."));
+			frappe.msgprint(__("Select a group {0} first.", [__(me.doctype)]));
 			return;
 		}
 
@@ -381,8 +381,10 @@ frappe.views.TreeView = class TreeView {
 			{
 				fieldtype: "Check",
 				fieldname: "is_group",
-				label: __("Group Node"),
-				description: __("Further nodes can be only created under 'Group' type nodes"),
+				label: __("Is Group"),
+				description: __(
+					"Further sub-groups can only be created under records marked as 'Group'"
+				),
 			},
 		];
 

--- a/frappe/public/js/frappe/web_form/web_form_list.js
+++ b/frappe/public/js/frappe/web_form/web_form_list.js
@@ -103,6 +103,7 @@ export default class WebFormList {
 					label: df.label,
 					fieldname: df.fieldname,
 					fieldtype: df.fieldtype,
+					options: df.options,
 				};
 			});
 		}

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -1,7 +1,14 @@
+@mixin grid-focus() {
+	outline: none;
+	border: 1px solid var(--gray-400) !important;
+}
 .form-grid {
 	border: 1px solid var(--table-border-color);
 	border-radius: var(--border-radius-md);
 	color: var(--text-color);
+	&:focus-visible {
+		@include grid-focus();
+	}
 }
 
 .form-grid.error {
@@ -112,6 +119,9 @@
 	}
 }
 
+.grid-static-col:focus-visible {
+	@include grid-focus();
+}
 .grid-static-col,
 .row-index {
 	height: 38px;

--- a/frappe/tests/test_api.py
+++ b/frappe/tests/test_api.py
@@ -137,14 +137,25 @@ class FrappeAPITestCase(FrappeTestCase):
 
 class TestResourceAPI(FrappeAPITestCase):
 	DOCTYPE = "ToDo"
-	GENERATED_DOCUMENTS: typing.ClassVar = []
+	GENERATED_DOCUMENTS: typing.ClassVar[list] = []
+	TEST_USER = "test@restapi.com"
 
 	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()
+		cls.GENERATED_DOCUMENTS = []
+		user = frappe.get_doc(
+			{"doctype": "User", "email": cls.TEST_USER, "first_name": "Test User", "send_welcome_email": 0}
+		).insert(ignore_permissions=True)
+
 		for _ in range(20):
-			doc = frappe.get_doc({"doctype": "ToDo", "description": frappe.mock("paragraph")}).insert()
-			cls.GENERATED_DOCUMENTS = []
+			doc = frappe.get_doc(
+				{
+					"doctype": "ToDo",
+					"description": frappe.mock("paragraph"),
+					"allocated_to": user.name,
+				}
+			).insert()
 			cls.GENERATED_DOCUMENTS.append(doc.name)
 		frappe.db.commit()
 
@@ -153,6 +164,7 @@ class TestResourceAPI(FrappeAPITestCase):
 		frappe.db.commit()
 		for name in cls.GENERATED_DOCUMENTS:
 			frappe.delete_doc_if_exists(cls.DOCTYPE, name)
+		frappe.delete_doc_if_exists("User", cls.TEST_USER)
 		frappe.db.commit()
 
 	def test_unauthorized_call(self):
@@ -166,6 +178,35 @@ class TestResourceAPI(FrappeAPITestCase):
 		self.assertEqual(response.status_code, 200)
 		self.assertIsInstance(response.json, dict)
 		self.assertIn("data", response.json)
+
+	def test_get_list_expand(self):
+		response = self.get(
+			self.resource(self.DOCTYPE),
+			{
+				"sid": self.sid,
+				"filters": json.dumps([["name", "=", self.GENERATED_DOCUMENTS[0]]]),
+				"fields": json.dumps(["allocated_to", "name"]),
+				"expand": json.dumps(["allocated_to"]),
+			},
+		)
+		self.assertEqual(response.status_code, 200)
+		self.assertIsInstance(response.json, dict)
+		self.assertIn("data", response.json)
+		self.assertIn("allocated_to", response.json["data"][0])
+		self.assertIsInstance(response.json["data"][0]["allocated_to"], dict)
+		self.assertIn("name", response.json["data"][0]["allocated_to"])
+
+	def test_get_doc_expand(self):
+		response = self.get(
+			self.resource(self.DOCTYPE, self.GENERATED_DOCUMENTS[0]),
+			{
+				"expand_links": json.dumps(True),
+			},
+		)
+		self.assertEqual(response.status_code, 200)
+		self.assertIsInstance(response.json, dict)
+		self.assertIn("data", response.json)
+		self.assertIsInstance(response.json["data"]["allocated_to"], dict)
 
 	def test_get_list_limit(self):
 		# test 3: fetch data with limit

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -481,6 +481,23 @@ class TestDBQuery(FrappeTestCase):
 		)
 		self.assertTrue("_relevance" in data[0])
 
+		# Test that fields with keywords in strings are allowed
+		data = DatabaseQuery("DocType").execute(
+			fields=["name", "locate('select', name)"],
+			limit_start=0,
+			limit_page_length=1,
+		)
+		self.assertTrue(data)
+
+		# Test that subqueries with other DML are blocked
+		self.assertRaises(
+			frappe.DataError,
+			DatabaseQuery("DocType").execute,
+			fields=["name", "issingle", "(insert into tabUser values (1))"],
+			limit_start=0,
+			limit_page_length=1,
+		)
+
 		data = DatabaseQuery("DocType").execute(
 			fields=["name", "issingle", "date(creation) as creation"],
 			limit_start=0,
@@ -545,6 +562,16 @@ class TestDBQuery(FrappeTestCase):
 				limit_start=0,
 				limit_page_length=1,
 			)
+
+		# Ensure search terms aren't blocked as functions
+		from frappe.desk.search import search_link
+
+		search_terms = ("global", "user")
+
+		for term in search_terms:
+			with self.subTest(term=term):
+				result = search_link("ToDo", term)
+				self.assertIsInstance(result, list)
 
 	def test_nested_permission(self):
 		frappe.set_user("Administrator")

--- a/frappe/tests/test_db_update.py
+++ b/frappe/tests/test_db_update.py
@@ -178,18 +178,16 @@ class TestDBUpdate(FrappeTestCase):
 		self.assertEqual(frappe.db.get_column_type(referring_doctype.name, link), "uuid")
 
 	@run_only_if(db_type_is.MARIADB)
-	def test_row_size(self):
+	def test_varchar_length(self):
 		from frappe.database.schema import add_column
-		from frappe.utils import get_table_name
 
 		test_doc = new_doctype().insert()
-		try:
-			for i in range(400):
-				add_column(test_doc.name, fieldtype="Data", column_name=f"col{i}", length=63)
-		except Exception as e:
-			print(e)
-		finally:
-			frappe.db.sql_ddl(f"drop table `{get_table_name(test_doc.name)}`")
+		col_name = f"col_{frappe.generate_hash(length=4)}"
+		add_column(test_doc.name, fieldtype="Data", column_name=col_name, length=50)
+		length = frappe.db.sql(
+			f"SELECT CHARACTER_MAXIMUM_LENGTH FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'tab{test_doc.name}' AND COLUMN_NAME = '{col_name}' ",
+		)[0][0]
+		self.assertEqual(length, 64)
 
 
 class TestDBUpdateSanityChecks(IntegrationTestCase):

--- a/frappe/tests/test_db_update.py
+++ b/frappe/tests/test_db_update.py
@@ -162,6 +162,7 @@ class TestDBUpdate(FrappeTestCase):
 		)[0][0]
 		self.assertEqual(length, 64)
 
+
 def get_fieldtype_from_def(field_def):
 	fieldtuple = frappe.db.type_map.get(field_def.fieldtype, ("", 0))
 	fieldtype = fieldtuple[0]

--- a/frappe/tests/test_db_update.py
+++ b/frappe/tests/test_db_update.py
@@ -150,33 +150,6 @@ class TestDBUpdate(FrappeTestCase):
 		doctype.delete()
 		frappe.db.commit()
 
-<<<<<<< HEAD
-=======
-	def test_uuid_varchar_migration(self):
-		doctype = new_doctype().insert()
-		doctype.autoname = "UUID"
-		doctype.save()
-		self.assertEqual(frappe.db.get_column_type(doctype.name, "name"), "uuid")
-
-		doc = frappe.new_doc(doctype.name).insert()
-
-		doctype.autoname = "hash"
-		doctype.save()
-		varchar = "varchar" if frappe.db.db_type == "mariadb" else "character varying"
-		self.assertIn(varchar, frappe.db.get_column_type(doctype.name, "name"))
-		doc.reload()  # ensure that docs are still accesible
-
-	def test_uuid_link_field(self):
-		uuid_doctype = new_doctype().update({"autoname": "UUID"}).insert()
-		self.assertEqual(frappe.db.get_column_type(uuid_doctype.name, "name"), "uuid")
-
-		link = "link_field"
-		referring_doctype = new_doctype(
-			fields=[{"fieldname": link, "fieldtype": "Link", "options": uuid_doctype.name}]
-		).insert()
-
-		self.assertEqual(frappe.db.get_column_type(referring_doctype.name, link), "uuid")
-
 	@run_only_if(db_type_is.MARIADB)
 	def test_varchar_length(self):
 		from frappe.database.schema import add_column
@@ -188,27 +161,6 @@ class TestDBUpdate(FrappeTestCase):
 			f"SELECT CHARACTER_MAXIMUM_LENGTH FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'tab{test_doc.name}' AND COLUMN_NAME = '{col_name}' ",
 		)[0][0]
 		self.assertEqual(length, 64)
-
-
-class TestDBUpdateSanityChecks(IntegrationTestCase):
-	@run_only_if(db_type_is.MARIADB)
-	def test_no_unnecessary_migrates(self):
-		doctypes = frappe.get_all("DocType", {"is_virtual": 0, "custom": 0}, pluck="name")
-
-		# Migrating all doctypes takes way too long of a time.
-		# NOTE: This test mostly won't be flaky, if it fails randomly, it is because it tests
-		# randomly.
-		# DO NOT IGNORE FAILURES.
-		random.shuffle(doctypes)
-		doctypes = doctypes[:20]
-
-		for doctype in doctypes:
-			with self.subTest(f"Check {doctype}"):
-				frappe.reload_doctype(doctype, force=True)
-				with self.assertQueryCount(0, query_type=("alter",)):
-					frappe.reload_doctype(doctype, force=True)
-
->>>>>>> 3cb061bacb (fix: add reference and test_case)
 
 def get_fieldtype_from_def(field_def):
 	fieldtuple = frappe.db.type_map.get(field_def.fieldtype, ("", 0))

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -59,6 +59,7 @@ from frappe.utils.data import (
 	duration_to_seconds,
 	evaluate_filters,
 	expand_relative_urls,
+	format_duration,
 	get_datetime,
 	get_first_day_of_week,
 	get_time,
@@ -716,6 +717,24 @@ class TestDateUtils(FrappeTestCase):
 		self.assertEqual(duration_to_seconds("1h"), 3600)
 		self.assertEqual(duration_to_seconds("110m"), 110 * 60)
 		self.assertEqual(duration_to_seconds("110m"), 110 * 60)
+
+	def test_format_duration(self):
+		# Basic positive durations
+		self.assertEqual(format_duration(0), "")
+		self.assertEqual(format_duration(45.7), "45s")
+		self.assertEqual(format_duration(90.9), "1m 30s")
+		self.assertEqual(format_duration(3600), "1h")
+		self.assertEqual(format_duration("12885"), "3h 34m 45s")
+		self.assertEqual(format_duration(86400), "1d")
+		self.assertEqual(format_duration(86401), "1d 1s")
+
+		# Negative durations
+		self.assertEqual(format_duration(-45.3), "-45s")
+		self.assertEqual(format_duration(-12885), "-3h 34m 45s")
+
+		# hide_days parameter
+		self.assertEqual(format_duration(86400, hide_days=True), "24h")
+		self.assertEqual(format_duration(90061, hide_days=True), "25h 1m 1s")
 
 	def test_get_timespan_date_range(self):
 		supported_timespans = [

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -54,6 +54,7 @@ from frappe.utils.data import (
 	add_years,
 	cast,
 	cint,
+	compare,
 	cstr,
 	duration_to_seconds,
 	evaluate_filters,
@@ -221,6 +222,112 @@ class TestFilters(FrappeTestCase):
 			"last_password_reset_date": None,
 		}
 		self.assertFalse(evaluate_filters(doc, [("last_password_reset_date", "Timespan", "today")]))
+
+	def test_is_operator(self):
+		"""Test 'is' operator for checking if values are set or not set."""
+		# Test "is set" with different fieldtypes and values
+		self.assertTrue(compare("1", "is", "set", "Int"))
+		self.assertTrue(compare(1, "is", "set", "Int"))
+		self.assertTrue(compare(0, "is", "set", "Int"))  # 0 is considered "set"
+		self.assertTrue(compare("hello", "is", "set", "Data"))
+		self.assertTrue(compare(0.0, "is", "set", "Float"))
+
+		# Test "is set" with unset values - None should always be "not set" regardless of fieldtype
+		self.assertFalse(compare(None, "is", "set", "Int"))
+		self.assertFalse(compare(None, "is", "set", "Float"))
+		self.assertFalse(compare(None, "is", "set", "Check"))
+		self.assertFalse(compare(None, "is", "set", "Data"))
+		self.assertFalse(compare("", "is", "set"))
+		self.assertFalse(compare("", "is", "set", "Data"))
+		self.assertFalse(compare(None, "is", "set"))
+
+		# Test "is not set" with set values
+		self.assertFalse(compare("1", "is", "not set", "Int"))
+		self.assertFalse(compare(1, "is", "not set", "Int"))
+		self.assertFalse(compare(0, "is", "not set", "Int"))
+		self.assertFalse(compare("hello", "is", "not set", "Data"))
+		self.assertFalse(compare(0.0, "is", "not set", "Float"))
+
+		# Test "is not set" with unset values - None should always be "not set" regardless of fieldtype
+		self.assertTrue(compare(None, "is", "not set", "Int"))
+		self.assertTrue(compare(None, "is", "not set", "Float"))
+		self.assertTrue(compare(None, "is", "not set", "Check"))
+		self.assertTrue(compare(None, "is", "not set", "Data"))
+		self.assertTrue(compare("", "is", "not set"))
+		self.assertTrue(compare("", "is", "not set", "Data"))
+		self.assertTrue(compare(None, "is", "not set"))
+
+	def test_in_operators(self):
+		"""Test 'in' and 'not in' operators with and without fieldtype casting."""
+		test_list = ["a", "b", "c"]
+
+		# Test "in" operator without fieldtype
+		self.assertTrue(compare("a", "in", test_list))
+		self.assertFalse(compare("", "in", test_list))
+		self.assertFalse(compare("d", "in", test_list))
+		self.assertFalse(compare(None, "in", test_list))
+
+		# Test "not in" operator without fieldtype
+		self.assertFalse(compare("a", "not in", test_list))
+		self.assertTrue(compare("", "not in", test_list))
+		self.assertTrue(compare("d", "not in", test_list))
+		self.assertTrue(compare(None, "not in", test_list))
+
+		# Test "in" operator with fieldtype casting - only first value should be cast
+		string_list = ["1", "2", "3"]
+		self.assertTrue(compare(1, "in", string_list, "Data"))
+		self.assertTrue(compare("2", "in", string_list, "Data"))
+		self.assertFalse(compare(4, "in", string_list, "Data"))
+
+		# Test type mismatch: Int fieldtype with string list (val2 is NOT cast)
+		mixed_list = ["1", "2", "3"]
+		self.assertFalse(compare("1", "in", mixed_list, "Int"))
+		self.assertFalse(compare(1, "in", mixed_list, "Int"))
+
+		# Test with matching types: Int fieldtype with int list
+		int_list = [1, 2, 3]
+		self.assertTrue(compare("1", "in", int_list, "Int"))
+		self.assertTrue(compare(2, "in", int_list, "Int"))
+		self.assertFalse(compare("4", "in", int_list, "Int"))
+
+		# Test "not in" operator with fieldtype casting
+		self.assertFalse(compare(1, "not in", string_list, "Data"))
+		self.assertFalse(compare("2", "not in", string_list, "Data"))
+		self.assertTrue(compare(4, "not in", string_list, "Data"))
+
+		# Test "not in" with type mismatch
+		self.assertTrue(compare("1", "not in", mixed_list, "Int"))
+		self.assertFalse(compare("1", "not in", int_list, "Int"))
+
+		# Test with Float fieldtype
+		float_list = [1.5, 2.5, 3.5]
+		self.assertTrue(compare("1.5", "in", float_list, "Float"))
+		self.assertFalse(compare("4.5", "in", float_list, "Float"))
+
+		# Test None with "in"/"not in" operators - None should not be cast
+		self.assertFalse(compare(None, "in", [""], "Data"))
+		self.assertFalse(compare(None, "in", [0], "Int"))
+		self.assertFalse(compare(None, "in", [0.0], "Float"))
+		self.assertFalse(compare(None, "in", ["", "test"], "Data"))
+		self.assertTrue(compare(None, "in", [None, "test"], "Data"))
+
+		# Test "not in" with None
+		self.assertTrue(compare(None, "not in", [""], "Data"))
+		self.assertTrue(compare(None, "not in", [0], "Int"))
+		self.assertTrue(compare(None, "not in", [0.0], "Float"))
+		self.assertTrue(compare(None, "not in", ["", "test"], "Data"))
+		self.assertFalse(compare(None, "not in", [None, "test"], "Data"))
+
+	def test_is_operator_case_insensitive(self):
+		"""Test that 'is' operator patterns are case insensitive."""
+		self.assertTrue(compare("value", "is", "SET"))
+		self.assertTrue(compare("value", "is", "Set"))
+		self.assertTrue(compare("value", "is", "set"))
+
+		self.assertTrue(compare(None, "is", "NOT SET"))
+		self.assertTrue(compare(None, "is", "Not Set"))
+		self.assertTrue(compare(None, "is", "not set"))
+
 
 class TestMoney(FrappeTestCase):
 	def test_money_in_words(self):

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -16,397 +16,378 @@ from frappe.utils.data import convert_utc_to_timezone, get_datetime, get_system_
 
 datetime_like_types = (datetime.datetime, datetime.date, datetime.time, datetime.timedelta)
 
+
 class FrappeTestCase(unittest.TestCase):
-    """Base test class for Frappe tests.
+	"""Base test class for Frappe tests.
 
 
-    If you specify `setUpClass` then make sure to call `super().setUpClass`
-    otherwise this class will become ineffective.
-    """
+	If you specify `setUpClass` then make sure to call `super().setUpClass`
+	otherwise this class will become ineffective.
+	"""
 
-    TEST_SITE = "test_site"
+	TEST_SITE = "test_site"
 
-    SHOW_TRANSACTION_COMMIT_WARNINGS = False
-    maxDiff = 10_000  # prints long diffs but useful in CI
+	SHOW_TRANSACTION_COMMIT_WARNINGS = False
+	maxDiff = 10_000  # prints long diffs but useful in CI
 
-    @classmethod
-    def setUpClass(cls) -> None:
-        cls.TEST_SITE = getattr(frappe.local, "site", None) or cls.TEST_SITE
-        cls.ADMIN_PASSWORD = frappe.get_conf(cls.TEST_SITE).admin_password
-        cls._primary_connection = frappe.local.db
-        cls._secondary_connection = None
-        # flush changes done so far to avoid flake
-        frappe.db.commit()
-        if cls.SHOW_TRANSACTION_COMMIT_WARNINGS:
-            frappe.db.before_commit.add(_commit_watcher)
+	@classmethod
+	def setUpClass(cls) -> None:
+		cls.TEST_SITE = getattr(frappe.local, "site", None) or cls.TEST_SITE
+		cls.ADMIN_PASSWORD = frappe.get_conf(cls.TEST_SITE).admin_password
+		cls._primary_connection = frappe.local.db
+		cls._secondary_connection = None
+		# flush changes done so far to avoid flake
+		frappe.db.commit()
+		if cls.SHOW_TRANSACTION_COMMIT_WARNINGS:
+			frappe.db.before_commit.add(_commit_watcher)
 
-        # enqueue teardown actions (executed in LIFO order)
-        cls.addClassCleanup(_restore_thread_locals, copy.deepcopy(frappe.local.flags))
-        cls.addClassCleanup(_rollback_db)
-        return super().setUpClass()
+		# enqueue teardown actions (executed in LIFO order)
+		cls.addClassCleanup(_restore_thread_locals, copy.deepcopy(frappe.local.flags))
+		cls.addClassCleanup(_rollback_db)
 
-    def assertSequenceSubset(self, larger: Sequence, smaller: Sequence, msg=None):
-        """Assert that `expected` is a subset of `actual`."""
-        self.assertTrue(set(smaller).issubset(set(larger)), msg=msg)
+		return super().setUpClass()
 
-    # --- Frappe Framework specific assertions
-    def assertDocumentEqual(self, expected, actual):
-        """Compare a (partial) expected document with actual Document."""
+	def assertSequenceSubset(self, larger: Sequence, smaller: Sequence, msg=None):
+		"""Assert that `expected` is a subset of `actual`."""
+		self.assertTrue(set(smaller).issubset(set(larger)), msg=msg)
 
-        if isinstance(expected, BaseDocument):
-            expected = expected.as_dict()
+	# --- Frappe Framework specific assertions
+	def assertDocumentEqual(self, expected, actual):
+		"""Compare a (partial) expected document with actual Document."""
 
-        for field, value in expected.items():
-            if isinstance(value, list):
-                actual_child_docs = actual.get(field)
-                self.assertEqual(len(value), len(actual_child_docs), msg=f"{field} length should be same")
-                for exp_child, actual_child in zip(value, actual_child_docs, strict=False):
-                    self.assertDocumentEqual(exp_child, actual_child)
-            else:
-                self._compare_field(value, actual.get(field), actual, field)
+		if isinstance(expected, BaseDocument):
+			expected = expected.as_dict()
 
-    def _compare_field(self, expected, actual, doc: BaseDocument, field: str):
-        msg = f"{field} should be same."
+		for field, value in expected.items():
+			if isinstance(value, list):
+				actual_child_docs = actual.get(field)
+				self.assertEqual(len(value), len(actual_child_docs), msg=f"{field} length should be same")
+				for exp_child, actual_child in zip(value, actual_child_docs, strict=False):
+					self.assertDocumentEqual(exp_child, actual_child)
+			else:
+				self._compare_field(value, actual.get(field), actual, field)
 
-        if isinstance(expected, float):
-            precision = doc.precision(field)
-            self.assertAlmostEqual(
-                expected, actual, places=precision, msg=f"{field} should be same to {precision} digits"
-            )
-        elif isinstance(expected, bool | int):
-            self.assertEqual(expected, cint(actual), msg=msg)
-        elif isinstance(expected, datetime_like_types):
-            self.assertEqual(str(expected), str(actual), msg=msg)
-        else:
-            self.assertEqual(expected, actual, msg=msg)
+	def _compare_field(self, expected, actual, doc: BaseDocument, field: str):
+		msg = f"{field} should be same."
 
-    def normalize_html(self, code: str) -> str:
-        """Formats HTML consistently so simple string comparisons can work on them."""
-        from bs4 import BeautifulSoup
+		if isinstance(expected, float):
+			precision = doc.precision(field)
+			self.assertAlmostEqual(
+				expected, actual, places=precision, msg=f"{field} should be same to {precision} digits"
+			)
+		elif isinstance(expected, bool | int):
+			self.assertEqual(expected, cint(actual), msg=msg)
+		elif isinstance(expected, datetime_like_types):
+			self.assertEqual(str(expected), str(actual), msg=msg)
+		else:
+			self.assertEqual(expected, actual, msg=msg)
 
-        return BeautifulSoup(code, "html.parser").prettify(formatter=None)
+	def normalize_html(self, code: str) -> str:
+		"""Formats HTML consistently so simple string comparisons can work on them."""
+		from bs4 import BeautifulSoup
 
-    def normalize_sql(self, query: str) -> str:
-        """Formats SQL consistently so simple string comparisons can work on them."""
-        import sqlparse
+		return BeautifulSoup(code, "html.parser").prettify(formatter=None)
 
-        return sqlparse.format(query.strip(), keyword_case="upper", reindent=True, strip_comments=True)
+	def normalize_sql(self, query: str) -> str:
+		"""Formats SQL consistently so simple string comparisons can work on them."""
+		import sqlparse
 
-    @contextmanager
-    def primary_connection(self):
-        """Switch to primary DB connection
+		return sqlparse.format(query.strip(), keyword_case="upper", reindent=True, strip_comments=True)
 
-        This is used for simulating multiple users performing actions by simulating two DB connections"""
-        try:
-            current_conn = frappe.local.db
-            frappe.local.db = self._primary_connection
-            yield
-        finally:
-            frappe.local.db = current_conn
+	@contextmanager
+	def primary_connection(self):
+		"""Switch to primary DB connection
 
-    @contextmanager
-    def secondary_connection(self):
-        """Switch to secondary DB connection."""
-        if self._secondary_connection is None:
-            frappe.connect()  # get second connection
-            self._secondary_connection = frappe.local.db
+		This is used for simulating multiple users performing actions by simulating two DB connections"""
+		try:
+			current_conn = frappe.local.db
+			frappe.local.db = self._primary_connection
+			yield
+		finally:
+			frappe.local.db = current_conn
 
-        try:
-            current_conn = frappe.local.db
-            frappe.local.db = self._secondary_connection
-            yield
-        finally:
-            frappe.local.db = current_conn
-            self.addCleanup(self._rollback_connections)
+	@contextmanager
+	def secondary_connection(self):
+		"""Switch to secondary DB connection."""
+		if self._secondary_connection is None:
+			frappe.connect()  # get second connection
+			self._secondary_connection = frappe.local.db
 
-    def _rollback_connections(self):
-        self._primary_connection.rollback()
-        self._secondary_connection.rollback()
+		try:
+			current_conn = frappe.local.db
+			frappe.local.db = self._secondary_connection
+			yield
+		finally:
+			frappe.local.db = current_conn
+			self.addCleanup(self._rollback_connections)
 
-    def assertQueryEqual(self, first: str, second: str):
-        self.assertEqual(self.normalize_sql(first), self.normalize_sql(second))
+	def _rollback_connections(self):
+		self._primary_connection.rollback()
+		self._secondary_connection.rollback()
 
-    @contextmanager
-    def assertQueryCount(self, count):
-        queries = []
+	def assertQueryEqual(self, first: str, second: str):
+		self.assertEqual(self.normalize_sql(first), self.normalize_sql(second))
 
-        def _sql_with_count(*args, **kwargs):
-            ret = orig_sql(*args, **kwargs)
-            queries.append(args[0].last_query)
-            return ret
+	@contextmanager
+	def assertQueryCount(self, count):
+		queries = []
 
-        try:
-            orig_sql = frappe.db.__class__.sql
-            frappe.db.__class__.sql = _sql_with_count
-            yield
-            self.assertLessEqual(len(queries), count, msg="Queries executed: \n" + "\n\n".join(queries))
-        finally:
-            frappe.db.__class__.sql = orig_sql
+		def _sql_with_count(*args, **kwargs):
+			ret = orig_sql(*args, **kwargs)
+			queries.append(args[0].last_query)
+			return ret
 
-    @contextmanager
-    def assertRedisCallCounts(self, count):
-        commands = []
+		try:
+			orig_sql = frappe.db.__class__.sql
+			frappe.db.__class__.sql = _sql_with_count
+			yield
+			self.assertLessEqual(len(queries), count, msg="Queries executed: \n" + "\n\n".join(queries))
+		finally:
+			frappe.db.__class__.sql = orig_sql
 
-        def execute_command_and_count(*args, **kwargs):
-            ret = orig_execute(*args, **kwargs)
-            key_len = 2
-            if "H" in args[0]:
-                key_len = 3
-            commands.append((args)[:key_len])
-            return ret
+	@contextmanager
+	def assertRedisCallCounts(self, count):
+		commands = []
 
-        try:
-            orig_execute = frappe.cache.execute_command
-            frappe.cache.execute_command = execute_command_and_count
-            yield
-            self.assertLessEqual(
-                len(commands), count, msg="commands executed: \n" + "\n".join(str(c) for c in commands)
-            )
-        finally:
-            frappe.cache.execute_command = orig_execute
+		def execute_command_and_count(*args, **kwargs):
+			ret = orig_execute(*args, **kwargs)
+			key_len = 2
+			if "H" in args[0]:
+				key_len = 3
+			commands.append((args)[:key_len])
+			return ret
 
-    @contextmanager
-    def assertRowsRead(self, count):
-        rows_read = 0
+		try:
+			orig_execute = frappe.cache.execute_command
+			frappe.cache.execute_command = execute_command_and_count
+			yield
+			self.assertLessEqual(
+				len(commands), count, msg="commands executed: \n" + "\n".join(str(c) for c in commands)
+			)
+		finally:
+			frappe.cache.execute_command = orig_execute
 
-        def _sql_with_count(*args, **kwargs):
-            nonlocal rows_read
+	@contextmanager
+	def assertRowsRead(self, count):
+		rows_read = 0
 
-            ret = orig_sql(*args, **kwargs)
-            # count of last touched rows as per DB-API 2.0 https://peps.python.org/pep-0249/#rowcount
-            rows_read += cint(frappe.db._cursor.rowcount)
-            return ret
+		def _sql_with_count(*args, **kwargs):
+			nonlocal rows_read
 
-        try:
-            orig_sql = frappe.db.sql
-            frappe.db.sql = _sql_with_count
-            yield
-            self.assertLessEqual(rows_read, count, msg="Queries read more rows than expected")
-        finally:
-            frappe.db.sql = orig_sql
+			ret = orig_sql(*args, **kwargs)
+			# count of last touched rows as per DB-API 2.0 https://peps.python.org/pep-0249/#rowcount
+			rows_read += cint(frappe.db._cursor.rowcount)
+			return ret
 
-    @classmethod
-    def enable_safe_exec(cls) -> None:
-        """Enable safe exec and disable them after test case is completed."""
-        from frappe.installer import update_site_config
-        from frappe.utils.safe_exec import SAFE_EXEC_CONFIG_KEY
+		try:
+			orig_sql = frappe.db.sql
+			frappe.db.sql = _sql_with_count
+			yield
+			self.assertLessEqual(rows_read, count, msg="Queries read more rows than expected")
+		finally:
+			frappe.db.sql = orig_sql
 
-        cls._common_conf = os.path.join(frappe.local.sites_path, "common_site_config.json")
-        update_site_config(SAFE_EXEC_CONFIG_KEY, 1, validate=False, site_config_path=cls._common_conf)
+	@classmethod
+	def enable_safe_exec(cls) -> None:
+		"""Enable safe exec and disable them after test case is completed."""
+		from frappe.installer import update_site_config
+		from frappe.utils.safe_exec import SAFE_EXEC_CONFIG_KEY
 
-        cls.addClassCleanup(
-            lambda: update_site_config(
-                SAFE_EXEC_CONFIG_KEY, 0, validate=False, site_config_path=cls._common_conf
-            )
-        )
+		cls._common_conf = os.path.join(frappe.local.sites_path, "common_site_config.json")
+		update_site_config(SAFE_EXEC_CONFIG_KEY, 1, validate=False, site_config_path=cls._common_conf)
 
-    @contextmanager
-    def set_user(self, user: str):
-        try:
-            old_user = frappe.session.user
-            frappe.set_user(user)
-            yield
-        finally:
-            frappe.set_user(old_user)
+		cls.addClassCleanup(
+			lambda: update_site_config(
+				SAFE_EXEC_CONFIG_KEY, 0, validate=False, site_config_path=cls._common_conf
+			)
+		)
 
-    @contextmanager
-    def switch_site(self, site: str):
-        """Switch connection to different site.
-        Note: Drops current site connection completely."""
+	@contextmanager
+	def set_user(self, user: str):
+		try:
+			old_user = frappe.session.user
+			frappe.set_user(user)
+			yield
+		finally:
+			frappe.set_user(old_user)
 
-        try:
-            old_site = frappe.local.site
-            frappe.init(site, force=True)
-            frappe.connect()
-            yield
-        finally:
-            frappe.init(old_site, force=True)
-            frappe.connect()
+	@contextmanager
+	def switch_site(self, site: str):
+		"""Switch connection to different site.
+		Note: Drops current site connection completely."""
 
-    @contextmanager
-    def freeze_time(self, time_to_freeze, *args, **kwargs):
-        from freezegun import freeze_time
+		try:
+			old_site = frappe.local.site
+			frappe.init(site, force=True)
+			frappe.connect()
+			yield
+		finally:
+			frappe.init(old_site, force=True)
+			frappe.connect()
 
-        # Freeze time expects UTC or tzaware objects. We have neither, so convert to UTC.
-        timezone = pytz.timezone(get_system_timezone())
-        fake_time_with_tz = timezone.localize(get_datetime(time_to_freeze)).astimezone(pytz.utc)
+	@contextmanager
+	def freeze_time(self, time_to_freeze, *args, **kwargs):
+		from freezegun import freeze_time
 
-        with freeze_time(fake_time_with_tz, *args, **kwargs):
-            yield
+		# Freeze time expects UTC or tzaware objects. We have neither, so convert to UTC.
+		timezone = pytz.timezone(get_system_timezone())
+		fake_time_with_tz = timezone.localize(get_datetime(time_to_freeze)).astimezone(pytz.utc)
+
+		with freeze_time(fake_time_with_tz, *args, **kwargs):
+			yield
 
 
 class MockedRequestTestCase(FrappeTestCase):
-    def setUp(self):
-        import responses
+	def setUp(self):
+		import responses
 
-        self.responses = responses.RequestsMock()
-        self.responses.start()
+		self.responses = responses.RequestsMock()
+		self.responses.start()
 
-        self.addCleanup(self.responses.stop)
-        self.addCleanup(self.responses.reset)
+		self.addCleanup(self.responses.stop)
+		self.addCleanup(self.responses.reset)
 
-        return super().setUp()
+		return super().setUp()
 
 
 def _commit_watcher():
-    import traceback
+	import traceback
 
-    print("Warning:, transaction committed during tests.")
-    traceback.print_stack(limit=10)
+	print("Warning:, transaction committed during tests.")
+	traceback.print_stack(limit=10)
 
 
 def _rollback_db():
-    frappe.db.value_cache = {}
-    frappe.db.rollback()
+	frappe.db.value_cache = {}
+	frappe.db.rollback()
 
 
 def _restore_thread_locals(flags):
-    frappe.local.flags = flags
-    frappe.local.error_log = []
-    frappe.local.message_log = []
-    frappe.local.debug_log = []
-    frappe.local.conf = frappe._dict(frappe.get_site_config())
-    frappe.local.cache = {}
-    frappe.local.lang = "en"
-    frappe.local.preload_assets = {"style": [], "script": [], "icons": []}
+	frappe.local.flags = flags
+	frappe.local.error_log = []
+	frappe.local.message_log = []
+	frappe.local.debug_log = []
+	frappe.local.conf = frappe._dict(frappe.get_site_config())
+	frappe.local.cache = {}
+	frappe.local.lang = "en"
+	frappe.local.preload_assets = {"style": [], "script": [], "icons": []}
 
-    if hasattr(frappe.local, "request"):
-        delattr(frappe.local, "request")
+	if hasattr(frappe.local, "request"):
+		delattr(frappe.local, "request")
 
 
 @contextmanager
 def change_settings(doctype, settings_dict=None, /, commit=False, **settings):
-    """A context manager to ensure that settings are changed before running
-    function and restored after running it regardless of exceptions occured.
-    This is useful in tests where you want to make changes in a function but
-    don't retain those changes.
-    import and use as decorator to cover full function or using `with` statement.
+	"""
+	A context manager to ensure that settings are changed before running
+	function and restored after running it regardless of exceptions occurred.
 
-    example:
-    @change_settings("Print Settings", {"send_print_as_pdf": 1})
-    def test_case(self):
-            ...
+	This is useful in tests where you want to make changes in a function but
+	don't retain those changes.
 
-    @change_settings("Print Settings", send_print_as_pdf=1)
-    def test_case(self):
-            ...
-    """
+	import and use as decorator to cover full function or using `with` statement.
 
-    if settings_dict is None:
-        settings_dict = settings
+	Example:
 
-    try:
-        settings = frappe.get_doc(doctype)
-        # remember setting
-        previous_settings = copy.deepcopy(settings_dict)
-        for key in previous_settings:
-            previous_settings[key] = getattr(settings, key)
+	```
+	@change_settings("Print Settings", {"send_print_as_pdf": 1})
+	def test_case(self):
+	    pass
 
-        # change setting
-        for key, value in settings_dict.items():
-            setattr(settings, key, value)
-        settings.save(ignore_permissions=True)
-        # singles are cached by default, clear to avoid flake
-        frappe.db.value_cache[settings] = {}
-        if commit:
-            frappe.db.commit()
-        yield  # yield control to calling function
 
-    finally:
-        # restore settings
-        settings = frappe.get_doc(doctype)
-        for key, value in previous_settings.items():
-            setattr(settings, key, value)
-        settings.save(ignore_permissions=True)
-        if commit:
-            frappe.db.commit()
+	@change_settings("Print Settings", send_print_as_pdf=1)
+	def test_case(self):
+	    pass
+	```
+	"""
+
+	if settings_dict is None:
+		settings_dict = settings
+
+	try:
+		settings = frappe.get_doc(doctype)
+		# remember setting
+		previous_settings = copy.deepcopy(settings_dict)
+		for key in previous_settings:
+			previous_settings[key] = getattr(settings, key)
+
+		# change setting
+		for key, value in settings_dict.items():
+			setattr(settings, key, value)
+		settings.save(ignore_permissions=True)
+		# singles are cached by default, clear to avoid flake
+		frappe.db.value_cache[settings] = {}
+		if commit:
+			frappe.db.commit()
+		yield  # yield control to calling function
+
+	finally:
+		# restore settings
+		settings = frappe.get_doc(doctype)
+		for key, value in previous_settings.items():
+			setattr(settings, key, value)
+		settings.save(ignore_permissions=True)
+		if commit:
+			frappe.db.commit()
 
 
 def timeout(seconds=30, error_message="Test timed out."):
-    """Timeout decorator to ensure a test doesn't run for too long.
+	"""Timeout decorator to ensure a test doesn't run for too long.
 
-    adapted from https://stackoverflow.com/a/2282656"""
+	adapted from https://stackoverflow.com/a/2282656"""
 
-    # Support @timeout (without function call)
-    no_args = bool(callable(seconds))
-    actual_timeout = 30 if no_args else seconds
-    actual_error_message = "Test timed out" if no_args else error_message
+	# Support @timeout (without function call)
+	no_args = bool(callable(seconds))
+	actual_timeout = 30 if no_args else seconds
+	actual_error_message = "Test timed out" if no_args else error_message
 
-    def decorator(func):
-        def _handle_timeout(signum, frame):
-            raise Exception(actual_error_message)
+	def decorator(func):
+		def _handle_timeout(signum, frame):
+			raise Exception(actual_error_message)
 
-        def wrapper(*args, **kwargs):
-            signal.signal(signal.SIGALRM, _handle_timeout)
-            signal.alarm(actual_timeout)
-            try:
-                result = func(*args, **kwargs)
-            finally:
-                signal.alarm(0)
-            return result
+		def wrapper(*args, **kwargs):
+			signal.signal(signal.SIGALRM, _handle_timeout)
+			signal.alarm(actual_timeout)
+			try:
+				result = func(*args, **kwargs)
+			finally:
+				signal.alarm(0)
+			return result
 
-        return wrapper
+		return wrapper
 
-    if no_args:
-        return decorator(seconds)
+	if no_args:
+		return decorator(seconds)
 
-    return decorator
+	return decorator
 
 
 @contextmanager
 def patch_hooks(overridden_hoooks):
-    get_hooks = frappe.get_hooks
+	get_hooks = frappe.get_hooks
 
-    def patched_hooks(hook=None, default="_KEEP_DEFAULT_LIST", app_name=None):
-        if hook in overridden_hoooks:
-            return overridden_hoooks[hook]
-        return get_hooks(hook, default, app_name)
+	def patched_hooks(hook=None, default="_KEEP_DEFAULT_LIST", app_name=None):
+		if hook in overridden_hoooks:
+			return overridden_hoooks[hook]
+		return get_hooks(hook, default, app_name)
 
-    with patch.object(frappe, "get_hooks", patched_hooks):
-        yield
+	with patch.object(frappe, "get_hooks", patched_hooks):
+		yield
 
 
 def check_orpahned_doctypes():
-    """Check that all doctypes in DB actually exist after patch test"""
+	"""Check that all doctypes in DB actually exist after patch test"""
 
-    doctypes = frappe.get_all("DocType", {"custom": 0}, pluck="name")
-    orpahned_doctypes = []
+	doctypes = frappe.get_all("DocType", {"custom": 0}, pluck="name")
+	orpahned_doctypes = []
 
-    for doctype in doctypes:
-        try:
-            get_controller(doctype)
-        except ImportError:
-            orpahned_doctypes.append(doctype)
+	for doctype in doctypes:
+		try:
+			get_controller(doctype)
+		except ImportError:
+			orpahned_doctypes.append(doctype)
 
-    if orpahned_doctypes:
-        frappe.throw(
-            "Following doctypes exist in DB without controller.\n {}".format("\n".join(orpahned_doctypes))
-        )
-
-def if_app_installed(app):
-    """Decorator to check if app is installed"""
-    def wrapper(function):
-        if app in frappe.get_installed_apps():
-            return function
-        return   
-    return wrapper
-
-
-def if_app_not_installed(app):
-    """Decorator to check if app is not installed"""
-    def wrapper(function):
-        if app not in frappe.get_installed_apps():
-            return function
-        return
-    return wrapper
-
-
-def check_doctype_and_module(doctype):
-    if not frappe.db.exists("DocType", doctype):
-        return False
-
-    module = frappe.db.get_value("DocType", doctype, "module")
-    if not module:
-        return False
-
-    return True
+	if orpahned_doctypes:
+		frappe.throw(
+			"Following doctypes exist in DB without controller.\n {}".format("\n".join(orpahned_doctypes))
+		)

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -316,7 +316,8 @@ def send_token_via_sms(otpsecret, token=None, phone_no=None):
 		return False
 
 	hotp = pyotp.HOTP(otpsecret)
-	args = {ss.message_parameter: f"Your verification code is {hotp.at(int(token))}"}
+	otp = hotp.at(int(token))
+	args = {ss.message_parameter: get_rendered_otp_message(otp)}
 
 	for d in ss.get("parameters"):
 		args[d.parameter] = d.value
@@ -335,6 +336,14 @@ def send_token_via_sms(otpsecret, token=None, phone_no=None):
 		**sms_args,
 	)
 	return True
+
+
+def get_rendered_otp_message(otp: str) -> str:
+	default_template = "Your verification code is {{otp}}"
+	custom_template = frappe.get_system_settings("otp_sms_template")
+	template = custom_template or default_template
+
+	return frappe.render_template(template, {"otp": otp})
 
 
 def send_token_via_email(user, token, otp_secret, otp_issuer, subject=None, message=None):

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -634,19 +634,12 @@ def format_datetime(datetime_string: DateTimeLikeObject, format_string: str | No
 	return formatted_datetime
 
 
-<<<<<<< HEAD
-def format_duration(seconds, hide_days=False):
-	"""Converts the given duration value in float(seconds) to duration format
-
-	example: converts 12885 to '3h 34m 45s' where 12885 = seconds in float
-=======
 def format_duration(seconds: float | int, hide_days: bool = False) -> str:
 	"""Convert the given duration value in seconds to duration format.
 
 	example:
 	convert 12885 to '3h 34m 45s' where 12885 = seconds in float
 	        -12885 to '-3h 34m 45s'
->>>>>>> 4908b926c0 (fix(utils): format_duration for negative values)
 	"""
 	seconds = cint(seconds)
 	negative = seconds < 0

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -648,9 +648,9 @@ def format_duration(seconds: float | int, hide_days: bool = False) -> str:
 	        -12885 to '-3h 34m 45s'
 >>>>>>> 4908b926c0 (fix(utils): format_duration for negative values)
 	"""
-
+	seconds = cint(seconds)
 	negative = seconds < 0
-	seconds = abs(cint(seconds))
+	seconds = abs(seconds)
 
 	days = (seconds // (3600 * 24)) if not hide_days else 0
 	hours = ((seconds % (3600 * 24)) // 3600) if not hide_days else (seconds // 3600)

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -634,38 +634,44 @@ def format_datetime(datetime_string: DateTimeLikeObject, format_string: str | No
 	return formatted_datetime
 
 
+<<<<<<< HEAD
 def format_duration(seconds, hide_days=False):
 	"""Converts the given duration value in float(seconds) to duration format
 
 	example: converts 12885 to '3h 34m 45s' where 12885 = seconds in float
+=======
+def format_duration(seconds: float | int, hide_days: bool = False) -> str:
+	"""Convert the given duration value in seconds to duration format.
+
+	example:
+	convert 12885 to '3h 34m 45s' where 12885 = seconds in float
+	        -12885 to '-3h 34m 45s'
+>>>>>>> 4908b926c0 (fix(utils): format_duration for negative values)
 	"""
 
-	seconds = cint(seconds)
+	negative = seconds < 0
+	seconds = abs(cint(seconds))
 
-	total_duration = {
-		"days": math.floor(seconds / (3600 * 24)),
-		"hours": math.floor(seconds % (3600 * 24) / 3600),
-		"minutes": math.floor(seconds % 3600 / 60),
-		"seconds": math.floor(seconds % 60),
-	}
+	days = (seconds // (3600 * 24)) if not hide_days else 0
+	hours = ((seconds % (3600 * 24)) // 3600) if not hide_days else (seconds // 3600)
+	minutes = (seconds % 3600) // 60
+	seconds = seconds % 60
 
-	if hide_days:
-		total_duration["hours"] = math.floor(seconds / 3600)
-		total_duration["days"] = 0
+	total_duration = []
 
-	duration = ""
-	if total_duration:
-		if total_duration.get("days"):
-			duration += str(total_duration.get("days")) + "d"
-		if total_duration.get("hours"):
-			duration += " " if len(duration) else ""
-			duration += str(total_duration.get("hours")) + "h"
-		if total_duration.get("minutes"):
-			duration += " " if len(duration) else ""
-			duration += str(total_duration.get("minutes")) + "m"
-		if total_duration.get("seconds"):
-			duration += " " if len(duration) else ""
-			duration += str(total_duration.get("seconds")) + "s"
+	if days:
+		total_duration.append(f"{days}d")
+	if hours:
+		total_duration.append(f"{hours}h")
+	if minutes:
+		total_duration.append(f"{minutes}m")
+	if seconds:
+		total_duration.append(f"{seconds}s")
+
+	duration = " ".join(total_duration)
+
+	if negative and duration:
+		duration = "-" + duration
 
 	return duration
 

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -12,6 +12,7 @@ import re
 import time
 import typing
 from code import compile_command
+from collections import defaultdict
 from enum import Enum
 from functools import lru_cache
 from typing import Any, Literal, Optional, TypeVar, Union
@@ -2350,3 +2351,78 @@ def _get_rss_memory_usage():
 
 	rss = psutil.Process().memory_info().rss // (1024 * 1024)
 	return rss
+
+
+def attach_expanded_links(doctype: str, docs: list, fields_to_expand: list):
+	"""
+	Expands specified link or dynamic link fields in a list of documents by replacing
+	their linked values (names) with full document records.
+
+	This function takes a list of documents and a list of link fieldnames that should be
+	expanded. For each specified field, it retrieves all referenced linked records from
+	the corresponding doctypes and replaces the link value in each document with the
+	full linked record (as a dict).
+
+	Args:
+		doctype (str): The parent doctype of the provided documents.
+		docs (list[dict]): A list of document dictionaries whose link fields are to be expanded.
+		fields_to_expand (list[str]): A list of fieldnames corresponding to link or dynamic
+			link fields that should be expanded.
+
+	Returns:
+		None: The function modifies the `docs` list in place.
+
+	Example:
+		>>> docs = [{"customer": "CUST-001"}, {"customer": "CUST-002"}]
+		>>> attach_expanded_links("Sales Invoice", docs, ["customer"])
+		>>> docs[0]["customer"]
+		{
+			"name": "CUST-001",
+			"customer_name": "John Doe",
+			"customer_group": "Retail",
+			...
+		}
+
+	"""
+
+	if not fields_to_expand:
+		return
+
+	meta = frappe.get_meta(doctype)
+
+	link_fields = {f.fieldname: f for f in meta.get_link_fields() + meta.get_dynamic_link_fields()}
+
+	doctype_values = defaultdict(set)
+	field_to_doctype = {}
+
+	for fieldname in fields_to_expand:
+		if fieldname not in link_fields:
+			continue
+		e = link_fields[fieldname]
+		link_doctype = e.options
+		field_to_doctype[fieldname] = link_doctype
+
+		for li in docs:
+			val = li.get(fieldname)
+			if val:
+				doctype_values[link_doctype].add(val)
+
+	doctype_title_maps = {}
+
+	for link_doctype, values in doctype_values.items():
+		records = frappe.get_list(
+			link_doctype,
+			filters={"name": ["in", list(values)]},
+			fields=["*"],
+		)
+		doctype_title_maps[link_doctype] = {r["name"]: r for r in records}
+
+	for li in docs:
+		for fieldname in fields_to_expand:
+			if fieldname not in field_to_doctype:
+				continue
+			link_doctype = field_to_doctype[fieldname]
+			val = li.get(fieldname)
+			val_title = doctype_title_maps.get(link_doctype, {}).get(val)
+			if val and val_title:
+				li[fieldname] = val_title

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1712,7 +1712,7 @@ def sql_like(value: str, pattern: str) -> bool:
 		return pattern in value
 
 
-def filter_operator_is(value: str, pattern: str) -> bool:
+def filter_operator_is(value: str | None, pattern: str) -> bool:
 	"""Operator `is` can have two values: 'set' or 'not set'."""
 	pattern = pattern.lower()
 
@@ -1776,11 +1776,37 @@ def evaluate_filters(doc, filters: dict | list | tuple):
 	return True
 
 
-def compare(val1: Any, condition: str, val2: Any, fieldtype: str | None = None):
+def compare(val1: Any, condition: str, val2: Any, fieldtype: str | None = None) -> bool:
+	"""Compare two values using the specified operator with optional fieldtype casting.
+
+	Args:
+		val1: The left operand value to compare
+		condition: The comparison operator (e.g., "=", ">", "is", "in", "like")
+		val2: The right operand value to compare against
+		fieldtype: Optional fieldtype for casting val1 (and val2 for most operators)
+
+	Returns:
+		bool: True if the comparison evaluates to True, False otherwise
+
+	Note:
+	- For "is" operator: No casting is performed to preserve None values
+	- For "in"/"not in" operators: Only val1 is cast (if not None), val2 remains unchanged
+	- For "Timespan" operator: No casting is performed
+	- For other operators: Both val1 and val2 are cast to the specified fieldtype
+	"""
 	if fieldtype:
-		val1 = cast(fieldtype, val1)
-		if condition != "Timespan":
+		if condition in {"is", "Timespan"}:
+			# No casting to preserve original values
+			pass
+		elif condition in {"in", "not in"}:
+			# Cast only val1 (if not None), preserve val2 container
+			if val1 is not None:
+				val1 = cast(fieldtype, val1)
+		else:
+			# Cast both values for comparison operators (=, !=, >, <, >=, <=, like, etc.)
+			val1 = cast(fieldtype, val1)
 			val2 = cast(fieldtype, val2)
+
 	if condition in operator_map:
 		return operator_map[condition](val1, val2)
 

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1697,6 +1697,41 @@ def get_url_to_report_with_filters(name, filters, report_type=None, doctype=None
 	return get_url(uri=f"/app/query-report/{quoted(name)}?{filters}")
 
 
+def get_filtered_list_url(doctype: str, docnames: list[str] | None = None) -> str:
+	"""
+	Get a filtered list view URL for a doctype with specific document names.
+
+	:param doctype: The doctype name
+	:param docnames: List of document names to filter
+
+	:return: URL to the filtered list view
+	"""
+	list_url = get_url_to_list(doctype)
+
+	if not docnames:
+		return list_url
+
+	return "".join((list_url, "?", urlencode({"name": json.dumps(["in", docnames])})))
+
+
+def get_filtered_list_link(doctype: str, docnames: list[str] | None = None, label: str | None = None) -> str:
+	"""
+	Get an HTML link to a filtered list view for a doctype with specific document names.
+
+	:param doctype: The doctype name
+	:param docnames: List of document names to filter
+	:param label: Optional label for the link. If not provided, uses doctype
+
+	:return: HTML link to the filtered list view
+	"""
+	from frappe import _
+
+	url = get_filtered_list_url(doctype, docnames)
+	label = label or _(doctype)
+
+	return f"""<a href="{url}">{label}</a>"""
+
+
 def sql_like(value: str, pattern: str) -> bool:
 	if not isinstance(pattern, str) and isinstance(value, str):
 		return False

--- a/frappe/utils/inplacevar.py
+++ b/frappe/utils/inplacevar.py
@@ -1,0 +1,127 @@
+#############################################################################
+#
+# Copyright (c) 2002 Zope Foundation and Contributors.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE
+#
+##############################################################################
+
+# Extracted from AccessControl.ZopeGuards
+# https://github.com/zopefoundation/AccessControl
+
+valid_inplace_types = (list, set)
+
+
+inplace_slots = {
+    '+=': '__iadd__',
+    '-=': '__isub__',
+    '*=': '__imul__',
+    '/=': (1 / 2 == 0) and '__idiv__' or '__itruediv__',
+    '//=': '__ifloordiv__',
+    '%=': '__imod__',
+    '**=': '__ipow__',
+    '<<=': '__ilshift__',
+    '>>=': '__irshift__',
+    '&=': '__iand__',
+    '^=': '__ixor__',
+    '|=': '__ior__',
+}
+
+
+def __iadd__(x, y):
+    x += y
+    return x
+
+
+def __isub__(x, y):
+    x -= y
+    return x
+
+
+def __imul__(x, y):
+    x *= y
+    return x
+
+
+def __idiv__(x, y):
+    x /= y
+    return x
+
+
+def __ifloordiv__(x, y):
+    x //= y
+    return x
+
+
+def __imod__(x, y):
+    x %= y
+    return x
+
+
+def __ipow__(x, y):
+    x **= y
+    return x
+
+
+def __ilshift__(x, y):
+    x <<= y
+    return x
+
+
+def __irshift__(x, y):
+    x >>= y
+    return x
+
+
+def __iand__(x, y):
+    x &= y
+    return x
+
+
+def __ixor__(x, y):
+    x ^= y
+    return x
+
+
+def __ior__(x, y):
+    x |= y
+    return x
+
+
+inplace_ops = {
+    '+=': __iadd__,
+    '-=': __isub__,
+    '*=': __imul__,
+    '/=': __idiv__,
+    '//=': __ifloordiv__,
+    '%=': __imod__,
+    '**=': __ipow__,
+    '<<=': __ilshift__,
+    '>>=': __irshift__,
+    '&=': __iand__,
+    '^=': __ixor__,
+    '|=': __ior__,
+}
+
+
+def protected_inplacevar(op, var, expr):
+    """Do an inplace operation
+
+    If the var has an inplace slot, then disallow the operation
+    unless the var an instance of ``valid_inplace_types``.
+    """
+    if hasattr(var, inplace_slots[op]) and \
+       not isinstance(var, valid_inplace_types):
+        try:
+            cls = var.__class__
+        except AttributeError:
+            cls = type(var)
+        raise TypeError(
+            "Augmented assignment to %s objects is not allowed"
+            " in untrusted code" % cls.__name__)
+    return inplace_ops[op](var, expr)

--- a/frappe/utils/inplacevar.py
+++ b/frappe/utils/inplacevar.py
@@ -18,110 +18,107 @@ valid_inplace_types = (list, set)
 
 
 inplace_slots = {
-    '+=': '__iadd__',
-    '-=': '__isub__',
-    '*=': '__imul__',
-    '/=': (1 / 2 == 0) and '__idiv__' or '__itruediv__',
-    '//=': '__ifloordiv__',
-    '%=': '__imod__',
-    '**=': '__ipow__',
-    '<<=': '__ilshift__',
-    '>>=': '__irshift__',
-    '&=': '__iand__',
-    '^=': '__ixor__',
-    '|=': '__ior__',
+	"+=": "__iadd__",
+	"-=": "__isub__",
+	"*=": "__imul__",
+	"/=": ((1 / 2 == 0) and "__idiv__") or "__itruediv__",
+	"//=": "__ifloordiv__",
+	"%=": "__imod__",
+	"**=": "__ipow__",
+	"<<=": "__ilshift__",
+	">>=": "__irshift__",
+	"&=": "__iand__",
+	"^=": "__ixor__",
+	"|=": "__ior__",
 }
 
 
 def __iadd__(x, y):
-    x += y
-    return x
+	x += y
+	return x
 
 
 def __isub__(x, y):
-    x -= y
-    return x
+	x -= y
+	return x
 
 
 def __imul__(x, y):
-    x *= y
-    return x
+	x *= y
+	return x
 
 
 def __idiv__(x, y):
-    x /= y
-    return x
+	x /= y
+	return x
 
 
 def __ifloordiv__(x, y):
-    x //= y
-    return x
+	x //= y
+	return x
 
 
 def __imod__(x, y):
-    x %= y
-    return x
+	x %= y
+	return x
 
 
 def __ipow__(x, y):
-    x **= y
-    return x
+	x **= y
+	return x
 
 
 def __ilshift__(x, y):
-    x <<= y
-    return x
+	x <<= y
+	return x
 
 
 def __irshift__(x, y):
-    x >>= y
-    return x
+	x >>= y
+	return x
 
 
 def __iand__(x, y):
-    x &= y
-    return x
+	x &= y
+	return x
 
 
 def __ixor__(x, y):
-    x ^= y
-    return x
+	x ^= y
+	return x
 
 
 def __ior__(x, y):
-    x |= y
-    return x
+	x |= y
+	return x
 
 
 inplace_ops = {
-    '+=': __iadd__,
-    '-=': __isub__,
-    '*=': __imul__,
-    '/=': __idiv__,
-    '//=': __ifloordiv__,
-    '%=': __imod__,
-    '**=': __ipow__,
-    '<<=': __ilshift__,
-    '>>=': __irshift__,
-    '&=': __iand__,
-    '^=': __ixor__,
-    '|=': __ior__,
+	"+=": __iadd__,
+	"-=": __isub__,
+	"*=": __imul__,
+	"/=": __idiv__,
+	"//=": __ifloordiv__,
+	"%=": __imod__,
+	"**=": __ipow__,
+	"<<=": __ilshift__,
+	">>=": __irshift__,
+	"&=": __iand__,
+	"^=": __ixor__,
+	"|=": __ior__,
 }
 
 
 def protected_inplacevar(op, var, expr):
-    """Do an inplace operation
+	"""Do an inplace operation
 
-    If the var has an inplace slot, then disallow the operation
-    unless the var an instance of ``valid_inplace_types``.
-    """
-    if hasattr(var, inplace_slots[op]) and \
-       not isinstance(var, valid_inplace_types):
-        try:
-            cls = var.__class__
-        except AttributeError:
-            cls = type(var)
-        raise TypeError(
-            "Augmented assignment to %s objects is not allowed"
-            " in untrusted code" % cls.__name__)
-    return inplace_ops[op](var, expr)
+	If the var has an inplace slot, then disallow the operation
+	unless the var an instance of ``valid_inplace_types``.
+	"""
+	if hasattr(var, inplace_slots[op]) and not isinstance(var, valid_inplace_types):
+		try:
+			cls = var.__class__
+		except AttributeError:
+			cls = type(var)
+		raise TypeError("Augmented assignment to %s objects is not allowed in untrusted code" % cls.__name__)
+	return inplace_ops[op](var, expr)

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -29,6 +29,7 @@ from frappe.model.mapper import get_mapped_doc
 from frappe.model.rename_doc import rename_doc
 from frappe.modules import scrub
 from frappe.utils.background_jobs import enqueue, get_jobs
+from frappe.utils.inplacevar import protected_inplacevar
 from frappe.website.utils import get_next_link, get_toc
 from frappe.www.printview import get_visible_columns
 
@@ -301,6 +302,7 @@ def get_safe_globals():
 	# allow iterators and list comprehension
 	out._getiter_ = iter
 	out._iter_unpack_sequence_ = RestrictedPython.Guards.guarded_iter_unpack_sequence
+	out._inplacevar_ = protected_inplacevar
 
 	# add common python builtins
 	out.update(get_python_builtins())
@@ -706,4 +708,5 @@ WHITELISTED_SAFE_EVAL_GLOBALS = {
 	"_getitem_": _getitem,
 	"_getiter_": iter,
 	"_iter_unpack_sequence_": RestrictedPython.Guards.guarded_iter_unpack_sequence,
+	"_inplacevar_": protected_inplacevar,
 }

--- a/frappe/website/doctype/web_form/web_form.js
+++ b/frappe/website/doctype/web_form/web_form.js
@@ -301,6 +301,7 @@ frappe.ui.form.on("Web Form List Column", {
 		if (!df) return;
 		doc.fieldtype = df.fieldtype;
 		doc.label = df.label;
+		doc.options = df.options;
 		frm.refresh_field("list_columns");
 	},
 });

--- a/frappe/website/doctype/web_form/web_form.js
+++ b/frappe/website/doctype/web_form/web_form.js
@@ -132,11 +132,26 @@ frappe.ui.form.on("Web Form", {
 	set_fields(frm) {
 		let doc = frm.doc;
 
-		let update_options = (options) => {
-			[frm.fields_dict.web_form_fields.grid, frm.fields_dict.list_columns.grid].forEach(
-				(obj) => {
-					obj.update_docfield_property("fieldname", "options", options);
-				}
+		let as_select_option = (df) => ({
+			label: df.label,
+			value: df.fieldname,
+		});
+		let update_options = (fields) => {
+			frm.fields_dict.web_form_fields.grid.update_docfield_property(
+				"fieldname",
+				"options",
+				fields.map(as_select_option)
+			);
+			frm.fields_dict.list_columns.grid.update_docfield_property(
+				"fieldname",
+				"options",
+				fields
+					.filter(
+						(df) =>
+							!frappe.model.no_value_type.includes(df.fieldtype) &&
+							df.is_virtual !== 1
+					)
+					.map(as_select_option)
 			);
 		};
 
@@ -146,14 +161,12 @@ frappe.ui.form.on("Web Form", {
 			return;
 		}
 
-		update_options([`Fetching fields from ${doc.doc_type}...`]);
+		update_options([
+			{ label: __("Fetching fields from {0}...", [doc.doc_type]), fieldname: "" },
+		]);
 
 		get_fields_for_doctype(doc.doc_type).then((fields) => {
-			let as_select_option = (df) => ({
-				label: df.label,
-				value: df.fieldname,
-			});
-			update_options(fields.map(as_select_option));
+			update_options(fields);
 
 			let currency_fields = fields
 				.filter((df) => ["Currency", "Float"].includes(df.fieldtype))
@@ -161,7 +174,7 @@ frappe.ui.form.on("Web Form", {
 			if (!currency_fields.length) {
 				currency_fields = [
 					{
-						label: `No currency fields in ${doc.doc_type}`,
+						label: __("No currency fields in {0}", [doc.doc_type]),
 						value: "",
 						disabled: true,
 					},

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -604,6 +604,10 @@ def accept(web_form, data):
 		# insert
 		doc = frappe.new_doc(doctype)
 
+	# Set ignore_mandatory flag if allow_incomplete is enabled
+	if web_form.allow_incomplete:
+		doc.flags.ignore_mandatory = True
+
 	# set values
 	for field in web_form.web_form_fields:
 		fieldname = field.fieldname
@@ -634,7 +638,7 @@ def accept(web_form, data):
 		if web_form.login_required and frappe.session.user == "Guest":
 			frappe.throw(_("You must login to submit this form"))
 
-		ignore_mandatory = True if files else False
+		ignore_mandatory = True if (files or web_form.allow_incomplete) else False
 
 		doc.insert(ignore_permissions=True, ignore_mandatory=ignore_mandatory)
 

--- a/frappe/website/doctype/web_form_list_column/web_form_list_column.json
+++ b/frappe/website/doctype/web_form_list_column/web_form_list_column.json
@@ -8,7 +8,8 @@
  "field_order": [
   "fieldname",
   "fieldtype",
-  "label"
+  "label",
+  "options"
  ],
  "fields": [
   {
@@ -30,12 +31,18 @@
    "in_list_view": 1,
    "label": "Fieldtype",
    "read_only": 1
+  },
+  {
+   "fieldname": "options",
+   "fieldtype": "Text",
+   "in_list_view": 1,
+   "label": "Options"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-08-17 19:09:01.417841",
+ "modified": "2025-09-24 22:28:54.931089",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Form List Column",

--- a/frappe/website/doctype/web_form_list_column/web_form_list_column.py
+++ b/frappe/website/doctype/web_form_list_column/web_form_list_column.py
@@ -18,6 +18,7 @@ class WebFormListColumn(Document):
 		fieldtype: DF.Data | None
 		label: DF.Data | None
 		name: DF.Int | None
+		options: DF.Text | None
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data

--- a/frappe/www/list.py
+++ b/frappe/www/list.py
@@ -26,8 +26,15 @@ def get_context(context, **dict_params):
 
 
 @frappe.whitelist(allow_guest=True)
-def get(doctype, txt=None, limit_start=0, limit=20, pathname=None, **kwargs):
-	"""Returns processed HTML page for a standard listing."""
+def get(
+	doctype: str,
+	txt: str | None = None,
+	limit_start: int = 0,
+	limit: int = 20,
+	pathname: str | None = None,
+	**kwargs,
+):
+	"""Return processed HTML page for a standard listing."""
 	limit_start = cint(limit_start)
 	raw_result = get_list_data(doctype, txt, limit_start, limit=limit + 1, **kwargs)
 	show_more = len(raw_result) > limit
@@ -75,7 +82,14 @@ def get(doctype, txt=None, limit_start=0, limit=20, pathname=None, **kwargs):
 
 @frappe.whitelist(allow_guest=True)
 def get_list_data(
-	doctype, txt=None, limit_start=0, fields=None, cmd=None, limit=20, web_form_name=None, **kwargs
+	doctype: str,
+	txt: str | None = None,
+	limit_start: int = 0,
+	fields: list | None = None,
+	cmd: str | None = None,
+	limit: int = 20,
+	web_form_name: str | None = None,
+	**kwargs,
 ):
 	"""Returns processed HTML page for a standard listing."""
 	limit_start = cint(limit_start)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     # We depend on internal attributes,
     # do NOT add loose requirements on PyMySQL versions.
     "PyMySQL==1.1.1",
-    "pypdf~=6.0.0",
+    "pypdf~=6.1.3",
     "PyPika==0.48.9",
     "PyQRCode~=1.2.1",
     "PyYAML~=6.0.2",


### PR DESCRIPTION
### Title:
Sync Frappe v15 Code Changes from Oct to Nov

### Scenario Covered :

chore: enforce conventional commits (#34219) (#34222)

fix(doctype): restrict length to 61 characters (backport #34225) (#34228)
fix: pass the argument to delete_doc via rename_doc (#34226) (#34230)
fix: special operators in compare util (backport #34145) (#34147)
fix: let focus jump directly inside the first input of the first row
fix(test): create one row at a time
fix: validate mandatory fields before applying action
fix(UX): simplified group node term (#34205)
fix(db_query): Issue with certain DocType Names
fix(db_query): adjust doctype name detection
fix: ignore virtual fields in filter UI (#34224) (#34233)
 
fix: format Percent value like Float (#34238) (#34240)
feat: extract translatable strings from standard web forms (#34237) (#34245)
 
fix: prevent row-size limit error
fix: add reference and test_case
fix: add a correct test
chore: update POT file (#34247)
 
fix: focus btn only if grid is editable (#34269) (#34272)
fix(UI/UX): list view routing fixed (#34274)
fix: multi select field overflows its parent
refactor: change variable name to snake_case
feat: add protected_inplacevar function extracted from AccessControl
chore(inplacevar): lint
 
chore: use our copy of protected_inplacevar
fix: remove merge conflicts
fix: merge conflicts
fix(xss): sanitize on input itself
chore: run linter
fix: escape HTML in filename before display (backport #34289) (#34291)
 
chore(release): Bumped to Version 15.85.0
fix: multicheck style
fix: format array in link filters
fix(ldap): escape filter characters
 
fix: format array in link filters (#34311)
fix(schema): ensure int-int comparison (#34320) (#34324)
chore(release): Bumped to Version 15.85.1
fix(schema): ensure int-int comparison (#34320) (#34323)
fix: check Submission Queue already exists for the record (#34094) (#34326)
fix: OAuth2 absolute authorize access token and api urls (#34266)
fix(oauth): drop keycloak check
 
fix: prevent kanban columns from expanding with long text
fix: enable fetching datetime fields in Quick Entry dialogs
fix: web form allow incomplete feature not working
fix: increase label field length to 255 chars
fix: use link title as address title
refactor: Enhance About dialog box (backport #28994) (#34121)
fix: clear doc_events_hooks cache during uninstallation of app (backport #34321) (#34374)
 
feat(web form list column): add options (backport #34132) (#34216)
fix(sanitize_fields): use sqlparse for function detection
fix(static_page): ensure that requested files are within app/www (#34404)
 
fix: add in type hints to the list APIs
fix(system_settings): don't change 2fa settings for roles unless the value actually changed
chore(release): Bumped to Version 15.86.0
fix: multiselect field overflowing issue
fix: input mode for numbers (#34419)
 
fix: move backup file locating logic to _restore()
 
feat(geo): Add Kosovo(XK) country details to country_info.json (#34476) (#34484)
build(deps): bump pypdf (backport #34485) (#34487)
fix: don't show stray, in communication relink dialog for some doctypes"
fix(link): check whether description exists before trying to merge duplicates
 
chore(release): Bumped to Version 15.87.0
 
fix(Web Form): dont offer all fieldtypes as list columns (#34268) (#34515)
fix: cleaner message when adding/removing child table rows in bulk
chore: refactor string
fix(utils): format_duration for negative values
fix(utils): added format_duration test
fix(grid_row): use optional chaining to prevent TypeError (#34498)
chore: resolve conflicts
 
fix: onboarding - write in read only request (#34537)
 
fix: don't show empty menu in form view
feat: utility to generate filtered list URLs and links for doctype (#34503)
 
fix: use setTimeout before setting the value
fix: consider sent or received for duplicate check (backport #34439) (#34587)
feat: configure SMS OTP template for 2FA (backport #34585) (#34590)
feat: add support of expand in rest api v1/document_list (backport #34027) (#34567)
 
chore(release): Bumped to Version 15.88.0
fix(auto_repeat): render template from DB (#34580) (#34601)
 
fix: update no-commit-to-branch args for version 15 branches (#34622)
chore: remove typos (#34621)
 
refactor: allow defer_insert in doc.log_error (#34631) (#34634)
 
fix(AutoEmailReport): ignore mandatory field if hidden (#34640) (#34641)
 
fix(middleware): check path before returning file (#34651) (#34653)
 
fix: read lock applied while fetching the current value from the tabSeries
chore(release): Bumped to Version 15.88.1
fix(perm): check can_read if meta is not present (#34658) (#34671)
fix(api/v1): don't use as_dict() unless expand_links is passed (#34672) (#34674)
chore(release): Bumped to Version 15.88.2

